### PR TITLE
Add PNG, PDF, and kitty terminal output format support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""  # Don't fail on warnings (98 pre-existing)
+      - run: cargo test --features all-formats
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy, rustfmt
+          rustflags: ""
+      - run: cargo fmt --check
+      - run: cargo clippy --features all-formats

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,10 +90,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -109,6 +139,32 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytemuck"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cc"
@@ -181,6 +237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -193,12 +255,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -233,6 +313,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-url"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "diff"
@@ -277,10 +363,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "euclid"
+version = "0.22.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+
+[[package]]
+name = "flate2"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
+name = "font-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -324,10 +482,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -473,6 +657,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "gif 0.14.1",
+ "moxcms",
+ "num-traits",
+ "png 0.18.0",
+ "zune-core 0.5.0",
+ "zune-jpeg 0.5.8",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,10 +722,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62026ae44756f8a599ba21140f350303d4f08dcdcc71b5ad9c9bb8128c13c62"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce9729cc38c18d86123ab736fd2e7151763ba226ac2490ec092d1dd148825e32"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "smallvec",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libm"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "litemap"
@@ -562,6 +817,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memmap2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "mermaid-rs"
 version = "0.1.0"
 dependencies = [
@@ -574,11 +838,33 @@ dependencies = [
  "pest_derive",
  "pretty_assertions",
  "regex",
+ "resvg",
  "roxmltree",
  "serde",
  "serde_json",
+ "svg2pdf",
  "thiserror",
  "uuid",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac9557c559cd6fc9867e122e20d2cbefc9ca29d80d027a8e39310920ed2f0a97"
+dependencies = [
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -629,6 +915,18 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pdf-writer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df03c7d216de06f93f398ef06f1385a60f2c597bb96f8195c8d98e08a26b1d5"
+dependencies = [
+ "bitflags 2.10.0",
+ "itoa",
+ "memchr",
+ "ryu",
 ]
 
 [[package]]
@@ -733,6 +1031,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +1097,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,12 +1142,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
+name = "read-fonts"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -835,16 +1190,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "gif 0.13.3",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg 0.4.21",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "scopeguard"
@@ -913,10 +1324,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "skrifa"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "smallvec"
@@ -929,6 +1374,15 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
 
 [[package]]
 name = "string_cache"
@@ -960,6 +1414,48 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subsetter"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6895a12ac5599bb6057362f00e8a3cf1daab4df33f553a55690a44e4fed8d0"
+dependencies = [
+ "kurbo 0.12.0",
+ "rustc-hash",
+ "skrifa",
+ "write-fonts",
+]
+
+[[package]]
+name = "svg2pdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e50dc062439cc1a396181059c80932a6e6bd731b130e674c597c0c8874b6df22"
+dependencies = [
+ "fontdb",
+ "image",
+ "log",
+ "miniz_oxide",
+ "once_cell",
+ "pdf-writer",
+ "resvg",
+ "siphasher",
+ "subsetter",
+ "tiny-skia",
+ "ttf-parser",
+ "usvg",
+]
+
+[[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo 0.11.3",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -1015,6 +1511,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-skia"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "log",
+ "png 0.17.16",
+ "tiny-skia-path",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e7fc0c2e86a30b117d0462aa261b72b7a99b7ebd7deb3a14ceda95c5bdc93"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1022,6 +1544,30 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
 ]
 
 [[package]]
@@ -1037,10 +1583,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "url"
@@ -1052,6 +1634,33 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+]
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo 0.11.3",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -1156,6 +1765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,10 +1845,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "write-fonts"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886614b5ce857341226aa091f3c285e450683894acaaa7887f366c361efef79d"
+dependencies = [
+ "font-types",
+ "indexmap",
+ "kurbo 0.12.0",
+ "log",
+ "read-fonts",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yansi"
@@ -1323,3 +1957,33 @@ name = "zmij"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111f7d9820f05fd715df3144e254d6fc02ee4088b0644c0ffd0efc9e6d9d2773"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
+dependencies = [
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35aee689668bf9bd6f6f3a6c60bb29ba1244b3b43adfd50edd554a371da37d5"
+dependencies = [
+ "zune-core 0.5.0",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "ammonia"
 version = "4.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +108,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,16 +143,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.17",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8fbc0f831f4519fe8b810b6a7a91410ec83031b8233f730a0480029f6a23f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
 name = "bitflags"
@@ -126,6 +236,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "bitstream-io"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
+dependencies = [
+ "core2",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,6 +252,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -173,6 +298,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -255,6 +382,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "core_maths"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +416,37 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -363,6 +530,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +568,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad9cdb4b747e485a12abb0e6566612956c7a1bafa3bdb8d682c5b6d403589e48"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
+name = "fax"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
+dependencies = [
+ "fax_derive",
+]
+
+[[package]]
+name = "fax_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -508,6 +736,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,6 +757,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "html5ever"
@@ -665,10 +913,17 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
+ "exr",
  "gif 0.14.1",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png 0.18.0",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
  "zune-core 0.5.0",
  "zune-jpeg 0.5.8",
 ]
@@ -690,6 +945,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
 
 [[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,16 +961,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -744,10 +1035,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libm"
@@ -775,6 +1082,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
 
 [[package]]
 name = "mac"
@@ -811,6 +1127,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,9 +1156,13 @@ name = "mermaid-rs"
 version = "0.1.0"
 dependencies = [
  "ammonia",
+ "atty",
+ "base64",
  "chrono",
  "clap",
  "glob",
+ "image",
+ "libc",
  "log",
  "pest",
  "pest_derive",
@@ -843,7 +1173,7 @@ dependencies = [
  "serde",
  "serde_json",
  "svg2pdf",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -872,6 +1202,62 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -916,6 +1302,18 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pdf-writer"
@@ -1005,7 +1403,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1072,6 +1470,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,12 +1504,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7186d3822593aa4393561d186d1393b3923e9d6163d3fbfd6e825e3e6cf3e6a8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1132,7 +1567,27 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1140,6 +1595,85 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.2",
+ "rand_chacha",
+ "simd_helpers",
+ "thiserror 2.0.17",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef69c1990ceef18a116855938e74793a5f7496ee907562bd0857b6ac734ab285"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "read-fonts"
@@ -1330,6 +1864,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "simplecss"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,7 +2039,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -1508,6 +2060,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tiff"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9605de7fee8d9551863fd692cce7637f548dbd9db9180fcc07ccc6d26c336f"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -1693,6 +2270,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,6 +2357,28 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1870,6 +2480,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,6 +2512,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1969,6 +2605,15 @@ name = "zune-core"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111f7d9820f05fd715df3144e254d6fc02ee4088b0644c0ffd0efc9e6d9d2773"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-jpeg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,8 @@ default = ["cli"]
 cli = ["clap"]
 png = ["resvg"]
 pdf = ["svg2pdf", "resvg"]
-all-formats = ["png", "pdf"]
+kitty = ["resvg", "base64", "libc", "atty", "image"]
+all-formats = ["png", "pdf", "kitty"]
 
 [dependencies.clap]
 version = "4.4"
@@ -92,4 +93,20 @@ optional = true
 
 [dependencies.svg2pdf]
 version = "0.13"
+optional = true
+
+[dependencies.base64]
+version = "0.22"
+optional = true
+
+[dependencies.libc]
+version = "0.2"
+optional = true
+
+[dependencies.atty]
+version = "0.2"
+optional = true
+
+[dependencies.image]
+version = "0.25"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,19 @@ required-features = ["cli"]
 [features]
 default = ["cli"]
 cli = ["clap"]
+png = ["resvg"]
+pdf = ["svg2pdf", "resvg"]
+all-formats = ["png", "pdf"]
 
 [dependencies.clap]
 version = "4.4"
 features = ["derive"]
+optional = true
+
+[dependencies.resvg]
+version = "0.45"
+optional = true
+
+[dependencies.svg2pdf]
+version = "0.13"
 optional = true

--- a/src/bin/cross_validate.rs
+++ b/src/bin/cross_validate.rs
@@ -141,30 +141,82 @@ fn validate_with_rust(text: &str) -> (bool, String, String) {
     };
 
     let result: Result<(), String> = match dtype {
-        "sequence" => mermaid::diagrams::sequence::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "flowchart" => mermaid::diagrams::flowchart::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "class" => mermaid::diagrams::class::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "state" => mermaid::diagrams::state::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "er" => mermaid::diagrams::er::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "gantt" => mermaid::diagrams::gantt::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "pie" => mermaid::diagrams::pie::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "mindmap" => mermaid::diagrams::mindmap::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "timeline" => mermaid::diagrams::timeline::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "journey" => mermaid::diagrams::journey::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "quadrant" => mermaid::diagrams::quadrant::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "xychart" => mermaid::diagrams::xychart::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "sankey" => mermaid::diagrams::sankey::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "packet" => mermaid::diagrams::packet::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "block" => mermaid::diagrams::block::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "architecture" => mermaid::diagrams::architecture::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "c4" => mermaid::diagrams::c4::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "git" => mermaid::diagrams::git::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "requirement" => mermaid::diagrams::requirement::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "kanban" => mermaid::diagrams::kanban::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "info" => mermaid::diagrams::info::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "radar" => mermaid::diagrams::radar::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        "treemap" => mermaid::diagrams::treemap::parse(&clean_text).map(|_| ()).map_err(|e| e.to_string()),
-        _ => return (false, format!("No Rust parser for type: {}", dtype), dtype.to_string()),
+        "sequence" => mermaid::diagrams::sequence::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "flowchart" => mermaid::diagrams::flowchart::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "class" => mermaid::diagrams::class::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "state" => mermaid::diagrams::state::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "er" => mermaid::diagrams::er::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "gantt" => mermaid::diagrams::gantt::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "pie" => mermaid::diagrams::pie::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "mindmap" => mermaid::diagrams::mindmap::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "timeline" => mermaid::diagrams::timeline::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "journey" => mermaid::diagrams::journey::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "quadrant" => mermaid::diagrams::quadrant::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "xychart" => mermaid::diagrams::xychart::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "sankey" => mermaid::diagrams::sankey::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "packet" => mermaid::diagrams::packet::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "block" => mermaid::diagrams::block::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "architecture" => mermaid::diagrams::architecture::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "c4" => mermaid::diagrams::c4::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "git" => mermaid::diagrams::git::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "requirement" => mermaid::diagrams::requirement::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "kanban" => mermaid::diagrams::kanban::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "info" => mermaid::diagrams::info::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "radar" => mermaid::diagrams::radar::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        "treemap" => mermaid::diagrams::treemap::parse(&clean_text)
+            .map(|_| ())
+            .map_err(|e| e.to_string()),
+        _ => {
+            return (
+                false,
+                format!("No Rust parser for type: {}", dtype),
+                dtype.to_string(),
+            )
+        }
     };
 
     match result {
@@ -214,7 +266,11 @@ fn validate_with_typescript(text: &str, validator_path: &Path) -> (bool, String,
                 (false, result.error.unwrap_or_default(), String::new())
             }
         }
-        Err(e) => (false, format!("Invalid JSON: {} - {}", e, stdout), String::new()),
+        Err(e) => (
+            false,
+            format!("Invalid JSON: {} - {}", e, stdout),
+            String::new(),
+        ),
     }
 }
 
@@ -314,12 +370,17 @@ fn print_report(report: &ValidationReport, verbose: bool) {
     println!("TypeScript only:    {}", report.ts_only);
 
     // Show discrepancies
-    let discrepancies: Vec<&ValidationResult> = report.results.iter().filter(|r| !r.matches).collect();
+    let discrepancies: Vec<&ValidationResult> =
+        report.results.iter().filter(|r| !r.matches).collect();
     if !discrepancies.is_empty() {
         println!("\nDiscrepancies ({}):", discrepancies.len());
         println!("{}", "-".repeat(60));
         for r in discrepancies.iter().take(20) {
-            let status = if r.rust_valid { "RS✓ TS✗" } else { "RS✗ TS✓" };
+            let status = if r.rust_valid {
+                "RS✓ TS✗"
+            } else {
+                "RS✗ TS✓"
+            };
             println!("\n[{}] {}", status, r.test_name);
             println!("  Source: {}", r.source_file);
             if !r.rust_error.is_empty() {

--- a/src/bin/extract_diagrams.rs
+++ b/src/bin/extract_diagrams.rs
@@ -117,7 +117,12 @@ fn extract_diagrams_from_file(filepath: &Path) -> Vec<DiagramEntry> {
 fn extract_from_directory(directory: &Path) -> Vec<DiagramEntry> {
     let mut all_diagrams = Vec::new();
 
-    let patterns = ["**/*.spec.ts", "**/*.spec.js", "**/*.test.ts", "**/*.test.js"];
+    let patterns = [
+        "**/*.spec.ts",
+        "**/*.spec.js",
+        "**/*.test.ts",
+        "**/*.test.js",
+    ];
 
     for pattern in patterns {
         let full_pattern = directory.join(pattern);
@@ -176,7 +181,11 @@ fn main() {
 
     if let Some(output) = output_path {
         fs::write(&output, &json).expect("Failed to write output file");
-        eprintln!("Extracted {} diagrams to {}", result.count, output.display());
+        eprintln!(
+            "Extracted {} diagrams to {}",
+            result.count,
+            output.display()
+        );
     } else {
         println!("{}", json);
     }

--- a/src/bin/render_validate.rs
+++ b/src/bin/render_validate.rs
@@ -192,11 +192,7 @@ fn render_with_typescript(diagram: &str, validator_path: &Path) -> RenderResult 
     }
 }
 
-fn validate_diagram(
-    diagram: &str,
-    name: &str,
-    validator_path: &Path,
-) -> ValidationEntry {
+fn validate_diagram(diagram: &str, name: &str, validator_path: &Path) -> ValidationEntry {
     let rust_result = render_with_rust(diagram);
     let ts_result = render_with_typescript(diagram, validator_path);
 
@@ -296,12 +292,7 @@ fn print_report(report: &ValidationReport) {
     let mismatches: Vec<_> = report
         .entries
         .iter()
-        .filter(|e| {
-            e.comparison
-                .as_ref()
-                .map(|c| !c.matches)
-                .unwrap_or(false)
-        })
+        .filter(|e| e.comparison.as_ref().map(|c| !c.matches).unwrap_or(false))
         .collect();
 
     if !mismatches.is_empty() {
@@ -425,7 +416,11 @@ fn main() {
     } else {
         // Single file
         let content = fs::read_to_string(&input_path).expect("Failed to read input file");
-        let name = input_path.file_stem().unwrap().to_string_lossy().to_string();
+        let name = input_path
+            .file_stem()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
         vec![(name, content)]
     };
 

--- a/src/bin/selkie.rs
+++ b/src/bin/selkie.rs
@@ -167,8 +167,8 @@ fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
     // Load config file if specified
     let config_file = if let Some(ref path) = args.config_file {
-        let content = fs::read_to_string(path)
-            .map_err(|e| format!("Failed to read config file: {}", e))?;
+        let content =
+            fs::read_to_string(path).map_err(|e| format!("Failed to read config file: {}", e))?;
         let cfg: ConfigFile = serde_json::from_str(&content)
             .map_err(|e| format!("Failed to parse config file: {}", e))?;
         if args.verbose {
@@ -414,8 +414,8 @@ fn svg_to_png(
     opt.fontdb_mut().load_system_fonts();
 
     // Parse SVG
-    let tree = usvg::Tree::from_str(svg, &opt)
-        .map_err(|e| format!("Failed to parse SVG: {}", e))?;
+    let tree =
+        usvg::Tree::from_str(svg, &opt).map_err(|e| format!("Failed to parse SVG: {}", e))?;
 
     // Calculate dimensions
     let svg_size = tree.size();
@@ -433,8 +433,8 @@ fn svg_to_png(
     };
 
     // Create pixmap
-    let mut pixmap = tiny_skia::Pixmap::new(target_width, target_height)
-        .ok_or("Failed to create pixmap")?;
+    let mut pixmap =
+        tiny_skia::Pixmap::new(target_width, target_height).ok_or("Failed to create pixmap")?;
 
     // Calculate transform to fit
     let scale_x = target_width as f32 / svg_size.width();
@@ -462,8 +462,8 @@ fn svg_to_pdf(svg: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     opt.fontdb_mut().load_system_fonts();
 
     // Parse SVG
-    let tree = usvg::Tree::from_str(svg, &opt)
-        .map_err(|e| format!("Failed to parse SVG: {}", e))?;
+    let tree =
+        usvg::Tree::from_str(svg, &opt).map_err(|e| format!("Failed to parse SVG: {}", e))?;
 
     // Convert to PDF
     let pdf_data = svg2pdf::to_pdf(

--- a/src/bin/selkie.rs
+++ b/src/bin/selkie.rs
@@ -107,9 +107,32 @@ enum ThemeArg {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
 enum OutputFormat {
     Svg,
-    // PNG and PDF require additional dependencies (not yet supported)
-    // Png,
-    // Pdf,
+    #[cfg(feature = "png")]
+    Png,
+    #[cfg(feature = "pdf")]
+    Pdf,
+}
+
+impl OutputFormat {
+    /// Detect output format from file extension
+    fn from_extension(path: &str) -> Option<Self> {
+        let path_lower = path.to_lowercase();
+        if path_lower.ends_with(".svg") {
+            Some(OutputFormat::Svg)
+        } else if path_lower.ends_with(".png") {
+            #[cfg(feature = "png")]
+            return Some(OutputFormat::Png);
+            #[cfg(not(feature = "png"))]
+            return None;
+        } else if path_lower.ends_with(".pdf") {
+            #[cfg(feature = "pdf")]
+            return Some(OutputFormat::Pdf);
+            #[cfg(not(feature = "pdf"))]
+            return None;
+        } else {
+            None
+        }
+    }
 }
 
 fn main() {
@@ -229,8 +252,36 @@ fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("Rendered {} bytes of SVG", svg.len());
     }
 
-    // Write output
-    write_output(&args.output, &svg)?;
+    // Determine output format
+    let format = args.output_format.unwrap_or_else(|| {
+        args.output
+            .as_deref()
+            .and_then(|p| {
+                if p == "-" {
+                    None
+                } else {
+                    OutputFormat::from_extension(p)
+                }
+            })
+            .unwrap_or(OutputFormat::Svg)
+    });
+
+    // Write output based on format
+    match format {
+        OutputFormat::Svg => {
+            write_output(&args.output, svg.as_bytes())?;
+        }
+        #[cfg(feature = "png")]
+        OutputFormat::Png => {
+            let png_data = svg_to_png(&svg, args.width, args.height)?;
+            write_binary_output(&args.output, &png_data)?;
+        }
+        #[cfg(feature = "pdf")]
+        OutputFormat::Pdf => {
+            let pdf_data = svg_to_pdf(&svg)?;
+            write_binary_output(&args.output, &pdf_data)?;
+        }
+    }
 
     if !args.quiet && args.output.as_deref() != Some("-") {
         if let Some(ref output) = args.output {
@@ -251,14 +302,106 @@ fn read_input(input: &str) -> Result<String, Box<dyn std::error::Error>> {
     }
 }
 
-fn write_output(output: &Option<String>, content: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn write_output(output: &Option<String>, content: &[u8]) -> Result<(), Box<dyn std::error::Error>> {
     match output.as_deref() {
         Some("-") | None => {
-            io::stdout().write_all(content.as_bytes())?;
+            io::stdout().write_all(content)?;
         }
         Some(path) => {
             fs::write(path, content)?;
         }
     }
     Ok(())
+}
+
+fn write_binary_output(
+    output: &Option<String>,
+    content: &[u8],
+) -> Result<(), Box<dyn std::error::Error>> {
+    match output.as_deref() {
+        Some("-") | None => {
+            io::stdout().write_all(content)?;
+        }
+        Some(path) => {
+            fs::write(path, content)?;
+        }
+    }
+    Ok(())
+}
+
+/// Convert SVG string to PNG bytes using resvg
+#[cfg(feature = "png")]
+fn svg_to_png(
+    svg: &str,
+    width: Option<u32>,
+    height: Option<u32>,
+) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    use resvg::tiny_skia;
+    use resvg::usvg;
+
+    // Set up options with font database
+    let mut opt = usvg::Options::default();
+    opt.fontdb_mut().load_system_fonts();
+
+    // Parse SVG
+    let tree = usvg::Tree::from_str(svg, &opt)
+        .map_err(|e| format!("Failed to parse SVG: {}", e))?;
+
+    // Calculate dimensions
+    let svg_size = tree.size();
+    let (target_width, target_height) = match (width, height) {
+        (Some(w), Some(h)) => (w, h),
+        (Some(w), None) => {
+            let scale = w as f32 / svg_size.width();
+            (w, (svg_size.height() * scale) as u32)
+        }
+        (None, Some(h)) => {
+            let scale = h as f32 / svg_size.height();
+            ((svg_size.width() * scale) as u32, h)
+        }
+        (None, None) => (svg_size.width() as u32, svg_size.height() as u32),
+    };
+
+    // Create pixmap
+    let mut pixmap = tiny_skia::Pixmap::new(target_width, target_height)
+        .ok_or("Failed to create pixmap")?;
+
+    // Calculate transform to fit
+    let scale_x = target_width as f32 / svg_size.width();
+    let scale_y = target_height as f32 / svg_size.height();
+    let transform = tiny_skia::Transform::from_scale(scale_x, scale_y);
+
+    // Render
+    resvg::render(&tree, transform, &mut pixmap.as_mut());
+
+    // Encode to PNG
+    let png_data = pixmap
+        .encode_png()
+        .map_err(|e| format!("Failed to encode PNG: {}", e))?;
+
+    Ok(png_data)
+}
+
+/// Convert SVG string to PDF bytes using svg2pdf
+#[cfg(feature = "pdf")]
+fn svg_to_pdf(svg: &str) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+    use resvg::usvg;
+
+    // Set up options with font database
+    let mut opt = usvg::Options::default();
+    opt.fontdb_mut().load_system_fonts();
+
+    // Parse SVG
+    let tree = usvg::Tree::from_str(svg, &opt)
+        .map_err(|e| format!("Failed to parse SVG: {}", e))?;
+
+    // Convert to PDF
+    let pdf_data = svg2pdf::to_pdf(
+        &tree,
+        svg2pdf::ConversionOptions::default(),
+        svg2pdf::PageOptions::default(),
+    )
+    .map_err(|e| format!("Failed to convert to PDF: {}", e))?;
+
+    Ok(pdf_data)
 }

--- a/src/bin/selkie.rs
+++ b/src/bin/selkie.rs
@@ -94,6 +94,16 @@ struct Args {
     /// Show verbose output
     #[arg(short, long)]
     verbose: bool,
+
+    /// Display diagram directly in terminal (requires kitty/ghostty)
+    #[cfg(feature = "kitty")]
+    #[arg(short = 'd', long)]
+    display: bool,
+
+    /// Force terminal display even if kitty support is not detected
+    #[cfg(feature = "kitty")]
+    #[arg(long)]
+    force_display: bool,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
@@ -102,6 +112,9 @@ enum ThemeArg {
     Dark,
     Forest,
     Neutral,
+    /// Auto-detect based on terminal background color
+    #[cfg(feature = "kitty")]
+    Auto,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
@@ -184,6 +197,21 @@ fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
         ThemeArg::Dark => Theme::dark(),
         ThemeArg::Forest => Theme::forest(),
         ThemeArg::Neutral => Theme::neutral(),
+        #[cfg(feature = "kitty")]
+        ThemeArg::Auto => {
+            // Auto-detect based on terminal background
+            if mermaid::kitty::is_terminal_dark() {
+                if args.verbose {
+                    eprintln!("Auto-detected dark terminal, using dark theme");
+                }
+                Theme::dark()
+            } else {
+                if args.verbose {
+                    eprintln!("Auto-detected light terminal, using default theme");
+                }
+                Theme::default()
+            }
+        }
     };
 
     // Apply theme variables from config file
@@ -250,6 +278,48 @@ fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
 
     if args.verbose {
         eprintln!("Rendered {} bytes of SVG", svg.len());
+    }
+
+    // Handle terminal display mode
+    #[cfg(feature = "kitty")]
+    if args.display || args.force_display {
+        // Check for kitty support
+        if !args.force_display && !mermaid::kitty::is_supported() {
+            return Err("Terminal does not support kitty graphics protocol. Use --force-display to override.".into());
+        }
+
+        if args.verbose {
+            eprintln!("Displaying diagram in terminal using kitty graphics protocol");
+        }
+
+        // Convert to PNG for display
+        let png_data = svg_to_png(&svg, args.width, args.height)?;
+        mermaid::kitty::display_png(&png_data)
+            .map_err(|e| format!("Failed to display image: {}", e))?;
+
+        // Also write to file if output was specified
+        if let Some(ref output) = args.output {
+            if output != "-" {
+                let format = args.output_format.unwrap_or_else(|| {
+                    OutputFormat::from_extension(output).unwrap_or(OutputFormat::Svg)
+                });
+                match format {
+                    OutputFormat::Svg => write_output(&Some(output.clone()), svg.as_bytes())?,
+                    #[cfg(feature = "png")]
+                    OutputFormat::Png => write_binary_output(&Some(output.clone()), &png_data)?,
+                    #[cfg(feature = "pdf")]
+                    OutputFormat::Pdf => {
+                        let pdf_data = svg_to_pdf(&svg)?;
+                        write_binary_output(&Some(output.clone()), &pdf_data)?;
+                    }
+                }
+                if !args.quiet {
+                    eprintln!("Created {}", output);
+                }
+            }
+        }
+
+        return Ok(());
     }
 
     // Determine output format

--- a/src/common/sanitize.rs
+++ b/src/common/sanitize.rs
@@ -6,9 +6,8 @@ use std::sync::LazyLock;
 use crate::config::{Config, SecurityLevel};
 
 // Script tag patterns
-static SCRIPT_BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?is)<script[^>]*>.*?</script>").unwrap()
-});
+static SCRIPT_BLOCK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)<script[^>]*>.*?</script>").unwrap());
 
 static SCRIPT_SRC_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?i)<script[^>]*src\s*=\s*["'][^"']*["'][^>]*>\s*</script>"#).unwrap()
@@ -22,21 +21,17 @@ static JAVASCRIPT_COLON_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r#"(?i)<a[^>]*href\s*=\s*["']javascript&colon;[^"']*["'][^>]*>(.*?)</a>"#).unwrap()
 });
 
-static IMG_ONERROR_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?i)<img\s*[^>]*onerror\s*=\s*["'][^"']*["'][^>]*>"#).unwrap()
-});
+static IMG_ONERROR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)<img\s*[^>]*onerror\s*=\s*["'][^"']*["'][^>]*>"#).unwrap());
 
-static IFRAME_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?is)<iframe[^>]*>.*?</iframe>").unwrap()
-});
+static IFRAME_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)<iframe[^>]*>.*?</iframe>").unwrap());
 
-static TARGET_BLANK_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?i)<a([^>]*target\s*=\s*["']_blank["'][^>]*)>"#).unwrap()
-});
+static TARGET_BLANK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)<a([^>]*target\s*=\s*["']_blank["'][^>]*)>"#).unwrap());
 
-static HAS_REL_NOOPENER_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?i)rel\s*=\s*["'][^"']*noopener[^"']*["']"#).unwrap()
-});
+static HAS_REL_NOOPENER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)rel\s*=\s*["'][^"']*noopener[^"']*["']"#).unwrap());
 
 /// Remove script tags and dangerous patterns from HTML
 pub fn remove_script(text: &str) -> String {
@@ -49,10 +44,14 @@ pub fn remove_script(text: &str) -> String {
     result = SCRIPT_SRC_RE.replace_all(&result, "").to_string();
 
     // Remove javascript: URLs
-    result = JAVASCRIPT_URL_RE.replace_all(&result, "<a>$1</a>").to_string();
+    result = JAVASCRIPT_URL_RE
+        .replace_all(&result, "<a>$1</a>")
+        .to_string();
 
     // Remove javascript&colon; URLs
-    result = JAVASCRIPT_COLON_RE.replace_all(&result, "<a>$1</a>").to_string();
+    result = JAVASCRIPT_COLON_RE
+        .replace_all(&result, "<a>$1</a>")
+        .to_string();
 
     // Remove onerror handlers from images
     result = IMG_ONERROR_RE.replace_all(&result, "<img>").to_string();
@@ -61,14 +60,16 @@ pub fn remove_script(text: &str) -> String {
     result = IFRAME_RE.replace_all(&result, "").to_string();
 
     // Add rel="noopener" to target="_blank" links that don't have it
-    result = TARGET_BLANK_RE.replace_all(&result, |caps: &regex::Captures| {
-        let attrs = &caps[1];
-        if HAS_REL_NOOPENER_RE.is_match(attrs) {
-            format!("<a{}>", attrs)
-        } else {
-            format!("<a{} rel=\"noopener\">", attrs)
-        }
-    }).to_string();
+    result = TARGET_BLANK_RE
+        .replace_all(&result, |caps: &regex::Captures| {
+            let attrs = &caps[1];
+            if HAS_REL_NOOPENER_RE.is_match(attrs) {
+                format!("<a{}>", attrs)
+            } else {
+                format!("<a{} rel=\"noopener\">", attrs)
+            }
+        })
+        .to_string();
 
     result
 }
@@ -92,9 +93,7 @@ pub fn sanitize_text(text: &str, config: &Config) -> String {
             // In sandbox mode, allow HTML but remove scripts
             remove_script(text)
         }
-        SecurityLevel::Loose | SecurityLevel::Antiscript => {
-            remove_script(text)
-        }
+        SecurityLevel::Loose | SecurityLevel::Antiscript => remove_script(text),
     }
 }
 
@@ -326,14 +325,25 @@ mod tests {
             let test_cases = vec![
                 ("test~T~", "test<T>"),
                 ("test~Array~Array~string~~~", "test<Array<Array<string>>>"),
-                ("test~Array~Array~string[]~~~", "test<Array<Array<string[]>>>"),
-                ("test ~Array~Array~string[]~~~", "test <Array<Array<string[]>>>"),
+                (
+                    "test~Array~Array~string[]~~~",
+                    "test<Array<Array<string[]>>>",
+                ),
+                (
+                    "test ~Array~Array~string[]~~~",
+                    "test <Array<Array<string[]>>>",
+                ),
                 ("~test", "~test"),
                 ("~test~T~", "~test<T>"),
             ];
 
             for (input, expected) in test_cases {
-                assert_eq!(parse_generic_types(input), expected, "Failed for input: {}", input);
+                assert_eq!(
+                    parse_generic_types(input),
+                    expected,
+                    "Failed for input: {}",
+                    input
+                );
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -57,9 +57,7 @@ fn default_text_position() -> f64 {
 
 impl Default for PieConfig {
     fn default() -> Self {
-        Self {
-            text_position: 0.5,
-        }
+        Self { text_position: 0.5 }
     }
 }
 

--- a/src/diagrams/architecture/mod.rs
+++ b/src/diagrams/architecture/mod.rs
@@ -3,12 +3,12 @@
 //! This module provides data structures for architecture diagrams.
 //! Architecture diagrams show software architecture with services, groups, and connections.
 
-mod types;
 pub mod parser;
+mod types;
 
+pub use parser::parse;
 pub use types::{
     get_direction_alignment, ArchitectureAlignment, ArchitectureDb, ArchitectureDirection,
-    ArchitectureEdge, ArchitectureError, ArchitectureGroup, ArchitectureJunction,
-    ArchitectureNode, ArchitectureService, DirectionPair, RegistryEntry,
+    ArchitectureEdge, ArchitectureError, ArchitectureGroup, ArchitectureJunction, ArchitectureNode,
+    ArchitectureService, DirectionPair, RegistryEntry,
 };
-pub use parser::parse;

--- a/src/diagrams/architecture/parser.rs
+++ b/src/diagrams/architecture/parser.rs
@@ -706,7 +706,10 @@ mod tests {
 
         assert_eq!(result.get_title(), "My Architecture");
         assert_eq!(result.get_acc_title(), "Architecture Diagram");
-        assert_eq!(result.get_acc_description(), "Shows the system architecture");
+        assert_eq!(
+            result.get_acc_description(),
+            "Shows the system architecture"
+        );
 
         assert_eq!(result.get_groups().len(), 1);
         assert_eq!(result.get_services().len(), 3);

--- a/src/diagrams/architecture/types.rs
+++ b/src/diagrams/architecture/types.rs
@@ -65,7 +65,10 @@ pub enum ArchitectureAlignment {
 }
 
 /// Get alignment between two directions
-pub fn get_direction_alignment(a: ArchitectureDirection, b: ArchitectureDirection) -> ArchitectureAlignment {
+pub fn get_direction_alignment(
+    a: ArchitectureDirection,
+    b: ArchitectureDirection,
+) -> ArchitectureAlignment {
     if (a.is_x() && b.is_y()) || (a.is_y() && b.is_x()) {
         ArchitectureAlignment::Bend
     } else if a.is_x() {
@@ -106,17 +109,33 @@ impl DirectionPair {
     /// Shift a position based on this direction pair
     pub fn shift_position(&self, x: i32, y: i32) -> (i32, i32) {
         if self.source.is_x() {
-            let dx = if self.source == ArchitectureDirection::Left { -1 } else { 1 };
+            let dx = if self.source == ArchitectureDirection::Left {
+                -1
+            } else {
+                1
+            };
             if self.target.is_y() {
-                let dy = if self.target == ArchitectureDirection::Top { 1 } else { -1 };
+                let dy = if self.target == ArchitectureDirection::Top {
+                    1
+                } else {
+                    -1
+                };
                 (x + dx, y + dy)
             } else {
                 (x + dx, y)
             }
         } else {
-            let dy = if self.source == ArchitectureDirection::Top { 1 } else { -1 };
+            let dy = if self.source == ArchitectureDirection::Top {
+                1
+            } else {
+                -1
+            };
             if self.target.is_x() {
-                let dx = if self.target == ArchitectureDirection::Left { 1 } else { -1 };
+                let dx = if self.target == ArchitectureDirection::Left {
+                    1
+                } else {
+                    -1
+                };
                 (x + dx, y + dy)
             } else {
                 (x, y + dy)
@@ -322,7 +341,11 @@ pub enum ArchitectureError {
     /// Node not found for edge
     NodeNotFound { id: String },
     /// Invalid direction
-    InvalidDirection { lhs_id: String, rhs_id: String, dir: String },
+    InvalidDirection {
+        lhs_id: String,
+        rhs_id: String,
+        dir: String,
+    },
     /// Group boundary traversal error
     InvalidGroupBoundary { id: String },
 }
@@ -331,22 +354,42 @@ impl std::fmt::Display for ArchitectureError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ArchitectureError::DuplicateId { id, used_by } => {
-                write!(f, "The id [{}] is already in use by another {}", id, used_by)
+                write!(
+                    f,
+                    "The id [{}] is already in use by another {}",
+                    id, used_by
+                )
             }
             ArchitectureError::SelfReference { id } => {
                 write!(f, "The element [{}] cannot be placed within itself", id)
             }
             ArchitectureError::ParentNotFound { id, parent } => {
-                write!(f, "The element [{}]'s parent [{}] does not exist", id, parent)
+                write!(
+                    f,
+                    "The element [{}]'s parent [{}] does not exist",
+                    id, parent
+                )
             }
             ArchitectureError::ParentNotGroup { id, parent } => {
-                write!(f, "The element [{}]'s parent [{}] is not a group", id, parent)
+                write!(
+                    f,
+                    "The element [{}]'s parent [{}] is not a group",
+                    id, parent
+                )
             }
             ArchitectureError::NodeNotFound { id } => {
                 write!(f, "The node [{}] does not exist", id)
             }
-            ArchitectureError::InvalidDirection { lhs_id, rhs_id, dir } => {
-                write!(f, "Invalid direction [{}] for edge {}--{}", dir, lhs_id, rhs_id)
+            ArchitectureError::InvalidDirection {
+                lhs_id,
+                rhs_id,
+                dir,
+            } => {
+                write!(
+                    f,
+                    "Invalid direction [{}] for edge {}--{}",
+                    dir, lhs_id, rhs_id
+                )
             }
             ArchitectureError::InvalidGroupBoundary { id } => {
                 write!(f, "The id [{}] has invalid group boundary modifier", id)
@@ -445,14 +488,18 @@ impl ArchitectureDb {
                 return Err(ArchitectureError::SelfReference { id });
             }
             match self.registry.get(parent) {
-                None => return Err(ArchitectureError::ParentNotFound {
-                    id,
-                    parent: parent.clone(),
-                }),
-                Some(RegistryEntry::Node) => return Err(ArchitectureError::ParentNotGroup {
-                    id,
-                    parent: parent.clone(),
-                }),
+                None => {
+                    return Err(ArchitectureError::ParentNotFound {
+                        id,
+                        parent: parent.clone(),
+                    })
+                }
+                Some(RegistryEntry::Node) => {
+                    return Err(ArchitectureError::ParentNotGroup {
+                        id,
+                        parent: parent.clone(),
+                    })
+                }
                 Some(RegistryEntry::Group) => {}
             }
         }
@@ -463,7 +510,10 @@ impl ArchitectureDb {
     }
 
     /// Add a junction
-    pub fn add_junction(&mut self, junction: ArchitectureJunction) -> Result<(), ArchitectureError> {
+    pub fn add_junction(
+        &mut self,
+        junction: ArchitectureJunction,
+    ) -> Result<(), ArchitectureError> {
         let id = junction.id.clone();
 
         // Check for duplicate ID
@@ -483,14 +533,18 @@ impl ArchitectureDb {
                 return Err(ArchitectureError::SelfReference { id });
             }
             match self.registry.get(parent) {
-                None => return Err(ArchitectureError::ParentNotFound {
-                    id,
-                    parent: parent.clone(),
-                }),
-                Some(RegistryEntry::Node) => return Err(ArchitectureError::ParentNotGroup {
-                    id,
-                    parent: parent.clone(),
-                }),
+                None => {
+                    return Err(ArchitectureError::ParentNotFound {
+                        id,
+                        parent: parent.clone(),
+                    })
+                }
+                Some(RegistryEntry::Node) => {
+                    return Err(ArchitectureError::ParentNotGroup {
+                        id,
+                        parent: parent.clone(),
+                    })
+                }
                 Some(RegistryEntry::Group) => {}
             }
         }
@@ -521,14 +575,18 @@ impl ArchitectureDb {
                 return Err(ArchitectureError::SelfReference { id });
             }
             match self.registry.get(parent) {
-                None => return Err(ArchitectureError::ParentNotFound {
-                    id,
-                    parent: parent.clone(),
-                }),
-                Some(RegistryEntry::Node) => return Err(ArchitectureError::ParentNotGroup {
-                    id,
-                    parent: parent.clone(),
-                }),
+                None => {
+                    return Err(ArchitectureError::ParentNotFound {
+                        id,
+                        parent: parent.clone(),
+                    })
+                }
+                Some(RegistryEntry::Node) => {
+                    return Err(ArchitectureError::ParentNotGroup {
+                        id,
+                        parent: parent.clone(),
+                    })
+                }
                 Some(RegistryEntry::Group) => {}
             }
         }
@@ -542,10 +600,14 @@ impl ArchitectureDb {
     pub fn add_edge(&mut self, edge: ArchitectureEdge) -> Result<(), ArchitectureError> {
         // Validate that both nodes exist
         if !self.nodes.contains_key(&edge.lhs_id) && !self.groups.contains_key(&edge.lhs_id) {
-            return Err(ArchitectureError::NodeNotFound { id: edge.lhs_id.clone() });
+            return Err(ArchitectureError::NodeNotFound {
+                id: edge.lhs_id.clone(),
+            });
         }
         if !self.nodes.contains_key(&edge.rhs_id) && !self.groups.contains_key(&edge.rhs_id) {
-            return Err(ArchitectureError::NodeNotFound { id: edge.rhs_id.clone() });
+            return Err(ArchitectureError::NodeNotFound {
+                id: edge.rhs_id.clone(),
+            });
         }
 
         // Validate group boundary constraints
@@ -555,7 +617,9 @@ impl ArchitectureDb {
         if edge.lhs_group {
             if let (Some(lhs_g), Some(rhs_g)) = (lhs_group_id, rhs_group_id) {
                 if lhs_g == rhs_g {
-                    return Err(ArchitectureError::InvalidGroupBoundary { id: edge.lhs_id.clone() });
+                    return Err(ArchitectureError::InvalidGroupBoundary {
+                        id: edge.lhs_id.clone(),
+                    });
                 }
             }
         }
@@ -563,7 +627,9 @@ impl ArchitectureDb {
         if edge.rhs_group {
             if let (Some(lhs_g), Some(rhs_g)) = (lhs_group_id, rhs_group_id) {
                 if lhs_g == rhs_g {
-                    return Err(ArchitectureError::InvalidGroupBoundary { id: edge.rhs_id.clone() });
+                    return Err(ArchitectureError::InvalidGroupBoundary {
+                        id: edge.rhs_id.clone(),
+                    });
                 }
             }
         }
@@ -717,7 +783,10 @@ mod tests {
         let group = ArchitectureGroup::new("cloud".to_string()).with_parent("cloud");
         let result = db.add_group(group);
 
-        assert!(matches!(result, Err(ArchitectureError::SelfReference { .. })));
+        assert!(matches!(
+            result,
+            Err(ArchitectureError::SelfReference { .. })
+        ));
     }
 
     #[test]
@@ -727,7 +796,10 @@ mod tests {
         let service = ArchitectureService::new("db".to_string()).with_parent("nonexistent");
         let result = db.add_service(service);
 
-        assert!(matches!(result, Err(ArchitectureError::ParentNotFound { .. })));
+        assert!(matches!(
+            result,
+            Err(ArchitectureError::ParentNotFound { .. })
+        ));
     }
 
     #[test]
@@ -740,7 +812,10 @@ mod tests {
         let service2 = ArchitectureService::new("api".to_string()).with_parent("db");
         let result = db.add_service(service2);
 
-        assert!(matches!(result, Err(ArchitectureError::ParentNotGroup { .. })));
+        assert!(matches!(
+            result,
+            Err(ArchitectureError::ParentNotGroup { .. })
+        ));
     }
 
     #[test]
@@ -781,24 +856,51 @@ mod tests {
         );
         let result = db.add_edge(edge);
 
-        assert!(matches!(result, Err(ArchitectureError::NodeNotFound { .. })));
+        assert!(matches!(
+            result,
+            Err(ArchitectureError::NodeNotFound { .. })
+        ));
     }
 
     #[test]
     fn test_direction_from_char() {
-        assert_eq!(ArchitectureDirection::from_char('L'), Some(ArchitectureDirection::Left));
-        assert_eq!(ArchitectureDirection::from_char('r'), Some(ArchitectureDirection::Right));
-        assert_eq!(ArchitectureDirection::from_char('T'), Some(ArchitectureDirection::Top));
-        assert_eq!(ArchitectureDirection::from_char('b'), Some(ArchitectureDirection::Bottom));
+        assert_eq!(
+            ArchitectureDirection::from_char('L'),
+            Some(ArchitectureDirection::Left)
+        );
+        assert_eq!(
+            ArchitectureDirection::from_char('r'),
+            Some(ArchitectureDirection::Right)
+        );
+        assert_eq!(
+            ArchitectureDirection::from_char('T'),
+            Some(ArchitectureDirection::Top)
+        );
+        assert_eq!(
+            ArchitectureDirection::from_char('b'),
+            Some(ArchitectureDirection::Bottom)
+        );
         assert_eq!(ArchitectureDirection::from_char('X'), None);
     }
 
     #[test]
     fn test_direction_opposite() {
-        assert_eq!(ArchitectureDirection::Left.opposite(), ArchitectureDirection::Right);
-        assert_eq!(ArchitectureDirection::Right.opposite(), ArchitectureDirection::Left);
-        assert_eq!(ArchitectureDirection::Top.opposite(), ArchitectureDirection::Bottom);
-        assert_eq!(ArchitectureDirection::Bottom.opposite(), ArchitectureDirection::Top);
+        assert_eq!(
+            ArchitectureDirection::Left.opposite(),
+            ArchitectureDirection::Right
+        );
+        assert_eq!(
+            ArchitectureDirection::Right.opposite(),
+            ArchitectureDirection::Left
+        );
+        assert_eq!(
+            ArchitectureDirection::Top.opposite(),
+            ArchitectureDirection::Bottom
+        );
+        assert_eq!(
+            ArchitectureDirection::Bottom.opposite(),
+            ArchitectureDirection::Top
+        );
     }
 
     #[test]
@@ -814,10 +916,12 @@ mod tests {
 
     #[test]
     fn test_direction_pair_is_xy() {
-        let xy = DirectionPair::new(ArchitectureDirection::Left, ArchitectureDirection::Top).unwrap();
+        let xy =
+            DirectionPair::new(ArchitectureDirection::Left, ArchitectureDirection::Top).unwrap();
         assert!(xy.is_xy());
 
-        let not_xy = DirectionPair::new(ArchitectureDirection::Left, ArchitectureDirection::Right).unwrap();
+        let not_xy =
+            DirectionPair::new(ArchitectureDirection::Left, ArchitectureDirection::Right).unwrap();
         assert!(!not_xy.is_xy());
     }
 

--- a/src/diagrams/block/mod.rs
+++ b/src/diagrams/block/mod.rs
@@ -3,8 +3,8 @@
 //! This module provides data structures for block diagrams.
 //! Block diagrams show blocks/nodes and their connections in a grid layout.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{Block, BlockDb, BlockType, ClassDef, Edge};
 pub use parser::parse;
+pub use types::{Block, BlockDb, BlockType, ClassDef, Edge};

--- a/src/diagrams/block/parser.rs
+++ b/src/diagrams/block/parser.rs
@@ -13,8 +13,8 @@ pub struct BlockParser;
 pub fn parse(input: &str) -> Result<BlockDb, String> {
     let mut db = BlockDb::new();
 
-    let pairs = BlockParser::parse(Rule::diagram, input)
-        .map_err(|e| format!("Parse error: {}", e))?;
+    let pairs =
+        BlockParser::parse(Rule::diagram, input).map_err(|e| format!("Parse error: {}", e))?;
 
     for pair in pairs {
         if pair.as_rule() == Rule::diagram {
@@ -99,7 +99,9 @@ fn process_statement(
     Ok(())
 }
 
-fn extract_block_info(pair: pest::iterators::Pair<Rule>) -> Result<(String, Option<String>, BlockType, Option<usize>), String> {
+fn extract_block_info(
+    pair: pest::iterators::Pair<Rule>,
+) -> Result<(String, Option<String>, BlockType, Option<usize>), String> {
     let mut id = String::new();
     let mut label: Option<String> = None;
     let mut block_type = BlockType::Square;
@@ -211,7 +213,7 @@ fn extract_label(pair: pest::iterators::Pair<Rule>) -> String {
                     Rule::md_string => {
                         let s = label_inner.as_str();
                         if s.starts_with("\"`") && s.ends_with("`\"") {
-                            return s[2..s.len()-2].to_string();
+                            return s[2..s.len() - 2].to_string();
                         }
                         return s.to_string();
                     }
@@ -270,10 +272,7 @@ fn process_composite(
     Ok(())
 }
 
-fn process_edge(
-    db: &mut BlockDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_edge(db: &mut BlockDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut blocks: Vec<(String, Option<String>, BlockType, Option<usize>)> = Vec::new();
     let mut edge_label: Option<String> = None;
 
@@ -322,10 +321,7 @@ fn process_edge(
     Ok(())
 }
 
-fn process_class_def(
-    db: &mut BlockDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_class_def(db: &mut BlockDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut class_name = String::new();
     let mut styles: Vec<String> = Vec::new();
 
@@ -336,7 +332,8 @@ fn process_class_def(
             }
             Rule::style_list => {
                 // Split by semicolon or comma
-                styles = inner.as_str()
+                styles = inner
+                    .as_str()
                     .split(|c| c == ';' || c == ',')
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty())
@@ -384,10 +381,7 @@ fn process_class_assignment(
     Ok(())
 }
 
-fn process_style(
-    db: &mut BlockDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_style(db: &mut BlockDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut ids: Vec<String> = Vec::new();
     let mut styles: Vec<String> = Vec::new();
 
@@ -401,7 +395,8 @@ fn process_style(
                 }
             }
             Rule::style_list => {
-                styles = inner.as_str()
+                styles = inner
+                    .as_str()
                     .split(',')
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty())
@@ -421,7 +416,7 @@ fn process_style(
 /// Remove surrounding quotes from a string
 fn unquote(s: &str) -> String {
     if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
-        s[1..s.len()-1].to_string()
+        s[1..s.len() - 1].to_string()
     } else {
         s.to_string()
     }
@@ -540,7 +535,8 @@ mod tests {
 
         #[test]
         fn should_parse_space() {
-            let result = parse("block\n    columns 3\n    space\n    middle[\"In the middle\"]\n    space");
+            let result =
+                parse("block\n    columns 3\n    space\n    middle[\"In the middle\"]\n    space");
             assert!(result.is_ok(), "Parse error: {:?}", result.err());
             let db = result.unwrap();
             // Should have 3 blocks (2 spaces + 1 named)
@@ -562,7 +558,9 @@ mod tests {
 
         #[test]
         fn should_parse_style_statement() {
-            let result = parse("block\n    columns 1\n    B[\"A wide one\"]\n    style B fill:#f9F,stroke:#333");
+            let result = parse(
+                "block\n    columns 1\n    B[\"A wide one\"]\n    style B fill:#f9F,stroke:#333",
+            );
             assert!(result.is_ok(), "Parse error: {:?}", result.err());
             let db = result.unwrap();
             let block = db.get_blocks().get("B").unwrap();
@@ -591,7 +589,8 @@ mod tests {
 
         #[test]
         fn should_parse_width_spec() {
-            let result = parse("block\n    columns 3\n    one[\"One Slot\"]\n    two[\"Two slots\"]:2");
+            let result =
+                parse("block\n    columns 3\n    one[\"One Slot\"]\n    two[\"Two slots\"]:2");
             assert!(result.is_ok(), "Parse error: {:?}", result.err());
             let db = result.unwrap();
             let two = db.get_blocks().get("two").unwrap();

--- a/src/diagrams/block/types.rs
+++ b/src/diagrams/block/types.rs
@@ -279,7 +279,10 @@ mod tests {
 
         let classes = db.get_classes();
         assert!(classes.contains_key("highlight"));
-        assert_eq!(classes.get("highlight").unwrap().styles, vec!["fill: yellow"]);
+        assert_eq!(
+            classes.get("highlight").unwrap().styles,
+            vec!["fill: yellow"]
+        );
     }
 
     #[test]
@@ -290,7 +293,11 @@ mod tests {
         db.apply_class("a", "highlight");
 
         let blocks = db.get_blocks();
-        assert!(blocks.get("a").unwrap().classes.contains(&"highlight".to_string()));
+        assert!(blocks
+            .get("a")
+            .unwrap()
+            .classes
+            .contains(&"highlight".to_string()));
     }
 
     #[test]

--- a/src/diagrams/c4/mod.rs
+++ b/src/diagrams/c4/mod.rs
@@ -3,8 +3,8 @@
 //! This module provides data structures for C4 diagrams.
 //! C4 diagrams show software architecture using the C4 model.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{C4Boundary, C4Db, C4Element, C4Relationship, C4ShapeType};
 pub use parser::parse;
+pub use types::{C4Boundary, C4Db, C4Element, C4Relationship, C4ShapeType};

--- a/src/diagrams/c4/parser.rs
+++ b/src/diagrams/c4/parser.rs
@@ -13,8 +13,7 @@ pub struct C4Parser;
 pub fn parse(input: &str) -> Result<C4Db, String> {
     let mut db = C4Db::new();
 
-    let pairs = C4Parser::parse(Rule::diagram, input)
-        .map_err(|e| format!("Parse error: {}", e))?;
+    let pairs = C4Parser::parse(Rule::diagram, input).map_err(|e| format!("Parse error: {}", e))?;
 
     for pair in pairs {
         if pair.as_rule() == Rule::diagram {
@@ -36,20 +35,14 @@ pub fn parse(input: &str) -> Result<C4Db, String> {
     Ok(db)
 }
 
-fn process_document(
-    db: &mut C4Db,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_document(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for stmt in pair.into_inner() {
         process_statement(db, stmt)?;
     }
     Ok(())
 }
 
-fn process_statement(
-    db: &mut C4Db,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     match pair.as_rule() {
         Rule::statement => {
             for inner in pair.into_inner() {
@@ -418,7 +411,7 @@ fn extract_attribute(pair: pest::iterators::Pair<Rule>) -> String {
 /// Remove surrounding quotes from a string
 fn unquote(s: &str) -> String {
     if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
-        s[1..s.len()-1].to_string()
+        s[1..s.len() - 1].to_string()
     } else {
         s.to_string()
     }
@@ -473,7 +466,10 @@ Person(customerA, "Banking Customer A", "A customer of the bank, with personal b
             assert_eq!(elements.len(), 1);
             assert_eq!(elements[0].alias, "customerA");
             assert_eq!(elements[0].label, "Banking Customer A");
-            assert_eq!(elements[0].description, "A customer of the bank, with personal bank accounts.");
+            assert_eq!(
+                elements[0].description,
+                "A customer of the bank, with personal bank accounts."
+            );
             assert_eq!(elements[0].shape_type, C4ShapeType::Person);
         }
 

--- a/src/diagrams/c4/types.rs
+++ b/src/diagrams/c4/types.rs
@@ -3,7 +3,6 @@
 //! C4 diagrams show software architecture using the C4 model
 //! (Context, Containers, Components, Code).
 
-
 /// C4 element shape type
 #[derive(Debug, Clone, PartialEq)]
 pub enum C4ShapeType {
@@ -72,7 +71,12 @@ impl C4Element {
         }
     }
 
-    pub fn new_container(alias: String, label: String, technology: String, description: String) -> Self {
+    pub fn new_container(
+        alias: String,
+        label: String,
+        technology: String,
+        description: String,
+    ) -> Self {
         Self {
             alias,
             label,
@@ -86,7 +90,12 @@ impl C4Element {
         }
     }
 
-    pub fn new_component(alias: String, label: String, technology: String, description: String) -> Self {
+    pub fn new_component(
+        alias: String,
+        label: String,
+        technology: String,
+        description: String,
+    ) -> Self {
         Self {
             alias,
             label,
@@ -152,14 +161,28 @@ impl C4Db {
 
     /// Add a person element
     pub fn add_person(&mut self, alias: &str, label: &str, description: &str) {
-        let mut elem = C4Element::new_person(alias.to_string(), label.to_string(), description.to_string());
+        let mut elem = C4Element::new_person(
+            alias.to_string(),
+            label.to_string(),
+            description.to_string(),
+        );
         elem.parent_boundary = self.current_boundary();
         self.elements.push(elem);
     }
 
     /// Add a person element with specific shape type
-    pub fn add_person_with_type(&mut self, alias: &str, label: &str, description: &str, shape_type: C4ShapeType) {
-        let mut elem = C4Element::new_person(alias.to_string(), label.to_string(), description.to_string());
+    pub fn add_person_with_type(
+        &mut self,
+        alias: &str,
+        label: &str,
+        description: &str,
+        shape_type: C4ShapeType,
+    ) {
+        let mut elem = C4Element::new_person(
+            alias.to_string(),
+            label.to_string(),
+            description.to_string(),
+        );
         elem.shape_type = shape_type;
         elem.parent_boundary = self.current_boundary();
         self.elements.push(elem);
@@ -167,14 +190,28 @@ impl C4Db {
 
     /// Add a system element
     pub fn add_system(&mut self, alias: &str, label: &str, description: &str) {
-        let mut elem = C4Element::new_system(alias.to_string(), label.to_string(), description.to_string());
+        let mut elem = C4Element::new_system(
+            alias.to_string(),
+            label.to_string(),
+            description.to_string(),
+        );
         elem.parent_boundary = self.current_boundary();
         self.elements.push(elem);
     }
 
     /// Add a system element with specific shape type
-    pub fn add_system_with_type(&mut self, alias: &str, label: &str, description: &str, shape_type: C4ShapeType) {
-        let mut elem = C4Element::new_system(alias.to_string(), label.to_string(), description.to_string());
+    pub fn add_system_with_type(
+        &mut self,
+        alias: &str,
+        label: &str,
+        description: &str,
+        shape_type: C4ShapeType,
+    ) {
+        let mut elem = C4Element::new_system(
+            alias.to_string(),
+            label.to_string(),
+            description.to_string(),
+        );
         elem.shape_type = shape_type;
         elem.parent_boundary = self.current_boundary();
         self.elements.push(elem);
@@ -193,7 +230,14 @@ impl C4Db {
     }
 
     /// Add a container element with specific shape type
-    pub fn add_container_with_type(&mut self, alias: &str, label: &str, technology: &str, description: &str, shape_type: C4ShapeType) {
+    pub fn add_container_with_type(
+        &mut self,
+        alias: &str,
+        label: &str,
+        technology: &str,
+        description: &str,
+        shape_type: C4ShapeType,
+    ) {
         let mut elem = C4Element::new_container(
             alias.to_string(),
             label.to_string(),
@@ -218,7 +262,14 @@ impl C4Db {
     }
 
     /// Add a component element with specific shape type
-    pub fn add_component_with_type(&mut self, alias: &str, label: &str, technology: &str, description: &str, shape_type: C4ShapeType) {
+    pub fn add_component_with_type(
+        &mut self,
+        alias: &str,
+        label: &str,
+        technology: &str,
+        description: &str,
+        shape_type: C4ShapeType,
+    ) {
         let mut elem = C4Element::new_component(
             alias.to_string(),
             label.to_string(),

--- a/src/diagrams/class/mod.rs
+++ b/src/diagrams/class/mod.rs
@@ -3,11 +3,11 @@
 //! The class diagram shows the structure of classes, their attributes,
 //! methods, and relationships between them.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::*;
 pub use parser::parse;
+pub use types::*;
 
 #[cfg(test)]
 mod tests {
@@ -780,8 +780,10 @@ mod tests {
 
         #[test]
         fn member_name_should_handle_generic_type() {
-            let member =
-                ClassMember::new("getTime~T~(this T, int seconds)$ DateTime", MemberType::Method);
+            let member = ClassMember::new(
+                "getTime~T~(this T, int seconds)$ DateTime",
+                MemberType::Method,
+            );
             let details = member.get_display_details();
             assert_eq!(
                 details.display_text,

--- a/src/diagrams/class/parser.rs
+++ b/src/diagrams/class/parser.rs
@@ -13,8 +13,8 @@ pub struct ClassParser;
 pub fn parse(input: &str) -> Result<ClassDb, String> {
     let mut db = ClassDb::new();
 
-    let pairs = ClassParser::parse(Rule::diagram, input)
-        .map_err(|e| format!("Parse error: {}", e))?;
+    let pairs =
+        ClassParser::parse(Rule::diagram, input).map_err(|e| format!("Parse error: {}", e))?;
 
     for pair in pairs {
         if pair.as_rule() == Rule::diagram {
@@ -926,7 +926,10 @@ foo()
                 class.members[1].get_display_details().display_text,
                 "string fooMember"
             );
-            assert_eq!(class.methods[0].get_display_details().display_text, "test()");
+            assert_eq!(
+                class.methods[0].get_display_details().display_text,
+                "test()"
+            );
             assert_eq!(class.methods[1].get_display_details().display_text, "foo()");
         }
 
@@ -1046,7 +1049,10 @@ Class09 -- Class1",
             assert!(result.is_ok());
             let db = result.unwrap();
             assert_eq!(db.relations.len(), 1);
-            assert_eq!(db.relations[0].relation.type1, RelationType::Extension as i32);
+            assert_eq!(
+                db.relations[0].relation.type1,
+                RelationType::Extension as i32
+            );
             assert_eq!(db.relations[0].relation.type2, -1);
             assert_eq!(db.relations[0].relation.line_type, LineType::Solid);
         }
@@ -1394,8 +1400,16 @@ cssClass \"C1,C2\" styleClass",
             );
             assert!(result.is_ok());
             let db = result.unwrap();
-            assert!(db.get_class("C1").unwrap().css_classes.contains("styleClass"));
-            assert!(db.get_class("C2").unwrap().css_classes.contains("styleClass"));
+            assert!(db
+                .get_class("C1")
+                .unwrap()
+                .css_classes
+                .contains("styleClass"));
+            assert!(db
+                .get_class("C2")
+                .unwrap()
+                .css_classes
+                .contains("styleClass"));
         }
     }
 
@@ -1589,10 +1603,7 @@ Class1 : someMethod()*",
             assert_eq!(class.methods.len(), 1);
             let method = &class.methods[0];
             assert_eq!(method.get_display_details().display_text, "someMethod()");
-            assert_eq!(
-                method.get_display_details().css_style,
-                "font-style:italic;"
-            );
+            assert_eq!(method.get_display_details().css_style, "font-style:italic;");
         }
 
         #[test]

--- a/src/diagrams/class/types.rs
+++ b/src/diagrams/class/types.rs
@@ -462,7 +462,8 @@ impl ClassDb {
     /// Add a class to the database
     pub fn add_class(&mut self, id: &str) {
         if !self.classes.contains_key(id) {
-            self.classes.insert(id.to_string(), ClassNode::new(id.to_string()));
+            self.classes
+                .insert(id.to_string(), ClassNode::new(id.to_string()));
         }
     }
 
@@ -487,9 +488,13 @@ impl ClassDb {
         if let Some(class) = self.classes.get_mut(class_name) {
             // Determine if it's a method or attribute
             if member.contains('(') {
-                class.methods.push(ClassMember::new(member, MemberType::Method));
+                class
+                    .methods
+                    .push(ClassMember::new(member, MemberType::Method));
             } else {
-                class.members.push(ClassMember::new(member, MemberType::Attribute));
+                class
+                    .members
+                    .push(ClassMember::new(member, MemberType::Attribute));
             }
         }
     }
@@ -554,7 +559,8 @@ impl ClassDb {
     /// Add a namespace
     pub fn add_namespace(&mut self, id: &str) {
         if !self.namespaces.contains_key(id) {
-            self.namespaces.insert(id.to_string(), NamespaceNode::new(id.to_string()));
+            self.namespaces
+                .insert(id.to_string(), NamespaceNode::new(id.to_string()));
         }
     }
 

--- a/src/diagrams/detect.rs
+++ b/src/diagrams/detect.rs
@@ -34,32 +34,42 @@ pub enum DiagramType {
 }
 
 // Regex patterns for detecting diagram types
-static FLOWCHART_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^\s*(flowchart|graph)\s*(TB|BT|RL|LR|TD)?").unwrap()
-});
+static FLOWCHART_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*(flowchart|graph)\s*(TB|BT|RL|LR|TD)?").unwrap());
 
 static PIE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*pie").unwrap());
 static MINDMAP_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*mindmap").unwrap());
 static INFO_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*info").unwrap());
-static SEQUENCE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*sequenceDiagram").unwrap());
+static SEQUENCE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*sequenceDiagram").unwrap());
 static CLASS_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*classDiagram").unwrap());
 static STATE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*stateDiagram").unwrap());
 static ER_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*erDiagram").unwrap());
 static GANTT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*gantt").unwrap());
-static JOURNEY_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*(journey|user-journey)").unwrap());
+static JOURNEY_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*(journey|user-journey)").unwrap());
 static GIT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*gitGraph").unwrap());
-static REQUIREMENT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*requirementDiagram").unwrap());
-static QUADRANT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*quadrantChart").unwrap());
-static C4_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*C4(Context|Container|Component|Dynamic|Deployment)").unwrap());
+static REQUIREMENT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*requirementDiagram").unwrap());
+static QUADRANT_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*quadrantChart").unwrap());
+static C4_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)^\s*C4(Context|Container|Component|Dynamic|Deployment)").unwrap()
+});
 static TIMELINE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*timeline").unwrap());
-static SANKEY_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*sankey(-beta)?").unwrap());
-static XYCHART_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*xychart(-beta)?").unwrap());
+static SANKEY_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*sankey(-beta)?").unwrap());
+static XYCHART_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*xychart(-beta)?").unwrap());
 static BLOCK_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*block(-beta)?").unwrap());
-static PACKET_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*packet(-beta)?").unwrap());
-static ARCHITECTURE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*architecture(-beta)?").unwrap());
+static PACKET_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*packet(-beta)?").unwrap());
+static ARCHITECTURE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*architecture(-beta)?").unwrap());
 static KANBAN_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*kanban").unwrap());
 static RADAR_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*radar(-beta)?").unwrap());
-static TREEMAP_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?i)^\s*treemap(-beta)?").unwrap());
+static TREEMAP_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*treemap(-beta)?").unwrap());
 
 /// Detect the type of diagram from input text
 pub fn detect_type(input: &str) -> Result<DiagramType> {

--- a/src/diagrams/er/mod.rs
+++ b/src/diagrams/er/mod.rs
@@ -3,11 +3,11 @@
 //! ER diagrams model database schemas with entities, attributes,
 //! and relationships with cardinality and identification.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::*;
 pub use parser::parse;
+pub use types::*;
 
 #[cfg(test)]
 mod tests {
@@ -169,7 +169,11 @@ mod tests {
                 "Customer",
                 "places",
                 "Order",
-                RelSpec::new(Cardinality::OnlyOne, Cardinality::ZeroOrMore, Identification::Identifying),
+                RelSpec::new(
+                    Cardinality::OnlyOne,
+                    Cardinality::ZeroOrMore,
+                    Identification::Identifying,
+                ),
             );
 
             assert_eq!(db.get_relationships().len(), 1);
@@ -185,7 +189,11 @@ mod tests {
                 "Customer",
                 "places",
                 "Order",
-                RelSpec::new(Cardinality::OnlyOne, Cardinality::ZeroOrMore, Identification::Identifying),
+                RelSpec::new(
+                    Cardinality::OnlyOne,
+                    Cardinality::ZeroOrMore,
+                    Identification::Identifying,
+                ),
             );
 
             assert_eq!(db.get_relationships().len(), 0);
@@ -204,7 +212,11 @@ mod tests {
                 "Customer",
                 "places",
                 "Order",
-                RelSpec::new(Cardinality::OnlyOne, Cardinality::ZeroOrMore, Identification::Identifying),
+                RelSpec::new(
+                    Cardinality::OnlyOne,
+                    Cardinality::ZeroOrMore,
+                    Identification::Identifying,
+                ),
             );
 
             let rel = &db.get_relationships()[0];
@@ -219,7 +231,10 @@ mod tests {
         #[test]
         fn should_parse_cardinality() {
             assert_eq!(Cardinality::from_str("ZERO_OR_ONE"), Cardinality::ZeroOrOne);
-            assert_eq!(Cardinality::from_str("ZERO_OR_MORE"), Cardinality::ZeroOrMore);
+            assert_eq!(
+                Cardinality::from_str("ZERO_OR_MORE"),
+                Cardinality::ZeroOrMore
+            );
             assert_eq!(Cardinality::from_str("ONE_OR_MORE"), Cardinality::OneOrMore);
             assert_eq!(Cardinality::from_str("ONLY_ONE"), Cardinality::OnlyOne);
         }
@@ -238,10 +253,19 @@ mod tests {
 
         #[test]
         fn should_parse_identification() {
-            assert_eq!(Identification::from_str("IDENTIFYING"), Identification::Identifying);
-            assert_eq!(Identification::from_str("NON_IDENTIFYING"), Identification::NonIdentifying);
+            assert_eq!(
+                Identification::from_str("IDENTIFYING"),
+                Identification::Identifying
+            );
+            assert_eq!(
+                Identification::from_str("NON_IDENTIFYING"),
+                Identification::NonIdentifying
+            );
             assert_eq!(Identification::from_str("--"), Identification::Identifying);
-            assert_eq!(Identification::from_str(".."), Identification::NonIdentifying);
+            assert_eq!(
+                Identification::from_str(".."),
+                Identification::NonIdentifying
+            );
         }
 
         #[test]
@@ -365,7 +389,11 @@ mod tests {
                 "Customer",
                 "places",
                 "Order",
-                RelSpec::new(Cardinality::OnlyOne, Cardinality::ZeroOrMore, Identification::Identifying),
+                RelSpec::new(
+                    Cardinality::OnlyOne,
+                    Cardinality::ZeroOrMore,
+                    Identification::Identifying,
+                ),
             );
             db.add_class(&["highlight"], &["fill:#ff0"]);
             db.set_direction(Direction::LeftToRight);

--- a/src/diagrams/er/parser.rs
+++ b/src/diagrams/er/parser.rs
@@ -133,10 +133,12 @@ fn process_entity_stmt(pair: pest::iterators::Pair<Rule>, db: &mut ErDb) -> Resu
                     if a.as_rule() == Rule::alias_quoted {
                         // Strip quotes from alias
                         let raw = a.as_str();
-                        alias = Some(raw.strip_prefix('"')
-                            .and_then(|s| s.strip_suffix('"'))
-                            .unwrap_or(raw)
-                            .to_string());
+                        alias = Some(
+                            raw.strip_prefix('"')
+                                .and_then(|s| s.strip_suffix('"'))
+                                .unwrap_or(raw)
+                                .to_string(),
+                        );
                     }
                 }
             }
@@ -173,10 +175,12 @@ fn process_entity_with_attrs(pair: pest::iterators::Pair<Rule>, db: &mut ErDb) -
                     if a.as_rule() == Rule::alias_quoted {
                         // Strip quotes from alias
                         let raw = a.as_str();
-                        alias = Some(raw.strip_prefix('"')
-                            .and_then(|s| s.strip_suffix('"'))
-                            .unwrap_or(raw)
-                            .to_string());
+                        alias = Some(
+                            raw.strip_prefix('"')
+                                .and_then(|s| s.strip_suffix('"'))
+                                .unwrap_or(raw)
+                                .to_string(),
+                        );
                     }
                 }
             }
@@ -593,7 +597,9 @@ mod tests {
         let db = result.unwrap();
         let entity = db.get_entity("BOOK").unwrap();
         assert_eq!(entity.attributes.len(), 1);
-        assert!(entity.attributes[0].keys.contains(&AttributeKey::PrimaryKey));
+        assert!(entity.attributes[0]
+            .keys
+            .contains(&AttributeKey::PrimaryKey));
     }
 
     #[test]
@@ -615,7 +621,9 @@ mod tests {
 
         let db = result.unwrap();
         let entity = db.get_entity("BOOK").unwrap();
-        assert!(entity.attributes[0].keys.contains(&AttributeKey::PrimaryKey));
+        assert!(entity.attributes[0]
+            .keys
+            .contains(&AttributeKey::PrimaryKey));
         assert_eq!(entity.attributes[0].comment, "comment");
     }
 
@@ -627,8 +635,12 @@ mod tests {
 
         let db = result.unwrap();
         let entity = db.get_entity("CUSTOMER").unwrap();
-        assert!(entity.attributes[0].keys.contains(&AttributeKey::PrimaryKey));
-        assert!(entity.attributes[0].keys.contains(&AttributeKey::ForeignKey));
+        assert!(entity.attributes[0]
+            .keys
+            .contains(&AttributeKey::PrimaryKey));
+        assert!(entity.attributes[0]
+            .keys
+            .contains(&AttributeKey::ForeignKey));
     }
 
     #[test]
@@ -950,8 +962,16 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse: {:?}", result);
 
         let db = result.unwrap();
-        assert!(db.get_entity("CUSTOMER").unwrap().css_classes.contains("myClass"));
-        assert!(db.get_entity("PERSON").unwrap().css_classes.contains("myClass"));
+        assert!(db
+            .get_entity("CUSTOMER")
+            .unwrap()
+            .css_classes
+            .contains("myClass"));
+        assert!(db
+            .get_entity("PERSON")
+            .unwrap()
+            .css_classes
+            .contains("myClass"));
     }
 
     // Cypress test diagrams

--- a/src/diagrams/er/types.rs
+++ b/src/diagrams/er/types.rs
@@ -317,7 +317,13 @@ impl ErDb {
     }
 
     /// Add a relationship between entities
-    pub fn add_relationship(&mut self, entity_a: &str, role_a: &str, entity_b: &str, rel_spec: RelSpec) {
+    pub fn add_relationship(
+        &mut self,
+        entity_a: &str,
+        role_a: &str,
+        entity_b: &str,
+        rel_spec: RelSpec,
+    ) {
         // Only add relationship if both entities exist
         let entity_a_id = self.entities.get(entity_a).map(|e| e.id.clone());
         let entity_b_id = self.entities.get(entity_b).map(|e| e.id.clone());
@@ -357,9 +363,10 @@ impl ErDb {
     /// Add a style class definition
     pub fn add_class(&mut self, ids: &[&str], styles: &[&str]) {
         for id in ids {
-            let class_node = self.classes.entry(id.to_string()).or_insert_with(|| {
-                EntityClass::new(id.to_string())
-            });
+            let class_node = self
+                .classes
+                .entry(id.to_string())
+                .or_insert_with(|| EntityClass::new(id.to_string()));
 
             for style in styles {
                 // If style contains "color", also add to textStyles with "fill" -> "bgFill"

--- a/src/diagrams/flowchart/mod.rs
+++ b/src/diagrams/flowchart/mod.rs
@@ -5,8 +5,8 @@ mod types;
 
 pub use parser::parse;
 pub use types::{
-    Direction, EdgeStroke, FlowchartDb, FlowClass, FlowEdge, FlowSubGraph, FlowText, FlowTextType,
-    FlowVertex, FlowVertexType,
+    Direction, EdgeStroke, FlowClass, FlowEdge, FlowSubGraph, FlowText, FlowTextType, FlowVertex,
+    FlowVertexType, FlowchartDb,
 };
 
 #[cfg(test)]
@@ -24,7 +24,12 @@ mod tests {
             vec![
                 FlowSubGraph {
                     id: "sg1".to_string(),
-                    nodes: vec!["a".to_string(), "b".to_string(), "c".to_string(), "e".to_string()],
+                    nodes: vec![
+                        "a".to_string(),
+                        "b".to_string(),
+                        "c".to_string(),
+                        "e".to_string(),
+                    ],
                     ..Default::default()
                 },
                 FlowSubGraph {

--- a/src/diagrams/flowchart/parser.rs
+++ b/src/diagrams/flowchart/parser.rs
@@ -5,7 +5,7 @@
 use pest::Parser;
 use pest_derive::Parser;
 
-use super::types::{FlowVertexType, FlowchartDb, FlowText};
+use super::types::{FlowText, FlowVertexType, FlowchartDb};
 use crate::error::{MermaidError, Result};
 
 #[derive(Parser)]
@@ -160,7 +160,10 @@ fn process_node(pair: pest::iterators::Pair<Rule>, db: &mut FlowchartDb) -> Resu
     Ok(node_ids)
 }
 
-fn process_styled_vertex(pair: pest::iterators::Pair<Rule>, db: &mut FlowchartDb) -> Result<(String, Option<String>)> {
+fn process_styled_vertex(
+    pair: pest::iterators::Pair<Rule>,
+    db: &mut FlowchartDb,
+) -> Result<(String, Option<String>)> {
     let mut vertex_id = String::new();
     let mut class_name = None;
 
@@ -265,7 +268,9 @@ fn process_text(pair: pest::iterators::Pair<Rule>) -> Result<FlowText> {
     Ok(FlowText::new(""))
 }
 
-fn process_link(pair: pest::iterators::Pair<Rule>) -> Result<(String, Option<String>, Option<String>)> {
+fn process_link(
+    pair: pest::iterators::Pair<Rule>,
+) -> Result<(String, Option<String>, Option<String>)> {
     let mut arrow = String::new();
     let mut text = None;
     let mut link_id = None;
@@ -280,7 +285,8 @@ fn process_link(pair: pest::iterators::Pair<Rule>) -> Result<(String, Option<Str
                         }
                         Rule::link_id => {
                             let id_str = link_inner.as_str();
-                            link_id = Some(id_str[..id_str.len() - 1].to_string()); // Remove @
+                            link_id = Some(id_str[..id_str.len() - 1].to_string());
+                            // Remove @
                         }
                         _ => {}
                     }
@@ -503,7 +509,7 @@ fn process_click_stmt(pair: pest::iterators::Pair<Rule>, db: &mut FlowchartDb) -
                                         for t in a.into_inner() {
                                             if t.as_rule() == Rule::quoted_string {
                                                 let s = t.as_str();
-                                                tooltip = Some(s[1..s.len()-1].to_string());
+                                                tooltip = Some(s[1..s.len() - 1].to_string());
                                             }
                                         }
                                     }
@@ -516,7 +522,7 @@ fn process_click_stmt(pair: pest::iterators::Pair<Rule>, db: &mut FlowchartDb) -
                                 match a.as_rule() {
                                     Rule::quoted_string => {
                                         let s = a.as_str();
-                                        href = Some(s[1..s.len()-1].to_string());
+                                        href = Some(s[1..s.len() - 1].to_string());
                                     }
                                     Rule::link_target => {
                                         for t in a.into_inner() {
@@ -527,7 +533,7 @@ fn process_click_stmt(pair: pest::iterators::Pair<Rule>, db: &mut FlowchartDb) -
                                         for t in a.into_inner() {
                                             if t.as_rule() == Rule::quoted_string {
                                                 let s = t.as_str();
-                                                tooltip = Some(s[1..s.len()-1].to_string());
+                                                tooltip = Some(s[1..s.len() - 1].to_string());
                                             }
                                         }
                                     }
@@ -591,7 +597,8 @@ fn process_subgraph(pair: pest::iterators::Pair<Rule>, db: &mut FlowchartDb) -> 
     }
 
     // Find vertices that were added during subgraph processing
-    let new_vertices: Vec<String> = db.vertices()
+    let new_vertices: Vec<String> = db
+        .vertices()
         .keys()
         .filter(|k| !existing_vertices.contains(*k))
         .cloned()
@@ -660,7 +667,11 @@ mod tests {
         assert!(result.is_ok(), "Failed to parse: {:?}", result);
         let db = result.unwrap();
         let vertex = db.get_vertices().get("A").unwrap();
-        assert!(vertex.styles.len() > 0, "Vertex A should have styles: {:?}", vertex);
+        assert!(
+            vertex.styles.len() > 0,
+            "Vertex A should have styles: {:?}",
+            vertex
+        );
     }
 
     #[test]
@@ -669,7 +680,10 @@ mod tests {
         let result = parse(input);
         assert!(result.is_ok(), "Failed to parse: {:?}", result);
         let db = result.unwrap();
-        assert!(db.get_classes().contains_key("myClass"), "myClass should be defined");
+        assert!(
+            db.get_classes().contains_key("myClass"),
+            "myClass should be defined"
+        );
     }
 
     #[test]
@@ -690,7 +704,11 @@ end"#;
         let result = parse(input);
         assert!(result.is_ok(), "Failed to parse: {:?}", result);
         let db = result.unwrap();
-        assert_eq!(db.get_direction(), "TB", "Direction should be changed to TB");
+        assert_eq!(
+            db.get_direction(),
+            "TB",
+            "Direction should be changed to TB"
+        );
     }
 
     #[test]
@@ -732,7 +750,11 @@ click A myCallback"#;
     fn test_parse_graph_keyword() {
         let input = "graph TD\nA --> B";
         let result = parse(input);
-        assert!(result.is_ok(), "Failed to parse with 'graph' keyword: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "Failed to parse with 'graph' keyword: {:?}",
+            result
+        );
     }
 
     #[test]
@@ -787,7 +809,11 @@ A["Node with spaces"]"#;
     fn test_parse_semicolon_newline() {
         let input = "flowchart LR;A --> B;C --> D";
         let result = parse(input);
-        assert!(result.is_ok(), "Failed to parse semicolon-separated: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "Failed to parse semicolon-separated: {:?}",
+            result
+        );
         let db = result.unwrap();
         assert_eq!(db.get_edges().len(), 2);
     }
@@ -796,7 +822,11 @@ A["Node with spaces"]"#;
     fn test_parse_bidirectional_arrow() {
         let input = "flowchart LR\nA <--> B";
         let result = parse(input);
-        assert!(result.is_ok(), "Failed to parse bidirectional: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "Failed to parse bidirectional: {:?}",
+            result
+        );
     }
 
     #[test]
@@ -818,7 +848,11 @@ subgraph outer
     end
 end"#;
         let result = parse(input);
-        assert!(result.is_ok(), "Failed to parse nested subgraph: {:?}", result);
+        assert!(
+            result.is_ok(),
+            "Failed to parse nested subgraph: {:?}",
+            result
+        );
         let db = result.unwrap();
         assert_eq!(db.subgraphs().len(), 2);
     }
@@ -976,7 +1010,10 @@ A[Hard] -->|Text| B(Round)"#;
             assert!(result.is_ok(), "Failed to parse: {:?}", result);
             let db = result.unwrap();
             assert_eq!(db.get_acc_title(), Some("Big decisions"));
-            assert_eq!(db.get_acc_description(), Some("Flow chart of the decision making process"));
+            assert_eq!(
+                db.get_acc_description(),
+                Some("Flow chart of the decision making process")
+            );
         }
 
         #[test]
@@ -1145,14 +1182,22 @@ A[Hard] -->|Text| B(Round)"#;
         fn should_handle_double_arrow_circle() {
             let input = "graph TD;\nA o--o B;";
             let result = parse(input);
-            assert!(result.is_ok(), "Failed to parse double circle: {:?}", result);
+            assert!(
+                result.is_ok(),
+                "Failed to parse double circle: {:?}",
+                result
+            );
         }
 
         #[test]
         fn should_handle_thick_double_arrow_point() {
             let input = "graph TD;\nA <==> B;";
             let result = parse(input);
-            assert!(result.is_ok(), "Failed to parse thick double arrow: {:?}", result);
+            assert!(
+                result.is_ok(),
+                "Failed to parse thick double arrow: {:?}",
+                result
+            );
             let db = result.unwrap();
             assert_eq!(db.get_edges().len(), 1);
         }
@@ -1161,7 +1206,11 @@ A[Hard] -->|Text| B(Round)"#;
         fn should_handle_dotted_double_arrow_point() {
             let input = "graph TD;\nA <-.-> B;";
             let result = parse(input);
-            assert!(result.is_ok(), "Failed to parse dotted double arrow: {:?}", result);
+            assert!(
+                result.is_ok(),
+                "Failed to parse dotted double arrow: {:?}",
+                result
+            );
             let db = result.unwrap();
             assert_eq!(db.get_edges().len(), 1);
         }
@@ -1170,7 +1219,11 @@ A[Hard] -->|Text| B(Round)"#;
         fn should_handle_edge_with_text_normal() {
             let input = "graph TD;\nA -- text --> B;";
             let result = parse(input);
-            assert!(result.is_ok(), "Failed to parse edge with text: {:?}", result);
+            assert!(
+                result.is_ok(),
+                "Failed to parse edge with text: {:?}",
+                result
+            );
             let db = result.unwrap();
             let edges = db.get_edges();
             assert_eq!(edges.len(), 1);
@@ -1181,7 +1234,11 @@ A[Hard] -->|Text| B(Round)"#;
         fn should_handle_edge_with_text_thick() {
             let input = "graph TD;\nA == text ==> B;";
             let result = parse(input);
-            assert!(result.is_ok(), "Failed to parse thick edge with text: {:?}", result);
+            assert!(
+                result.is_ok(),
+                "Failed to parse thick edge with text: {:?}",
+                result
+            );
             let db = result.unwrap();
             let edges = db.get_edges();
             assert_eq!(edges.len(), 1);
@@ -1192,7 +1249,11 @@ A[Hard] -->|Text| B(Round)"#;
         fn should_handle_edge_with_text_dotted() {
             let input = "graph TD;\nA -. text .-> B;";
             let result = parse(input);
-            assert!(result.is_ok(), "Failed to parse dotted edge with text: {:?}", result);
+            assert!(
+                result.is_ok(),
+                "Failed to parse dotted edge with text: {:?}",
+                result
+            );
             let db = result.unwrap();
             let edges = db.get_edges();
             assert_eq!(edges.len(), 1);
@@ -1204,7 +1265,11 @@ A[Hard] -->|Text| B(Round)"#;
             // This is the mermaid.js syntax: -->|Yes|
             let input = "flowchart LR\n    B -->|Yes| C\n    B -->|No| D";
             let result = parse(input);
-            assert!(result.is_ok(), "Failed to parse pipe text edge: {:?}", result);
+            assert!(
+                result.is_ok(),
+                "Failed to parse pipe text edge: {:?}",
+                result
+            );
             let db = result.unwrap();
             let edges = db.get_edges();
             assert_eq!(edges.len(), 2, "Should have 2 edges");
@@ -1362,15 +1427,28 @@ A[Hard] -->|Text| B(Round)"#;
                 ("flowchart LR\nA([Stadium])", FlowVertexType::Stadium),
                 ("flowchart LR\nA{{Hexagon}}", FlowVertexType::Hexagon),
                 ("flowchart LR\nA[[Subroutine]]", FlowVertexType::Subroutine),
-                ("flowchart LR\nA(((DoubleCircle)))", FlowVertexType::DoubleCircle),
+                (
+                    "flowchart LR\nA(((DoubleCircle)))",
+                    FlowVertexType::DoubleCircle,
+                ),
             ];
 
             for (input, expected_type) in inputs {
                 let result = parse(input);
-                assert!(result.is_ok(), "Failed to parse shape: {:?} for input: {}", result, input);
+                assert!(
+                    result.is_ok(),
+                    "Failed to parse shape: {:?} for input: {}",
+                    result,
+                    input
+                );
                 let db = result.unwrap();
                 let vertex = db.get_vertices().get("A").unwrap();
-                assert_eq!(vertex.vertex_type, Some(expected_type), "Wrong shape type for input: {}", input);
+                assert_eq!(
+                    vertex.vertex_type,
+                    Some(expected_type),
+                    "Wrong shape type for input: {}",
+                    input
+                );
             }
         }
 
@@ -1392,7 +1470,11 @@ A[/Trapezoid\]"#;
             let input = r#"flowchart LR
 A[\InvTrapezoid/]"#;
             let result = parse(input);
-            assert!(result.is_ok(), "Failed to parse inv trapezoid: {:?}", result);
+            assert!(
+                result.is_ok(),
+                "Failed to parse inv trapezoid: {:?}",
+                result
+            );
             let db = result.unwrap();
             let vertex = db.get_vertices().get("A").unwrap();
             assert_eq!(vertex.vertex_type, Some(FlowVertexType::InvTrapezoid));
@@ -1430,10 +1512,17 @@ A[\LeanLeft\]"#;
         #[test]
         fn should_parse_link_arrow_directly() {
             // Test parsing just the link_arrow rule
-            let test_cases = ["-->", "---", "-.->", "===", "--->", "-.", "--", ".->", "<.->", ".-"];
+            let test_cases = [
+                "-->", "---", "-.->", "===", "--->", "-.", "--", ".->", "<.->", ".-",
+            ];
             for input in &test_cases {
                 let result = FlowchartParser::parse(Rule::link_arrow, input);
-                assert!(result.is_ok(), "Failed to parse link_arrow '{}': {:?}", input, result.err());
+                assert!(
+                    result.is_ok(),
+                    "Failed to parse link_arrow '{}': {:?}",
+                    input,
+                    result.err()
+                );
             }
         }
 
@@ -1443,7 +1532,12 @@ A[\LeanLeft\]"#;
             let test_cases = ["-->", "---", "-.->", "==="];
             for input in &test_cases {
                 let result = FlowchartParser::parse(Rule::simple_link, input);
-                assert!(result.is_ok(), "Failed to parse simple_link '{}': {:?}", input, result.err());
+                assert!(
+                    result.is_ok(),
+                    "Failed to parse simple_link '{}': {:?}",
+                    input,
+                    result.err()
+                );
             }
         }
 
@@ -1453,7 +1547,12 @@ A[\LeanLeft\]"#;
             let test_cases = ["-->", "---", "-.->", "==="];
             for input in &test_cases {
                 let result = FlowchartParser::parse(Rule::link, input);
-                assert!(result.is_ok(), "Failed to parse link '{}': {:?}", input, result.err());
+                assert!(
+                    result.is_ok(),
+                    "Failed to parse link '{}': {:?}",
+                    input,
+                    result.err()
+                );
             }
         }
 
@@ -1462,7 +1561,12 @@ A[\LeanLeft\]"#;
             let test_cases = ["L1 --- L2", "L2 --- C", "A --- B"];
             for input in &test_cases {
                 let result = FlowchartParser::parse(Rule::vertex_statement, input);
-                assert!(result.is_ok(), "Failed to parse vertex_statement '{}': {:?}", input, result.err());
+                assert!(
+                    result.is_ok(),
+                    "Failed to parse vertex_statement '{}': {:?}",
+                    input,
+                    result.err()
+                );
             }
         }
 
@@ -1563,14 +1667,22 @@ A[\LeanLeft\]"#;
         fn should_work_with_constructor_node_id() {
             let input = "graph LR\nconstructor --> A;";
             let result = parse(input);
-            assert!(result.is_ok(), "Should handle constructor node: {:?}", result);
+            assert!(
+                result.is_ok(),
+                "Should handle constructor node: {:?}",
+                result
+            );
         }
 
         #[test]
         fn should_work_with_proto_subgraph_id() {
             let input = "graph LR\n__proto__ --> A;\nsubgraph __proto__\n    C --> D;\nend;";
             let result = parse(input);
-            assert!(result.is_ok(), "Should handle __proto__ subgraph: {:?}", result);
+            assert!(
+                result.is_ok(),
+                "Should handle __proto__ subgraph: {:?}",
+                result
+            );
         }
     }
 }

--- a/src/diagrams/flowchart/types.rs
+++ b/src/diagrams/flowchart/types.rs
@@ -314,9 +314,13 @@ fn parse_arrow(arrow: &str) -> (String, EdgeStroke, u32) {
     };
 
     // Determine edge type based on start/end markers
-    let has_start_arrow = arrow.starts_with('<') || arrow.starts_with("x-") || arrow.starts_with("o-")
-        || arrow.starts_with("x=") || arrow.starts_with("o=")
-        || arrow.starts_with("<-") || arrow.starts_with("<=");
+    let has_start_arrow = arrow.starts_with('<')
+        || arrow.starts_with("x-")
+        || arrow.starts_with("o-")
+        || arrow.starts_with("x=")
+        || arrow.starts_with("o=")
+        || arrow.starts_with("<-")
+        || arrow.starts_with("<=");
     let has_end_arrow = arrow.ends_with('>');
     let has_end_cross = arrow.ends_with('x') && !arrow.starts_with('x');
     let has_end_circle = arrow.ends_with('o') && !arrow.starts_with('o');
@@ -397,7 +401,9 @@ impl FlowchartDb {
 
     /// Check if a node exists in any of the given subgraphs
     pub fn exists(&self, subgraphs: &[FlowSubGraph], node_id: &str) -> bool {
-        subgraphs.iter().any(|sg| sg.nodes.iter().any(|n| n == node_id))
+        subgraphs
+            .iter()
+            .any(|sg| sg.nodes.iter().any(|n| n == node_id))
     }
 
     /// Remove nodes from a subgraph that already exist in other subgraphs
@@ -454,7 +460,13 @@ impl FlowchartDb {
     }
 
     /// Add an edge between nodes
-    fn add_single_link(&mut self, start: &str, end: &str, link_data: Option<&FlowLink>, id: Option<&str>) {
+    fn add_single_link(
+        &mut self,
+        start: &str,
+        end: &str,
+        link_data: Option<&FlowLink>,
+        id: Option<&str>,
+    ) {
         let mut edge = FlowEdge::new(start, end);
         edge.interpolate.clone_from(&self.default_interpolate);
 
@@ -611,7 +623,11 @@ impl FlowchartDb {
             label_type: "text".to_string(),
             nodes,
             classes: Vec::new(),
-            dir: if dir.is_empty() { None } else { Some(dir.to_string()) },
+            dir: if dir.is_empty() {
+                None
+            } else {
+                Some(dir.to_string())
+            },
         };
 
         let idx = self.subgraphs.len();
@@ -655,13 +671,33 @@ impl FlowchartDb {
     }
 
     /// Simplified add_vertex for parser - just id, optional text and type
-    pub fn add_vertex_simple(&mut self, id: &str, text: Option<&str>, vertex_type: Option<FlowVertexType>) {
+    pub fn add_vertex_simple(
+        &mut self,
+        id: &str,
+        text: Option<&str>,
+        vertex_type: Option<FlowVertexType>,
+    ) {
         let text_obj = text.map(|t| FlowText::new(t));
-        self.add_vertex(id, text_obj, vertex_type, Vec::new(), Vec::new(), None, None);
+        self.add_vertex(
+            id,
+            text_obj,
+            vertex_type,
+            Vec::new(),
+            Vec::new(),
+            None,
+            None,
+        );
     }
 
     /// Add an edge between two nodes (simplified for parser)
-    pub fn add_edge(&mut self, start: &str, end: &str, arrow: &str, text: Option<&str>, link_id: Option<&str>) {
+    pub fn add_edge(
+        &mut self,
+        start: &str,
+        end: &str,
+        arrow: &str,
+        text: Option<&str>,
+        link_id: Option<&str>,
+    ) {
         // Ensure vertices exist
         if !self.vertices.contains_key(start) {
             self.add_vertex_simple(start, None, None);

--- a/src/diagrams/gantt/mod.rs
+++ b/src/diagrams/gantt/mod.rs
@@ -3,10 +3,8 @@
 //! This module provides parsing and data structures for Gantt chart diagrams.
 //! Gantt charts show project schedules with tasks, durations, and dependencies.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{
-    DisplayMode, Duration, DurationUnit, GanttDb, Task, TaskFlags, WeekendStart,
-};
 pub use parser::parse;
+pub use types::{DisplayMode, Duration, DurationUnit, GanttDb, Task, TaskFlags, WeekendStart};

--- a/src/diagrams/gantt/parser.rs
+++ b/src/diagrams/gantt/parser.rs
@@ -13,8 +13,8 @@ pub struct GanttParser;
 pub fn parse(input: &str) -> Result<GanttDb, String> {
     let mut db = GanttDb::new();
 
-    let pairs = GanttParser::parse(Rule::diagram, input)
-        .map_err(|e| format!("Parse error: {}", e))?;
+    let pairs =
+        GanttParser::parse(Rule::diagram, input).map_err(|e| format!("Parse error: {}", e))?;
 
     for pair in pairs {
         if pair.as_rule() == Rule::diagram {
@@ -29,20 +29,14 @@ pub fn parse(input: &str) -> Result<GanttDb, String> {
     Ok(db)
 }
 
-fn process_document(
-    db: &mut GanttDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_document(db: &mut GanttDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for stmt in pair.into_inner() {
         process_statement(db, stmt)?;
     }
     Ok(())
 }
 
-fn process_statement(
-    db: &mut GanttDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_statement(db: &mut GanttDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     match pair.as_rule() {
         Rule::statement => {
             for inner in pair.into_inner() {
@@ -149,10 +143,7 @@ fn process_statement(
     Ok(())
 }
 
-fn process_acc_descr(
-    db: &mut GanttDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_acc_descr(db: &mut GanttDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::acc_descr_single => {
@@ -175,10 +166,7 @@ fn process_acc_descr(
     Ok(())
 }
 
-fn process_click_stmt(
-    db: &mut GanttDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_click_stmt(db: &mut GanttDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut task_id = String::new();
     let mut href: Option<String> = None;
     let mut callback: Option<String> = None;
@@ -197,7 +185,7 @@ fn process_click_stmt(
                                 if href_inner.as_rule() == Rule::quoted_string {
                                     // Remove quotes
                                     let s = href_inner.as_str();
-                                    href = Some(s[1..s.len()-1].to_string());
+                                    href = Some(s[1..s.len() - 1].to_string());
                                 }
                             }
                         }
@@ -236,10 +224,7 @@ fn process_click_stmt(
     Ok(())
 }
 
-fn process_task_stmt(
-    db: &mut GanttDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_task_stmt(db: &mut GanttDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut task_name = String::new();
     let mut task_data = String::new();
 
@@ -402,7 +387,10 @@ mod tests {
             let result = parse("gantt\nsection Planning\nsection Development\nsection Testing");
             assert!(result.is_ok());
             let db = result.unwrap();
-            assert_eq!(db.get_sections(), vec!["Planning", "Development", "Testing"]);
+            assert_eq!(
+                db.get_sections(),
+                vec!["Planning", "Development", "Testing"]
+            );
         }
     }
 
@@ -411,7 +399,8 @@ mod tests {
 
         #[test]
         fn should_parse_simple_task() {
-            let result = parse("gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: 2023-01-01, 2023-01-10");
+            let result =
+                parse("gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: 2023-01-01, 2023-01-10");
             assert!(result.is_ok());
             let mut db = result.unwrap();
             let tasks = db.get_tasks();
@@ -421,7 +410,9 @@ mod tests {
 
         #[test]
         fn should_parse_task_with_id() {
-            let result = parse("gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: task1, 2023-01-01, 2023-01-10");
+            let result = parse(
+                "gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: task1, 2023-01-01, 2023-01-10",
+            );
             assert!(result.is_ok());
             let mut db = result.unwrap();
             let tasks = db.get_tasks();
@@ -431,7 +422,8 @@ mod tests {
 
         #[test]
         fn should_parse_task_with_duration() {
-            let result = parse("gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: task1, 2023-01-01, 5d");
+            let result =
+                parse("gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: task1, 2023-01-01, 5d");
             assert!(result.is_ok());
             let mut db = result.unwrap();
             let tasks = db.get_tasks();
@@ -449,7 +441,9 @@ mod tests {
 
         #[test]
         fn should_parse_critical_task() {
-            let result = parse("gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: crit, task1, 2023-01-01, 5d");
+            let result = parse(
+                "gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: crit, task1, 2023-01-01, 5d",
+            );
             assert!(result.is_ok());
             let mut db = result.unwrap();
             let tasks = db.get_tasks();
@@ -458,7 +452,9 @@ mod tests {
 
         #[test]
         fn should_parse_active_task() {
-            let result = parse("gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: active, task1, 2023-01-01, 5d");
+            let result = parse(
+                "gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: active, task1, 2023-01-01, 5d",
+            );
             assert!(result.is_ok());
             let mut db = result.unwrap();
             let tasks = db.get_tasks();
@@ -467,7 +463,9 @@ mod tests {
 
         #[test]
         fn should_parse_done_task() {
-            let result = parse("gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: done, task1, 2023-01-01, 5d");
+            let result = parse(
+                "gantt\ndateFormat YYYY-MM-DD\nsection Test\nTask 1: done, task1, 2023-01-01, 5d",
+            );
             assert!(result.is_ok());
             let mut db = result.unwrap();
             let tasks = db.get_tasks();
@@ -495,7 +493,9 @@ mod tests {
 
         #[test]
         fn should_parse_click_with_call() {
-            let result = parse("gantt\nsection Test\nTask 1: task1, 2023-01-01, 5d\nclick task1 call myFunction()");
+            let result = parse(
+                "gantt\nsection Test\nTask 1: task1, 2023-01-01, 5d\nclick task1 call myFunction()",
+            );
             assert!(result.is_ok());
         }
 

--- a/src/diagrams/gantt/types.rs
+++ b/src/diagrams/gantt/types.rs
@@ -401,7 +401,14 @@ impl GanttDb {
         let s = s.trim();
 
         // Check for multi-char units first
-        for (suffix, unit) in [("ms", "ms"), ("w", "w"), ("d", "d"), ("h", "h"), ("m", "m"), ("s", "s")] {
+        for (suffix, unit) in [
+            ("ms", "ms"),
+            ("w", "w"),
+            ("d", "d"),
+            ("h", "h"),
+            ("m", "m"),
+            ("s", "s"),
+        ] {
             if s.ends_with(suffix) {
                 let num_str = &s[..s.len() - suffix.len()];
                 if let Ok(value) = num_str.parse::<f64>() {
@@ -499,7 +506,10 @@ impl GanttDb {
                             }
                         } else {
                             // Unknown dependency - use today
-                            let today = chrono::Local::now().naive_local().date().and_hms_opt(0, 0, 0);
+                            let today = chrono::Local::now()
+                                .naive_local()
+                                .date()
+                                .and_hms_opt(0, 0, 0);
                             latest_end = Some(match latest_end {
                                 Some(current) => today.map(|t| current.max(t)).unwrap_or(current),
                                 None => today.unwrap_or_else(|| NaiveDateTime::default()),
@@ -633,10 +643,16 @@ impl GanttDb {
                 _ => {
                     // Check if it's an "after" reference
                     if part.starts_with("after ") {
-                        let deps = part[6..].split_whitespace().map(|s| s.to_string()).collect();
+                        let deps = part[6..]
+                            .split_whitespace()
+                            .map(|s| s.to_string())
+                            .collect();
                         result.after = deps;
                     } else if part.starts_with("until ") {
-                        let deps = part[6..].split_whitespace().map(|s| s.to_string()).collect();
+                        let deps = part[6..]
+                            .split_whitespace()
+                            .map(|s| s.to_string())
+                            .collect();
                         result.until = deps;
                     } else if self.looks_like_date(part) {
                         // It's a date
@@ -1098,11 +1114,20 @@ mod tests {
 
         assert_eq!(tasks[0].start_time.unwrap().and_utc().timestamp_millis(), 0);
         assert_eq!(tasks[0].end_time.unwrap().and_utc().timestamp_millis(), 20);
-        assert_eq!(tasks[1].start_time.unwrap().and_utc().timestamp_millis(), 20);
+        assert_eq!(
+            tasks[1].start_time.unwrap().and_utc().timestamp_millis(),
+            20
+        );
         assert_eq!(tasks[1].end_time.unwrap().and_utc().timestamp_millis(), 25);
-        assert_eq!(tasks[2].start_time.unwrap().and_utc().timestamp_millis(), 20);
+        assert_eq!(
+            tasks[2].start_time.unwrap().and_utc().timestamp_millis(),
+            20
+        );
         assert_eq!(tasks[2].end_time.unwrap().and_utc().timestamp_millis(), 30);
-        assert_eq!(tasks[3].start_time.unwrap().and_utc().timestamp_millis(), 30);
+        assert_eq!(
+            tasks[3].start_time.unwrap().and_utc().timestamp_millis(),
+            30
+        );
         assert_eq!(tasks[3].end_time.unwrap().and_utc().timestamp_millis(), 35);
     }
 
@@ -1142,7 +1167,10 @@ mod tests {
     fn test_today_marker_style() {
         let mut db = GanttDb::new();
         db.set_today_marker("stoke:stroke-width:5px,stroke:#00f,opacity:0.5");
-        assert_eq!(db.get_today_marker(), "stoke:stroke-width:5px,stroke:#00f,opacity:0.5");
+        assert_eq!(
+            db.get_today_marker(),
+            "stoke:stroke-width:5px,stroke:#00f,opacity:0.5"
+        );
     }
 
     // ==================

--- a/src/diagrams/git/mod.rs
+++ b/src/diagrams/git/mod.rs
@@ -3,11 +3,11 @@
 //! The git graph diagram visualizes git repository history with
 //! commits, branches, merges, and cherry-picks.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::*;
 pub use parser::parse;
+pub use types::*;
 
 #[cfg(test)]
 mod tests {
@@ -133,7 +133,12 @@ mod tests {
         #[test]
         fn should_handle_commit_with_custom_id() {
             let mut db = GitGraphDb::new();
-            db.commit(Some("1111".to_string()), String::new(), CommitType::Normal, vec![]);
+            db.commit(
+                Some("1111".to_string()),
+                String::new(),
+                CommitType::Normal,
+                vec![],
+            );
 
             let commits = db.get_commits();
             assert_eq!(commits.len(), 1);
@@ -148,7 +153,12 @@ mod tests {
         #[test]
         fn should_handle_commit_with_tag() {
             let mut db = GitGraphDb::new();
-            db.commit(None, String::new(), CommitType::Normal, vec!["test".to_string()]);
+            db.commit(
+                None,
+                String::new(),
+                CommitType::Normal,
+                vec!["test".to_string()],
+            );
 
             let commits = db.get_commits();
             assert_eq!(commits.len(), 1);

--- a/src/diagrams/git/parser.rs
+++ b/src/diagrams/git/parser.rs
@@ -13,8 +13,8 @@ pub struct GitGraphParser;
 pub fn parse(input: &str) -> Result<GitGraphDb, String> {
     let mut db = GitGraphDb::new();
 
-    let pairs = GitGraphParser::parse(Rule::diagram, input)
-        .map_err(|e| format!("Parse error: {}", e))?;
+    let pairs =
+        GitGraphParser::parse(Rule::diagram, input).map_err(|e| format!("Parse error: {}", e))?;
 
     for pair in pairs {
         if pair.as_rule() == Rule::diagram {
@@ -36,20 +36,14 @@ pub fn parse(input: &str) -> Result<GitGraphDb, String> {
     Ok(db)
 }
 
-fn process_document(
-    db: &mut GitGraphDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_document(db: &mut GitGraphDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for stmt in pair.into_inner() {
         process_statement(db, stmt)?;
     }
     Ok(())
 }
 
-fn process_statement(
-    db: &mut GitGraphDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_statement(db: &mut GitGraphDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     match pair.as_rule() {
         Rule::statement => {
             for inner in pair.into_inner() {
@@ -89,10 +83,7 @@ fn process_statement(
     Ok(())
 }
 
-fn process_acc_descr(
-    db: &mut GitGraphDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_acc_descr(db: &mut GitGraphDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::acc_descr_single => {
@@ -121,10 +112,7 @@ fn process_acc_descr(
     Ok(())
 }
 
-fn process_commit(
-    db: &mut GitGraphDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_commit(db: &mut GitGraphDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut id: Option<String> = None;
     let mut message = String::new();
     let mut commit_type = CommitType::Normal;
@@ -172,10 +160,7 @@ fn process_commit(
     Ok(())
 }
 
-fn process_branch(
-    db: &mut GitGraphDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_branch(db: &mut GitGraphDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut name = String::new();
     let mut order: Option<i32> = None;
 
@@ -203,10 +188,7 @@ fn process_branch(
     Ok(())
 }
 
-fn process_checkout(
-    db: &mut GitGraphDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_checkout(db: &mut GitGraphDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for inner in pair.into_inner() {
         if inner.as_rule() == Rule::branch_name {
             db.checkout(inner.as_str());
@@ -215,10 +197,7 @@ fn process_checkout(
     Ok(())
 }
 
-fn process_merge(
-    db: &mut GitGraphDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_merge(db: &mut GitGraphDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut branch = String::new();
     let mut id: Option<String> = None;
     let mut commit_type = CommitType::Normal;
@@ -317,7 +296,7 @@ fn process_cherry_pick(
 /// Remove surrounding quotes from a string
 fn unquote(s: &str) -> String {
     if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
-        s[1..s.len()-1].to_string()
+        s[1..s.len() - 1].to_string()
     } else {
         s.to_string()
     }
@@ -474,7 +453,9 @@ mod tests {
 
         #[test]
         fn should_handle_commit_with_all_params() {
-            let result = parse("gitGraph:\ncommit id:\"1111\" type: REVERSE tag:\"test tag\" msg:\"test msg\"\n");
+            let result = parse(
+                "gitGraph:\ncommit id:\"1111\" type: REVERSE tag:\"test tag\" msg:\"test msg\"\n",
+            );
             assert!(result.is_ok());
             let db = result.unwrap();
             let commit = db.get_commits().get("1111").unwrap();
@@ -509,7 +490,8 @@ mod tests {
 
         #[test]
         fn should_generate_branches_array() {
-            let result = parse("gitGraph:\ncommit\nbranch b1\ncheckout b1\ncommit\ncommit\nbranch b2\n");
+            let result =
+                parse("gitGraph:\ncommit\nbranch b1\ncheckout b1\ncommit\ncommit\nbranch b2\n");
             assert!(result.is_ok());
             let db = result.unwrap();
             let branches = db.get_branches();

--- a/src/diagrams/git/types.rs
+++ b/src/diagrams/git/types.rs
@@ -205,7 +205,13 @@ impl GitGraphDb {
     }
 
     /// Create a new commit
-    pub fn commit(&mut self, id: Option<String>, message: String, commit_type: CommitType, tags: Vec<String>) {
+    pub fn commit(
+        &mut self,
+        id: Option<String>,
+        message: String,
+        commit_type: CommitType,
+        tags: Vec<String>,
+    ) {
         let custom_id = id.is_some();
         let commit_id = id.unwrap_or_else(|| self.generate_commit_id());
 
@@ -224,7 +230,8 @@ impl GitGraphDb {
 
         self.seq += 1;
         self.head = Some(commit_id.clone());
-        self.branches.insert(self.current_branch.clone(), Some(commit_id.clone()));
+        self.branches
+            .insert(self.current_branch.clone(), Some(commit_id.clone()));
         self.commits.insert(commit_id, commit);
     }
 
@@ -233,7 +240,8 @@ impl GitGraphDb {
         // New branch points to the same commit as current branch
         let current_head = self.branches.get(&self.current_branch).cloned().flatten();
         self.branches.insert(name.clone(), current_head);
-        self.branch_config.insert(name.clone(), BranchConfig { name, order });
+        self.branch_config
+            .insert(name.clone(), BranchConfig { name, order });
     }
 
     /// Checkout/switch to a branch
@@ -245,7 +253,13 @@ impl GitGraphDb {
     }
 
     /// Merge a branch into the current branch
-    pub fn merge(&mut self, branch: &str, id: Option<String>, commit_type: CommitType, tags: Vec<String>) {
+    pub fn merge(
+        &mut self,
+        branch: &str,
+        id: Option<String>,
+        commit_type: CommitType,
+        tags: Vec<String>,
+    ) {
         let source_head = self.branches.get(branch).cloned().flatten();
         let current_head = self.branches.get(&self.current_branch).cloned().flatten();
 
@@ -272,12 +286,19 @@ impl GitGraphDb {
 
         self.seq += 1;
         self.head = Some(commit_id.clone());
-        self.branches.insert(self.current_branch.clone(), Some(commit_id.clone()));
+        self.branches
+            .insert(self.current_branch.clone(), Some(commit_id.clone()));
         self.commits.insert(commit_id, commit);
     }
 
     /// Cherry-pick a commit
-    pub fn cherry_pick(&mut self, source_id: &str, id: Option<String>, parent: Option<String>, tags: Vec<String>) {
+    pub fn cherry_pick(
+        &mut self,
+        source_id: &str,
+        id: Option<String>,
+        parent: Option<String>,
+        tags: Vec<String>,
+    ) {
         if !self.commits.contains_key(source_id) {
             return;
         }
@@ -285,9 +306,8 @@ impl GitGraphDb {
         let custom_id = id.is_some();
         let commit_id = id.unwrap_or_else(|| self.generate_commit_id());
 
-        let parent_id = parent.or_else(|| {
-            self.branches.get(&self.current_branch).cloned().flatten()
-        });
+        let parent_id =
+            parent.or_else(|| self.branches.get(&self.current_branch).cloned().flatten());
 
         let mut commit = Commit::new(commit_id.clone(), self.current_branch.clone(), self.seq);
         commit.commit_type = CommitType::CherryPick;
@@ -297,7 +317,8 @@ impl GitGraphDb {
 
         self.seq += 1;
         self.head = Some(commit_id.clone());
-        self.branches.insert(self.current_branch.clone(), Some(commit_id.clone()));
+        self.branches
+            .insert(self.current_branch.clone(), Some(commit_id.clone()));
         self.commits.insert(commit_id, commit);
     }
 

--- a/src/diagrams/journey/mod.rs
+++ b/src/diagrams/journey/mod.rs
@@ -4,8 +4,8 @@
 //! User journey diagrams show user experiences as a series of tasks
 //! with satisfaction scores and actors involved.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{JourneyDb, JourneyTask};
 pub use parser::parse;
+pub use types::{JourneyDb, JourneyTask};

--- a/src/diagrams/journey/parser.rs
+++ b/src/diagrams/journey/parser.rs
@@ -13,8 +13,8 @@ pub struct JourneyParser;
 pub fn parse(input: &str) -> Result<JourneyDb, String> {
     let mut db = JourneyDb::new();
 
-    let pairs = JourneyParser::parse(Rule::diagram, input)
-        .map_err(|e| format!("Parse error: {}", e))?;
+    let pairs =
+        JourneyParser::parse(Rule::diagram, input).map_err(|e| format!("Parse error: {}", e))?;
 
     for pair in pairs {
         if pair.as_rule() == Rule::diagram {
@@ -29,20 +29,14 @@ pub fn parse(input: &str) -> Result<JourneyDb, String> {
     Ok(db)
 }
 
-fn process_document(
-    db: &mut JourneyDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_document(db: &mut JourneyDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for stmt in pair.into_inner() {
         process_statement(db, stmt)?;
     }
     Ok(())
 }
 
-fn process_statement(
-    db: &mut JourneyDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_statement(db: &mut JourneyDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     match pair.as_rule() {
         Rule::statement => {
             for inner in pair.into_inner() {
@@ -84,10 +78,7 @@ fn process_statement(
     Ok(())
 }
 
-fn process_acc_descr(
-    db: &mut JourneyDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_acc_descr(db: &mut JourneyDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::acc_descr_single => {
@@ -116,10 +107,7 @@ fn process_acc_descr(
     Ok(())
 }
 
-fn process_task(
-    db: &mut JourneyDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_task(db: &mut JourneyDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut task_name = String::new();
     let mut task_data = String::new();
 
@@ -179,7 +167,10 @@ mod tests {
             let result = parse("journey\naccDescr: A user journey for family shopping\ntitle Adding journey\nsection Order from website");
             assert!(result.is_ok(), "Parse error: {:?}", result.err());
             let db = result.unwrap();
-            assert_eq!(db.get_acc_description(), "A user journey for family shopping");
+            assert_eq!(
+                db.get_acc_description(),
+                "A user journey for family shopping"
+            );
         }
 
         #[test]
@@ -196,9 +187,15 @@ section Order from website"#;
             let result = parse(input);
             assert!(result.is_ok(), "Parse error: {:?}", result.err());
             let db = result.unwrap();
-            assert_eq!(db.get_acc_description(), "A user journey for\nfamily shopping");
+            assert_eq!(
+                db.get_acc_description(),
+                "A user journey for\nfamily shopping"
+            );
             assert_eq!(db.title, "Adding journey diagram functionality to mermaid");
-            assert_eq!(db.get_acc_title(), "Adding acc journey diagram functionality to mermaid");
+            assert_eq!(
+                db.get_acc_title(),
+                "Adding acc journey diagram functionality to mermaid"
+            );
         }
 
         #[test]

--- a/src/diagrams/journey/types.rs
+++ b/src/diagrams/journey/types.rs
@@ -98,10 +98,7 @@ impl JourneyDb {
     /// Task data format: `:score:actor1, actor2, ...`
     /// Example: `:5:Dad` or `:3:Dad, Mum, Child#1`
     pub fn add_task(&mut self, task_name: &str, task_data: &str) {
-        let mut task = JourneyTask::new(
-            task_name.trim().to_string(),
-            self.current_section.clone(),
-        );
+        let mut task = JourneyTask::new(task_name.trim().to_string(), self.current_section.clone());
 
         // Parse task data format: :score:actor1, actor2
         // Or: score: actor1, actor2 (without leading colon)
@@ -222,7 +219,10 @@ mod tests {
         db.add_task("Go shopping", ":5:Mum");
 
         assert_eq!(db.get_acc_title(), "Shopping");
-        assert_eq!(db.get_acc_description(), "A user journey for family shopping");
+        assert_eq!(
+            db.get_acc_description(),
+            "A user journey for family shopping"
+        );
 
         let tasks = db.get_tasks();
         assert_eq!(tasks.len(), 4);

--- a/src/diagrams/kanban/mod.rs
+++ b/src/diagrams/kanban/mod.rs
@@ -3,8 +3,8 @@
 //! This module provides data structures for kanban board diagrams.
 //! Kanban diagrams show work items organized in columns/sections.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{KanbanData, KanbanDb, KanbanNode, NodeShape, Priority};
 pub use parser::parse;
+pub use types::{KanbanData, KanbanDb, KanbanNode, NodeShape, Priority};

--- a/src/diagrams/kanban/parser.rs
+++ b/src/diagrams/kanban/parser.rs
@@ -121,7 +121,9 @@ fn process_node(
     Ok(())
 }
 
-fn process_node_inner(pair: pest::iterators::Pair<Rule>) -> (Option<String>, Option<String>, NodeShape) {
+fn process_node_inner(
+    pair: pest::iterators::Pair<Rule>,
+) -> (Option<String>, Option<String>, NodeShape) {
     let mut id: Option<String> = None;
     let mut label: Option<String> = None;
     let mut shape = NodeShape::Default;

--- a/src/diagrams/kanban/types.rs
+++ b/src/diagrams/kanban/types.rs
@@ -125,7 +125,9 @@ impl KanbanDb {
     ///
     /// Level 0 = section, Level > 0 = item
     pub fn add_node(&mut self, level: usize, id: Option<&str>, label: &str, shape: NodeShape) {
-        let id = id.map(|s| s.to_string()).unwrap_or_else(|| label.to_string());
+        let id = id
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| label.to_string());
         let label = label.to_string();
 
         if level == 0 {

--- a/src/diagrams/mindmap/mod.rs
+++ b/src/diagrams/mindmap/mod.rs
@@ -29,11 +29,7 @@ mod tests {
         #[test]
         fn mmp_2_should_handle_hierarchical_mindmap_definition() {
             let mut db = setup();
-            parse_into(
-                "mindmap\n    root\n      child1\n      child2\n ",
-                &mut db,
-            )
-            .unwrap();
+            parse_into("mindmap\n    root\n      child1\n      child2\n ", &mut db).unwrap();
 
             let mm = db.get_mindmap().unwrap();
             assert_eq!(mm.descr, "root");
@@ -201,11 +197,7 @@ mod tests {
         #[test]
         fn mmp_14_should_set_classes_for_node() {
             let mut db = setup();
-            parse_into(
-                "mindmap\n    root[The root]\n    :::m-4 p-8\n    ",
-                &mut db,
-            )
-            .unwrap();
+            parse_into("mindmap\n    root[The root]\n    :::m-4 p-8\n    ", &mut db).unwrap();
 
             let mm = db.get_mindmap().unwrap();
             assert_eq!(mm.node_id.as_deref(), Some("root"));

--- a/src/diagrams/mindmap/parser.rs
+++ b/src/diagrams/mindmap/parser.rs
@@ -86,7 +86,8 @@ pub fn parse_into(input: &str, db: &mut MindmapDb) -> Result<()> {
         // Check for icon decoration
         if let Some(caps) = ICON_RE.captures(content) {
             let icon = caps.get(1).unwrap().as_str();
-            if let Some(target_idx) = pending_decorations.or_else(|| stack.last().map(|_| stack.len() - 1))
+            if let Some(target_idx) =
+                pending_decorations.or_else(|| stack.last().map(|_| stack.len() - 1))
             {
                 if let Some((_, node)) = stack.get_mut(target_idx) {
                     node.set_icon(icon);
@@ -99,7 +100,8 @@ pub fn parse_into(input: &str, db: &mut MindmapDb) -> Result<()> {
         // Check for class decoration
         if let Some(caps) = CLASS_RE.captures(content) {
             let class = caps.get(1).unwrap().as_str();
-            if let Some(target_idx) = pending_decorations.or_else(|| stack.last().map(|_| stack.len() - 1))
+            if let Some(target_idx) =
+                pending_decorations.or_else(|| stack.last().map(|_| stack.len() - 1))
             {
                 if let Some((_, node)) = stack.get_mut(target_idx) {
                     node.set_class(class);

--- a/src/diagrams/packet/mod.rs
+++ b/src/diagrams/packet/mod.rs
@@ -3,8 +3,8 @@
 //! This module provides data structures for packet diagrams.
 //! Packet diagrams show bit-level packet/protocol structure with labeled fields.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{PacketBlock, PacketDb, PacketError, PacketWord};
 pub use parser::parse;
+pub use types::{PacketBlock, PacketDb, PacketError, PacketWord};

--- a/src/diagrams/packet/types.rs
+++ b/src/diagrams/packet/types.rs
@@ -22,7 +22,11 @@ pub type PacketWord = Vec<PacketBlock>;
 #[derive(Debug, Clone, PartialEq)]
 pub enum PacketError {
     /// Block is not contiguous with previous block
-    NotContiguous { start: usize, end: usize, expected: usize },
+    NotContiguous {
+        start: usize,
+        end: usize,
+        expected: usize,
+    },
     /// End bit is less than start bit
     InvalidRange { start: usize, end: usize },
     /// Bit count is zero
@@ -32,7 +36,11 @@ pub enum PacketError {
 impl std::fmt::Display for PacketError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PacketError::NotContiguous { start, end, expected } => {
+            PacketError::NotContiguous {
+                start,
+                end,
+                expected,
+            } => {
                 write!(
                     f,
                     "Packet block {} - {} is not contiguous. It should start from {}.",
@@ -313,19 +321,19 @@ mod tests {
 
         assert_eq!(packet[0][1].start, 11);
         assert_eq!(packet[0][1].end, 31);
-        assert_eq!(packet[0][1].bits, 21);  // 31-11+1 = 21 bits
+        assert_eq!(packet[0][1].bits, 21); // 31-11+1 = 21 bits
         assert_eq!(packet[0][1].label, "multiple");
 
         // Second row
         assert_eq!(packet[1][0].start, 32);
         assert_eq!(packet[1][0].end, 63);
-        assert_eq!(packet[1][0].bits, 32);  // 63-32+1 = 32 bits (full row)
+        assert_eq!(packet[1][0].bits, 32); // 63-32+1 = 32 bits (full row)
         assert_eq!(packet[1][0].label, "multiple");
 
         // Third row
         assert_eq!(packet[2][0].start, 64);
         assert_eq!(packet[2][0].end, 90);
-        assert_eq!(packet[2][0].bits, 27);  // 90-64+1 = 27 bits
+        assert_eq!(packet[2][0].bits, 27); // 90-64+1 = 27 bits
         assert_eq!(packet[2][0].label, "multiple");
     }
 
@@ -345,13 +353,13 @@ mod tests {
 
         assert_eq!(packet[0][1].start, 17);
         assert_eq!(packet[0][1].end, 31);
-        assert_eq!(packet[0][1].bits, 15);  // 31-17+1 = 15 bits
+        assert_eq!(packet[0][1].bits, 15); // 31-17+1 = 15 bits
         assert_eq!(packet[0][1].label, "multiple");
 
         // Second row (exactly fills the row)
         assert_eq!(packet[1][0].start, 32);
         assert_eq!(packet[1][0].end, 63);
-        assert_eq!(packet[1][0].bits, 32);  // 63-32+1 = 32 bits (full row)
+        assert_eq!(packet[1][0].bits, 32); // 63-32+1 = 32 bits (full row)
         assert_eq!(packet[1][0].label, "multiple");
     }
 
@@ -362,7 +370,12 @@ mod tests {
         let result = db.add_block(18, 20, "error");
 
         assert!(result.is_err());
-        if let Err(PacketError::NotContiguous { start, end, expected }) = result {
+        if let Err(PacketError::NotContiguous {
+            start,
+            end,
+            expected,
+        }) = result
+        {
             assert_eq!(start, 18);
             assert_eq!(end, 20);
             assert_eq!(expected, 17);
@@ -378,7 +391,12 @@ mod tests {
         let result = db.add_block(18, 20, "error");
 
         assert!(result.is_err());
-        if let Err(PacketError::NotContiguous { start, end, expected }) = result {
+        if let Err(PacketError::NotContiguous {
+            start,
+            end,
+            expected,
+        }) = result
+        {
             assert_eq!(start, 18);
             assert_eq!(end, 20);
             assert_eq!(expected, 16);
@@ -394,7 +412,12 @@ mod tests {
         let result = db.add_single_bit(18, "error");
 
         assert!(result.is_err());
-        if let Err(PacketError::NotContiguous { start, end, expected }) = result {
+        if let Err(PacketError::NotContiguous {
+            start,
+            end,
+            expected,
+        }) = result
+        {
             assert_eq!(start, 18);
             assert_eq!(end, 18);
             assert_eq!(expected, 17);
@@ -444,7 +467,11 @@ mod tests {
 
     #[test]
     fn test_error_display() {
-        let err = PacketError::NotContiguous { start: 18, end: 20, expected: 17 };
+        let err = PacketError::NotContiguous {
+            start: 18,
+            end: 20,
+            expected: 17,
+        };
         assert_eq!(
             err.to_string(),
             "Packet block 18 - 20 is not contiguous. It should start from 17."

--- a/src/diagrams/pie/parser.rs
+++ b/src/diagrams/pie/parser.rs
@@ -7,29 +7,22 @@ use super::types::PieDb;
 use crate::error::{MermaidError, Result};
 
 // Regex patterns for pie chart parsing
-static PIE_HEADER_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^\s*pie\s*(showData)?(?:\s+title\s+(.+))?$").unwrap()
-});
+static PIE_HEADER_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*pie\s*(showData)?(?:\s+title\s+(.+))?$").unwrap());
 
-static SECTION_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"^\s*"([^"]+)"\s*:\s*(-?\d+(?:\.\d+)?)\s*$"#).unwrap()
-});
+static SECTION_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"^\s*"([^"]+)"\s*:\s*(-?\d+(?:\.\d+)?)\s*$"#).unwrap());
 
-static ACC_TITLE_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^\s*accTitle\s*:\s*(.+)$").unwrap()
-});
+static ACC_TITLE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*accTitle\s*:\s*(.+)$").unwrap());
 
-static ACC_DESCR_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^\s*accDescr\s*:\s*(.+)$").unwrap()
-});
+static ACC_DESCR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*accDescr\s*:\s*(.+)$").unwrap());
 
-static ACC_DESCR_MULTILINE_START_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^\s*accDescr\s*\{").unwrap()
-});
+static ACC_DESCR_MULTILINE_START_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\s*accDescr\s*\{").unwrap());
 
-static COMMENT_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^\s*%%").unwrap()
-});
+static COMMENT_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\s*%%").unwrap());
 
 /// Parse a pie chart diagram
 pub fn parse(input: &str) -> Result<PieDb> {

--- a/src/diagrams/pie/types.rs
+++ b/src/diagrams/pie/types.rs
@@ -53,7 +53,11 @@ impl PieDb {
     }
 
     /// Add a section to the pie chart
-    pub fn add_section(&mut self, label: impl Into<String>, value: f64) -> Result<(), crate::error::MermaidError> {
+    pub fn add_section(
+        &mut self,
+        label: impl Into<String>,
+        value: f64,
+    ) -> Result<(), crate::error::MermaidError> {
         let label = label.into();
         if value < 0.0 {
             return Err(crate::error::MermaidError::InvalidValue {
@@ -79,7 +83,8 @@ impl PieDb {
 
     /// Get a section value by label
     pub fn get_section(&self, label: &str) -> Option<f64> {
-        self.sections.iter()
+        self.sections
+            .iter()
             .find(|(l, _)| l == label)
             .map(|(_, v)| *v)
     }

--- a/src/diagrams/quadrant/mod.rs
+++ b/src/diagrams/quadrant/mod.rs
@@ -4,8 +4,8 @@
 //! Quadrant charts divide data into four quadrants based on two axes,
 //! commonly used for prioritization matrices.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{ClassDef, PointStyle, QuadrantDb, QuadrantPoint};
 pub use parser::parse;
+pub use types::{ClassDef, PointStyle, QuadrantDb, QuadrantPoint};

--- a/src/diagrams/quadrant/parser.rs
+++ b/src/diagrams/quadrant/parser.rs
@@ -13,8 +13,8 @@ pub struct QuadrantParser;
 pub fn parse(input: &str) -> Result<QuadrantDb, String> {
     let mut db = QuadrantDb::new();
 
-    let pairs = QuadrantParser::parse(Rule::diagram, input)
-        .map_err(|e| format!("Parse error: {}", e))?;
+    let pairs =
+        QuadrantParser::parse(Rule::diagram, input).map_err(|e| format!("Parse error: {}", e))?;
 
     for pair in pairs {
         if pair.as_rule() == Rule::diagram {
@@ -29,20 +29,14 @@ pub fn parse(input: &str) -> Result<QuadrantDb, String> {
     Ok(db)
 }
 
-fn process_document(
-    db: &mut QuadrantDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_document(db: &mut QuadrantDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for stmt in pair.into_inner() {
         process_statement(db, stmt)?;
     }
     Ok(())
 }
 
-fn process_statement(
-    db: &mut QuadrantDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_statement(db: &mut QuadrantDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     match pair.as_rule() {
         Rule::statement => {
             for inner in pair.into_inner() {
@@ -108,10 +102,7 @@ fn process_statement(
     Ok(())
 }
 
-fn process_x_axis(
-    db: &mut QuadrantDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_x_axis(db: &mut QuadrantDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut texts: Vec<String> = Vec::new();
     let mut has_arrow = false;
 
@@ -137,10 +128,7 @@ fn process_x_axis(
     Ok(())
 }
 
-fn process_y_axis(
-    db: &mut QuadrantDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_y_axis(db: &mut QuadrantDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut texts: Vec<String> = Vec::new();
     let mut has_arrow = false;
 
@@ -196,10 +184,7 @@ fn extract_label_text(pair: pest::iterators::Pair<Rule>) -> String {
     String::new()
 }
 
-fn process_class_def(
-    db: &mut QuadrantDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_class_def(db: &mut QuadrantDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut class_name = String::new();
     let mut styles: Vec<String> = Vec::new();
 
@@ -222,10 +207,7 @@ fn process_class_def(
     Ok(())
 }
 
-fn process_point(
-    db: &mut QuadrantDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_point(db: &mut QuadrantDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut point_name = String::new();
     let mut class_name = String::new();
     let mut x = String::new();
@@ -292,7 +274,7 @@ fn extract_point_name(pair: pest::iterators::Pair<Rule>) -> String {
 /// Remove surrounding quotes from a string
 fn unquote(s: &str) -> String {
     if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
-        s[1..s.len()-1].to_string()
+        s[1..s.len() - 1].to_string()
     } else {
         s.to_string()
     }

--- a/src/diagrams/quadrant/types.rs
+++ b/src/diagrams/quadrant/types.rs
@@ -398,7 +398,13 @@ mod tests {
     #[test]
     fn test_add_point_with_class() {
         let mut db = QuadrantDb::new();
-        db.add_point("Salesforce", "class1", "0.55", "0.60", &["radius: 10", "color: #ff0000"]);
+        db.add_point(
+            "Salesforce",
+            "class1",
+            "0.55",
+            "0.60",
+            &["radius: 10", "color: #ff0000"],
+        );
 
         let points = db.get_points();
         assert_eq!(points.len(), 1);
@@ -453,7 +459,12 @@ mod tests {
             "",
             "0.75",
             "0.75",
-            &["stroke-color: #ff00ff", "stroke-width: 10px", "color: #ff0000", "radius: 10"],
+            &[
+                "stroke-color: #ff00ff",
+                "stroke-width: 10px",
+                "color: #ff0000",
+                "radius: 10",
+            ],
         );
         db.add_point(
             "Salesforce",

--- a/src/diagrams/radar/mod.rs
+++ b/src/diagrams/radar/mod.rs
@@ -3,8 +3,8 @@
 //! This module provides data structures for radar (spider/web) diagrams.
 //! Radar diagrams show multivariate data plotted on axes radiating from a center point.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{Graticule, RadarAxis, RadarCurve, RadarDb, RadarEntry, RadarOptions};
 pub use parser::parse;
+pub use types::{Graticule, RadarAxis, RadarCurve, RadarDb, RadarEntry, RadarOptions};

--- a/src/diagrams/requirement/mod.rs
+++ b/src/diagrams/requirement/mod.rs
@@ -3,11 +3,11 @@
 //! This module provides data structures for requirement diagrams.
 //! Requirement diagrams show requirements, elements, and their relationships.
 
-mod types;
 pub mod parser;
+mod types;
 
+pub use parser::parse;
 pub use types::{
     Element, Relation, RelationshipType, Requirement, RequirementClass, RequirementDb,
     RequirementType, RiskLevel, VerifyType,
 };
-pub use parser::parse;

--- a/src/diagrams/requirement/parser.rs
+++ b/src/diagrams/requirement/parser.rs
@@ -277,10 +277,7 @@ fn process_relationship(
     Ok(())
 }
 
-fn process_style(
-    db: &mut RequirementDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_style(db: &mut RequirementDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut ids: Vec<String> = Vec::new();
     let mut styles: Vec<String> = Vec::new();
 
@@ -291,7 +288,9 @@ fn process_style(
             }
             Rule::style_list => {
                 // Split styles by comma
-                styles = inner.as_str().trim()
+                styles = inner
+                    .as_str()
+                    .trim()
                     .split(',')
                     .map(|s| s.trim().to_string())
                     .collect();
@@ -320,7 +319,9 @@ fn process_class_def(
             }
             Rule::style_list => {
                 // Split styles by comma
-                styles = inner.as_str().trim()
+                styles = inner
+                    .as_str()
+                    .trim()
                     .split(',')
                     .map(|s| s.trim().to_string())
                     .collect();
@@ -428,7 +429,7 @@ fn extract_id_list(pair: pest::iterators::Pair<Rule>) -> Vec<String> {
 /// Remove surrounding quotes from a string
 fn unquote(s: &str) -> String {
     if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
-        s[1..s.len()-1].to_string()
+        s[1..s.len() - 1].to_string()
     } else {
         s.to_string()
     }
@@ -494,7 +495,10 @@ id: test_id
             let db = result.unwrap();
 
             let req = db.get_requirements().get("test_req").unwrap();
-            assert_eq!(req.req_type, crate::diagrams::requirement::RequirementType::FunctionalRequirement);
+            assert_eq!(
+                req.req_type,
+                crate::diagrams::requirement::RequirementType::FunctionalRequirement
+            );
         }
 
         #[test]
@@ -728,7 +732,10 @@ style test_req fill:#f9f,stroke:#333,stroke-width:4px
             let db = result.unwrap();
 
             let req = db.get_requirements().get("test_req").unwrap();
-            assert_eq!(req.css_styles, vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]);
+            assert_eq!(
+                req.css_styles,
+                vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]
+            );
         }
 
         #[test]
@@ -744,7 +751,10 @@ style test_element fill:#f9f,stroke:#333,stroke-width:4px
             let db = result.unwrap();
 
             let elem = db.get_elements().get("test_element").unwrap();
-            assert_eq!(elem.css_styles, vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]);
+            assert_eq!(
+                elem.css_styles,
+                vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]
+            );
         }
 
         #[test]
@@ -762,10 +772,16 @@ style test_requirement,test_element fill:#f9f,stroke:#333,stroke-width:4px
             let db = result.unwrap();
 
             let req = db.get_requirements().get("test_requirement").unwrap();
-            assert_eq!(req.css_styles, vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]);
+            assert_eq!(
+                req.css_styles,
+                vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]
+            );
 
             let elem = db.get_elements().get("test_element").unwrap();
-            assert_eq!(elem.css_styles, vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]);
+            assert_eq!(
+                elem.css_styles,
+                vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]
+            );
         }
     }
 
@@ -783,7 +799,10 @@ classDef myClass fill:#f9f,stroke:#333,stroke-width:4px
             let db = result.unwrap();
 
             let class = db.get_classes().get("myClass").unwrap();
-            assert_eq!(class.styles, vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]);
+            assert_eq!(
+                class.styles,
+                vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]
+            );
         }
 
         #[test]
@@ -797,10 +816,16 @@ classDef firstClass,secondClass fill:#f9f,stroke:#333,stroke-width:4px
             let db = result.unwrap();
 
             let first = db.get_classes().get("firstClass").unwrap();
-            assert_eq!(first.styles, vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]);
+            assert_eq!(
+                first.styles,
+                vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]
+            );
 
             let second = db.get_classes().get("secondClass").unwrap();
-            assert_eq!(second.styles, vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]);
+            assert_eq!(
+                second.styles,
+                vec!["fill:#f9f", "stroke:#333", "stroke-width:4px"]
+            );
         }
 
         #[test]

--- a/src/diagrams/requirement/types.rs
+++ b/src/diagrams/requirement/types.rs
@@ -388,7 +388,10 @@ mod tests {
         let element = db.get_elements().get("element").unwrap();
 
         assert_eq!(requirement.css_styles, vec!["color:red"]);
-        assert_eq!(element.css_styles, vec!["stroke-width:4px", "stroke: yellow"]);
+        assert_eq!(
+            element.css_styles,
+            vec!["stroke-width:4px", "stroke: yellow"]
+        );
     }
 
     #[test]
@@ -419,7 +422,10 @@ mod tests {
         let element = db.get_elements().get("element").unwrap();
 
         assert_eq!(requirement.css_styles, vec!["color:red"]);
-        assert_eq!(element.css_styles, vec!["stroke-width:4px", "stroke: yellow"]);
+        assert_eq!(
+            element.css_styles,
+            vec!["stroke-width:4px", "stroke: yellow"]
+        );
     }
 
     #[test]

--- a/src/diagrams/sankey/mod.rs
+++ b/src/diagrams/sankey/mod.rs
@@ -3,8 +3,8 @@
 //! This module provides data structures for Sankey diagrams.
 //! Sankey diagrams show flow/movement between nodes with weighted connections.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{GraphLink, GraphNode, SankeyDb, SankeyGraph, SankeyLink, SankeyNode};
 pub use parser::parse;
+pub use types::{GraphLink, GraphNode, SankeyDb, SankeyGraph, SankeyLink, SankeyNode};

--- a/src/diagrams/sankey/parser.rs
+++ b/src/diagrams/sankey/parser.rs
@@ -193,7 +193,9 @@ District heating,"Heating and cooling, homes",46.184
         let nodes = result.get_nodes();
 
         // Find the nodes with commas
-        let has_commercial = nodes.iter().any(|n| n.id == "Heating and cooling, commercial");
+        let has_commercial = nodes
+            .iter()
+            .any(|n| n.id == "Heating and cooling, commercial");
         let has_homes = nodes.iter().any(|n| n.id == "Heating and cooling, homes");
         assert!(has_commercial);
         assert!(has_homes);

--- a/src/diagrams/sankey/types.rs
+++ b/src/diagrams/sankey/types.rs
@@ -94,7 +94,11 @@ impl SankeyDb {
     /// Get the graph structure for rendering
     pub fn get_graph(&self) -> SankeyGraph {
         SankeyGraph {
-            nodes: self.nodes.iter().map(|n| GraphNode { id: n.id.clone() }).collect(),
+            nodes: self
+                .nodes
+                .iter()
+                .map(|n| GraphNode { id: n.id.clone() })
+                .collect(),
             links: self
                 .links
                 .iter()

--- a/src/diagrams/sequence/mod.rs
+++ b/src/diagrams/sequence/mod.rs
@@ -3,11 +3,11 @@
 //! Sequence diagrams show interactions between actors/participants
 //! with messages, notes, and control structures (loops, alternatives, etc.)
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::*;
 pub use parser::parse;
+pub use types::*;
 
 #[cfg(test)]
 mod tests {
@@ -199,13 +199,28 @@ mod tests {
 
         #[test]
         fn should_parse_participant_types() {
-            assert_eq!(ParticipantType::from_str("participant"), ParticipantType::Participant);
+            assert_eq!(
+                ParticipantType::from_str("participant"),
+                ParticipantType::Participant
+            );
             assert_eq!(ParticipantType::from_str("actor"), ParticipantType::Actor);
-            assert_eq!(ParticipantType::from_str("boundary"), ParticipantType::Boundary);
-            assert_eq!(ParticipantType::from_str("control"), ParticipantType::Control);
+            assert_eq!(
+                ParticipantType::from_str("boundary"),
+                ParticipantType::Boundary
+            );
+            assert_eq!(
+                ParticipantType::from_str("control"),
+                ParticipantType::Control
+            );
             assert_eq!(ParticipantType::from_str("entity"), ParticipantType::Entity);
-            assert_eq!(ParticipantType::from_str("database"), ParticipantType::Database);
-            assert_eq!(ParticipantType::from_str("collections"), ParticipantType::Collections);
+            assert_eq!(
+                ParticipantType::from_str("database"),
+                ParticipantType::Database
+            );
+            assert_eq!(
+                ParticipantType::from_str("collections"),
+                ParticipantType::Collections
+            );
             assert_eq!(ParticipantType::from_str("queue"), ParticipantType::Queue);
         }
 

--- a/src/diagrams/sequence/parser.rs
+++ b/src/diagrams/sequence/parser.rs
@@ -27,8 +27,8 @@ pub fn parse(input: &str) -> Result<SequenceDb, String> {
     let mut db = SequenceDb::new();
     let mut block_stack: Vec<BlockType> = Vec::new();
 
-    let pairs = SequenceParser::parse(Rule::diagram, input)
-        .map_err(|e| format!("Parse error: {}", e))?;
+    let pairs =
+        SequenceParser::parse(Rule::diagram, input).map_err(|e| format!("Parse error: {}", e))?;
 
     for pair in pairs {
         if pair.as_rule() == Rule::diagram {
@@ -369,10 +369,7 @@ fn process_create_stmt(
     Ok(())
 }
 
-fn process_note_stmt(
-    db: &mut SequenceDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_note_stmt(db: &mut SequenceDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut placement = Placement::RightOf;
     let mut actors: Vec<String> = Vec::new();
     let mut text = String::new();
@@ -619,7 +616,11 @@ mod tests {
         fn should_handle_numeric_participant_name() {
             // Test numeric participant name
             let result = parse("sequenceDiagram\nparticipant 1");
-            assert!(result.is_ok(), "Failed to parse numeric participant: {:?}", result.err());
+            assert!(
+                result.is_ok(),
+                "Failed to parse numeric participant: {:?}",
+                result.err()
+            );
         }
 
         #[test]
@@ -774,8 +775,10 @@ User->>AuthService: Login"#,
         #[test]
         fn should_handle_half_arrow_solid_top() {
             // Half arrow: -|\ (solid half arrow top)
-            let result = parse(r"sequenceDiagram
-Alice-|\Bob:Hello");
+            let result = parse(
+                r"sequenceDiagram
+Alice-|\Bob:Hello",
+            );
             assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
         }
 
@@ -789,32 +792,40 @@ Alice-|\Bob:Hello");
         #[test]
         fn should_handle_half_arrow_stick_top() {
             // Half arrow: -\\ (stick half arrow top - double backslash)
-            let result = parse(r"sequenceDiagram
-Alice-\\Bob:Hello");
+            let result = parse(
+                r"sequenceDiagram
+Alice-\\Bob:Hello",
+            );
             assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
         }
 
         #[test]
         fn should_handle_half_arrow_with_spaces() {
             // Half arrow with spaces around it - like in mermaid tests
-            let result = parse(r"sequenceDiagram
-      Alice -|\  John: Hello John, how are you?");
+            let result = parse(
+                r"sequenceDiagram
+      Alice -|\  John: Hello John, how are you?",
+            );
             assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
         }
 
         #[test]
         fn should_handle_half_arrow_reverse() {
             // Half arrow reverse: \|- (solid half arrow bottom reverse)
-            let result = parse(r"sequenceDiagram
-Alice\|-Bob:Hello");
+            let result = parse(
+                r"sequenceDiagram
+Alice\|-Bob:Hello",
+            );
             assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
         }
 
         #[test]
         fn should_handle_half_arrow_reverse_with_spaces() {
             // Half arrow reverse with spaces
-            let result = parse(r"sequenceDiagram
-        Alice \|- John: Hello");
+            let result = parse(
+                r"sequenceDiagram
+        Alice \|- John: Hello",
+            );
             assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
         }
     }

--- a/src/diagrams/sequence/types.rs
+++ b/src/diagrams/sequence/types.rs
@@ -216,7 +216,13 @@ pub struct Message {
 }
 
 impl Message {
-    pub fn new(id: String, from: Option<String>, to: Option<String>, message: String, message_type: LineType) -> Self {
+    pub fn new(
+        id: String,
+        from: Option<String>,
+        to: Option<String>,
+        message: String,
+        message_type: LineType,
+    ) -> Self {
         Self {
             id,
             from,
@@ -331,7 +337,12 @@ impl SequenceDb {
     }
 
     /// Add an actor to the diagram
-    pub fn add_actor(&mut self, name: &str, description: Option<&str>, actor_type: ParticipantType) {
+    pub fn add_actor(
+        &mut self,
+        name: &str,
+        description: Option<&str>,
+        actor_type: ParticipantType,
+    ) {
         if self.actors.contains_key(name) {
             return;
         }
@@ -467,15 +478,22 @@ impl SequenceDb {
     }
 
     /// Create an actor (tracks when created)
-    pub fn create_actor(&mut self, name: &str, description: Option<&str>, actor_type: ParticipantType) {
+    pub fn create_actor(
+        &mut self,
+        name: &str,
+        description: Option<&str>,
+        actor_type: ParticipantType,
+    ) {
         self.add_actor(name, description, actor_type);
-        self.created_actors.insert(name.to_string(), self.messages.len());
+        self.created_actors
+            .insert(name.to_string(), self.messages.len());
     }
 
     /// Destroy an actor
     pub fn destroy_actor(&mut self, name: &str) {
         if self.actors.contains_key(name) {
-            self.destroyed_actors.insert(name.to_string(), self.messages.len());
+            self.destroyed_actors
+                .insert(name.to_string(), self.messages.len());
         }
     }
 

--- a/src/diagrams/state/mod.rs
+++ b/src/diagrams/state/mod.rs
@@ -3,11 +3,11 @@
 //! State diagrams model finite state machines with states, transitions,
 //! notes, and nested composite states.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::*;
 pub use parser::parse;
+pub use types::*;
 
 #[cfg(test)]
 mod tests {
@@ -64,7 +64,10 @@ mod tests {
                 state.state_type = StateType::Choice;
             }
 
-            assert_eq!(db.get_state("state1").unwrap().state_type, StateType::Choice);
+            assert_eq!(
+                db.get_state("state1").unwrap().state_type,
+                StateType::Choice
+            );
         }
     }
 
@@ -138,7 +141,10 @@ mod tests {
             db.add_relation("state1", "state2", Some("transition label"));
 
             let relations = db.get_relations();
-            assert_eq!(relations[0].description, Some("transition label".to_string()));
+            assert_eq!(
+                relations[0].description,
+                Some("transition label".to_string())
+            );
         }
 
         #[test]

--- a/src/diagrams/state/parser.rs
+++ b/src/diagrams/state/parser.rs
@@ -13,8 +13,8 @@ pub struct StateParser;
 pub fn parse(input: &str) -> Result<StateDb, String> {
     let mut db = StateDb::new();
 
-    let pairs = StateParser::parse(Rule::diagram, input)
-        .map_err(|e| format!("Parse error: {}", e))?;
+    let pairs =
+        StateParser::parse(Rule::diagram, input).map_err(|e| format!("Parse error: {}", e))?;
 
     for pair in pairs {
         if pair.as_rule() == Rule::diagram {
@@ -110,10 +110,7 @@ fn process_statement(
     Ok(())
 }
 
-fn process_acc_descr(
-    db: &mut StateDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_acc_descr(db: &mut StateDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::acc_descr_single => {
@@ -143,10 +140,7 @@ fn process_acc_descr(
     Ok(())
 }
 
-fn process_class_def(
-    db: &mut StateDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_class_def(db: &mut StateDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut class_name = String::new();
     let mut styles = String::new();
 
@@ -229,7 +223,7 @@ fn process_state_def(
                         }
                         Rule::quoted_string => {
                             let s = body_inner.as_str();
-                            state_id = s[1..s.len()-1].to_string(); // Remove quotes
+                            state_id = s[1..s.len() - 1].to_string(); // Remove quotes
                             db.add_state(&state_id);
                             if let Some(p) = parent {
                                 db.set_parent(&state_id, p);
@@ -280,7 +274,7 @@ fn process_state_def(
                         }
                         Rule::quoted_string => {
                             let s = alias_inner.as_str();
-                            alias = s[1..s.len()-1].to_string();
+                            alias = s[1..s.len() - 1].to_string();
                         }
                         _ => {}
                     }
@@ -328,10 +322,7 @@ fn process_state_def(
     Ok(())
 }
 
-fn process_note(
-    db: &mut StateDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_note(db: &mut StateDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut placement = NotePosition::RightOf;
     let mut state_id = String::new();
     let mut note_text = String::new();
@@ -382,10 +373,7 @@ fn process_note(
     Ok(())
 }
 
-fn process_transition(
-    db: &mut StateDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_transition(db: &mut StateDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut from = String::new();
     let mut to = String::new();
     let mut label: Option<String> = None;
@@ -493,28 +481,30 @@ mod tests {
         #[test]
         fn should_parse_transition_stmt_directly() {
             // Test parsing just the transition_stmt rule
-            let test_cases = [
-                "State1 --> State2",
-                "[*] --> State1",
-                "State1 --> [*]",
-            ];
+            let test_cases = ["State1 --> State2", "[*] --> State1", "State1 --> [*]"];
             for input in &test_cases {
                 let result = StateParser::parse(Rule::transition_stmt, input);
-                assert!(result.is_ok(), "Failed to parse transition_stmt '{}': {:?}", input, result.err());
+                assert!(
+                    result.is_ok(),
+                    "Failed to parse transition_stmt '{}': {:?}",
+                    input,
+                    result.err()
+                );
             }
         }
 
         #[test]
         fn should_parse_statement_as_transition() {
             // Test parsing statement rule - should match transition_stmt
-            let test_cases = [
-                "State1 --> State2",
-                "[*] --> State1",
-                "State1 --> [*]",
-            ];
+            let test_cases = ["State1 --> State2", "[*] --> State1", "State1 --> [*]"];
             for input in &test_cases {
                 let result = StateParser::parse(Rule::statement, input);
-                assert!(result.is_ok(), "Failed to parse statement '{}': {:?}", input, result.err());
+                assert!(
+                    result.is_ok(),
+                    "Failed to parse statement '{}': {:?}",
+                    input,
+                    result.err()
+                );
                 // Verify it was parsed as transition_stmt
                 let pairs = result.unwrap();
                 let first = pairs.into_iter().next().unwrap();
@@ -589,7 +579,8 @@ mod tests {
 
         #[test]
         fn should_parse_multiline_acc_descr() {
-            let result = parse("stateDiagram\naccDescr {\na simple description\nusing multiple lines\n}");
+            let result =
+                parse("stateDiagram\naccDescr {\na simple description\nusing multiple lines\n}");
             assert!(result.is_ok());
             let db = result.unwrap();
             assert!(db.acc_descr.contains("a simple description"));
@@ -642,7 +633,8 @@ mod tests {
 
         #[test]
         fn should_parse_composite_state() {
-            let result = parse("stateDiagram\nstate CompositeState {\n[*] --> First\nFirst --> [*]\n}");
+            let result =
+                parse("stateDiagram\nstate CompositeState {\n[*] --> First\nFirst --> [*]\n}");
             assert!(result.is_ok());
             let db = result.unwrap();
             assert!(db.get_states().contains_key("CompositeState"));
@@ -663,7 +655,8 @@ mod tests {
 
         #[test]
         fn should_apply_class_to_state() {
-            let result = parse("stateDiagram\nclassDef myClass fill:#f00\nState1\nclass State1 myClass");
+            let result =
+                parse("stateDiagram\nclassDef myClass fill:#f00\nState1\nclass State1 myClass");
             assert!(result.is_ok(), "Parse error: {:?}", result.err());
             let db = result.unwrap();
             let state = db.get_state("State1").unwrap();

--- a/src/diagrams/timeline/mod.rs
+++ b/src/diagrams/timeline/mod.rs
@@ -3,8 +3,8 @@
 //! This module provides data structures for timeline diagrams.
 //! Timeline diagrams show events organized by time periods or sections.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{TimelineDb, TimelineTask};
 pub use parser::parse;
+pub use types::{TimelineDb, TimelineTask};

--- a/src/diagrams/timeline/parser.rs
+++ b/src/diagrams/timeline/parser.rs
@@ -13,8 +13,8 @@ pub struct TimelineParser;
 pub fn parse(input: &str) -> Result<TimelineDb, String> {
     let mut db = TimelineDb::new();
 
-    let pairs = TimelineParser::parse(Rule::diagram, input)
-        .map_err(|e| format!("Parse error: {}", e))?;
+    let pairs =
+        TimelineParser::parse(Rule::diagram, input).map_err(|e| format!("Parse error: {}", e))?;
 
     for pair in pairs {
         if pair.as_rule() == Rule::diagram {
@@ -29,20 +29,14 @@ pub fn parse(input: &str) -> Result<TimelineDb, String> {
     Ok(db)
 }
 
-fn process_document(
-    db: &mut TimelineDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_document(db: &mut TimelineDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for stmt in pair.into_inner() {
         process_statement(db, stmt)?;
     }
     Ok(())
 }
 
-fn process_statement(
-    db: &mut TimelineDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_statement(db: &mut TimelineDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     match pair.as_rule() {
         Rule::statement => {
             for inner in pair.into_inner() {
@@ -83,10 +77,7 @@ fn process_statement(
     Ok(())
 }
 
-fn process_task(
-    db: &mut TimelineDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_task(db: &mut TimelineDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut task_name = String::new();
     let mut events_str = String::new();
 
@@ -170,7 +161,8 @@ mod tests {
 
         #[test]
         fn should_handle_task_with_events() {
-            let input = "timeline\n    section abc-123\n      task1: event1\n      task2: event2: event3";
+            let input =
+                "timeline\n    section abc-123\n      task1: event1\n      task2: event2: event3";
             let result = parse(input);
             assert!(result.is_ok(), "Parse error: {:?}", result.err());
             let db = result.unwrap();
@@ -215,7 +207,9 @@ mod tests {
             for task in tasks {
                 match task.task.trim() {
                     "task1" => assert_eq!(task.events, vec!["event1"]),
-                    "task2" => assert_eq!(task.events, vec!["event2", "event3", "event4", "event5"]),
+                    "task2" => {
+                        assert_eq!(task.events, vec!["event2", "event3", "event4", "event5"])
+                    }
                     _ => {}
                 }
             }

--- a/src/diagrams/timeline/types.rs
+++ b/src/diagrams/timeline/types.rs
@@ -96,11 +96,8 @@ impl TimelineDb {
         let parts: Vec<&str> = period.splitn(2, ": ").collect();
         let task_name = parts[0].trim().to_string();
 
-        let mut task = TimelineTask::new(
-            self.task_counter,
-            self.current_section.clone(),
-            task_name,
-        );
+        let mut task =
+            TimelineTask::new(self.task_counter, self.current_section.clone(), task_name);
 
         // Add event from period if present
         if parts.len() > 1 {
@@ -265,7 +262,10 @@ mod tests {
         assert_eq!(tasks[0].events, vec!["event1"]);
 
         assert_eq!(tasks[1].task, "task2");
-        assert_eq!(tasks[1].events, vec!["event2", "event3", "event4", "event5"]);
+        assert_eq!(
+            tasks[1].events,
+            vec!["event2", "event3", "event4", "event5"]
+        );
     }
 
     // ==================
@@ -299,7 +299,10 @@ mod tests {
         db.task_counter = 1;
 
         let tasks = db.get_tasks();
-        assert_eq!(tasks[0].events, vec![";ev;ent1; ", ";ev;ent2; ", ";ev;ent3;"]);
+        assert_eq!(
+            tasks[0].events,
+            vec![";ev;ent1; ", ";ev;ent2; ", ";ev;ent3;"]
+        );
     }
 
     #[test]
@@ -330,7 +333,10 @@ mod tests {
 
         let tasks = db.get_tasks();
         assert_eq!(tasks[0].task, "task1");
-        assert_eq!(tasks[0].events, vec!["#ev#ent1# ", "#ev#ent2# ", "#ev#ent3#"]);
+        assert_eq!(
+            tasks[0].events,
+            vec!["#ev#ent1# ", "#ev#ent2# ", "#ev#ent3#"]
+        );
     }
 
     // ==================

--- a/src/diagrams/treemap/mod.rs
+++ b/src/diagrams/treemap/mod.rs
@@ -3,8 +3,8 @@
 //! This module provides data structures for treemap diagrams.
 //! Treemap diagrams show hierarchical data as nested rectangles.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{build_hierarchy, StyleClass, TreemapDb, TreemapNode};
 pub use parser::parse;
+pub use types::{build_hierarchy, StyleClass, TreemapDb, TreemapNode};

--- a/src/diagrams/treemap/parser.rs
+++ b/src/diagrams/treemap/parser.rs
@@ -148,7 +148,9 @@ fn process_row(
     Ok(())
 }
 
-fn process_item(pair: pest::iterators::Pair<Rule>) -> Result<TreemapNode, Box<dyn std::error::Error>> {
+fn process_item(
+    pair: pest::iterators::Pair<Rule>,
+) -> Result<TreemapNode, Box<dyn std::error::Error>> {
     for inner in pair.into_inner() {
         match inner.as_rule() {
             Rule::leaf_item => return process_leaf_item(inner),
@@ -159,7 +161,9 @@ fn process_item(pair: pest::iterators::Pair<Rule>) -> Result<TreemapNode, Box<dy
     Ok(TreemapNode::section(""))
 }
 
-fn process_leaf_item(pair: pest::iterators::Pair<Rule>) -> Result<TreemapNode, Box<dyn std::error::Error>> {
+fn process_leaf_item(
+    pair: pest::iterators::Pair<Rule>,
+) -> Result<TreemapNode, Box<dyn std::error::Error>> {
     let mut name = String::new();
     let mut value: f64 = 0.0;
     let mut class_selector: Option<String> = None;
@@ -190,7 +194,9 @@ fn process_leaf_item(pair: pest::iterators::Pair<Rule>) -> Result<TreemapNode, B
     Ok(node)
 }
 
-fn process_section_item(pair: pest::iterators::Pair<Rule>) -> Result<TreemapNode, Box<dyn std::error::Error>> {
+fn process_section_item(
+    pair: pest::iterators::Pair<Rule>,
+) -> Result<TreemapNode, Box<dyn std::error::Error>> {
     let mut name = String::new();
     let mut class_selector: Option<String> = None;
 
@@ -433,6 +439,9 @@ classDef secondary fill:#6cf,stroke:#333;
 "#;
         let result = parse(input).unwrap();
         let root_nodes = result.get_root_nodes();
-        assert_eq!(root_nodes[0].children[0].children[0].children[0].name, "Level 4");
+        assert_eq!(
+            root_nodes[0].children[0].children[0].children[0].name,
+            "Level 4"
+        );
     }
 }

--- a/src/diagrams/treemap/types.rs
+++ b/src/diagrams/treemap/types.rs
@@ -71,9 +71,8 @@ impl StyleClass {
 
     pub fn add_style(&mut self, style: &str) {
         // Check if it's a label/text style
-        let is_text = style.starts_with("color:")
-            || style.starts_with("font-")
-            || style.starts_with("text-");
+        let is_text =
+            style.starts_with("color:") || style.starts_with("font-") || style.starts_with("text-");
         if is_text {
             self.text_styles.push(style.to_string());
         }
@@ -154,7 +153,11 @@ impl TreemapDb {
 
     /// Add a class definition
     pub fn add_class(&mut self, class_name: &str, style_text: &str) {
-        let mut style_class = self.classes.get(class_name).cloned().unwrap_or_else(|| StyleClass::new(class_name));
+        let mut style_class = self
+            .classes
+            .get(class_name)
+            .cloned()
+            .unwrap_or_else(|| StyleClass::new(class_name));
 
         // Parse styles (comma or semicolon separated)
         let normalized = style_text
@@ -182,7 +185,8 @@ impl TreemapDb {
 
     /// Get styles for a class
     pub fn get_styles_for_class(&self, class_selector: &str) -> Vec<String> {
-        self.classes.get(class_selector)
+        self.classes
+            .get(class_selector)
             .map(|c| c.styles.clone())
             .unwrap_or_default()
     }
@@ -197,9 +201,7 @@ impl TreemapDb {
 }
 
 /// Build hierarchy from flat items with indentation levels
-pub fn build_hierarchy(
-    items: Vec<(usize, TreemapNode)>,
-) -> Vec<TreemapNode> {
+pub fn build_hierarchy(items: Vec<(usize, TreemapNode)>) -> Vec<TreemapNode> {
     if items.is_empty() {
         return Vec::new();
     }

--- a/src/diagrams/xychart/mod.rs
+++ b/src/diagrams/xychart/mod.rs
@@ -3,11 +3,11 @@
 //! This module provides data structures for XY Chart diagrams.
 //! XY charts show data on a 2D coordinate system with line and bar plots.
 
-mod types;
 pub mod parser;
+mod types;
 
-pub use types::{
-    AxisType, BandAxisData, ChartOrientation, DataPoint, LinearAxisData, Plot, PlotType,
-    XAxisData, XYChartDb, YAxisData,
-};
 pub use parser::parse;
+pub use types::{
+    AxisType, BandAxisData, ChartOrientation, DataPoint, LinearAxisData, Plot, PlotType, XAxisData,
+    XYChartDb, YAxisData,
+};

--- a/src/diagrams/xychart/parser.rs
+++ b/src/diagrams/xychart/parser.rs
@@ -13,8 +13,8 @@ pub struct XYChartParser;
 pub fn parse(input: &str) -> Result<XYChartDb, String> {
     let mut db = XYChartDb::new();
 
-    let pairs = XYChartParser::parse(Rule::diagram, input)
-        .map_err(|e| format!("Parse error: {}", e))?;
+    let pairs =
+        XYChartParser::parse(Rule::diagram, input).map_err(|e| format!("Parse error: {}", e))?;
 
     for pair in pairs {
         if pair.as_rule() == Rule::diagram {
@@ -40,20 +40,14 @@ pub fn parse(input: &str) -> Result<XYChartDb, String> {
     Ok(db)
 }
 
-fn process_document(
-    db: &mut XYChartDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_document(db: &mut XYChartDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     for stmt in pair.into_inner() {
         process_statement(db, stmt)?;
     }
     Ok(())
 }
 
-fn process_statement(
-    db: &mut XYChartDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_statement(db: &mut XYChartDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     match pair.as_rule() {
         Rule::statement => {
             for inner in pair.into_inner() {
@@ -88,10 +82,7 @@ fn process_statement(
     Ok(())
 }
 
-fn process_x_axis(
-    db: &mut XYChartDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_x_axis(db: &mut XYChartDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut title = String::new();
     let mut categories: Vec<String> = Vec::new();
     let mut range: Option<(f64, f64)> = None;
@@ -122,10 +113,7 @@ fn process_x_axis(
     Ok(())
 }
 
-fn process_y_axis(
-    db: &mut XYChartDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_y_axis(db: &mut XYChartDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut title = String::new();
     let mut range: Option<(f64, f64)> = None;
 
@@ -150,10 +138,7 @@ fn process_y_axis(
     Ok(())
 }
 
-fn process_line(
-    db: &mut XYChartDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_line(db: &mut XYChartDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut title = String::new();
     let mut values: Vec<f64> = Vec::new();
 
@@ -174,7 +159,11 @@ fn process_line(
         .iter()
         .enumerate()
         .map(|(i, v)| DataPoint {
-            label: if title.is_empty() { format!("{}", i) } else { title.clone() },
+            label: if title.is_empty() {
+                format!("{}", i)
+            } else {
+                title.clone()
+            },
             value: *v,
         })
         .collect();
@@ -183,10 +172,7 @@ fn process_line(
     Ok(())
 }
 
-fn process_bar(
-    db: &mut XYChartDb,
-    pair: pest::iterators::Pair<Rule>,
-) -> Result<(), String> {
+fn process_bar(db: &mut XYChartDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
     let mut title = String::new();
     let mut values: Vec<f64> = Vec::new();
 
@@ -207,7 +193,11 @@ fn process_bar(
         .iter()
         .enumerate()
         .map(|(i, v)| DataPoint {
-            label: if title.is_empty() { format!("{}", i) } else { title.clone() },
+            label: if title.is_empty() {
+                format!("{}", i)
+            } else {
+                title.clone()
+            },
             value: *v,
         })
         .collect();
@@ -297,7 +287,9 @@ fn extract_range(pair: pest::iterators::Pair<Rule>) -> Result<(f64, f64), String
 
     for inner in pair.into_inner() {
         if inner.as_rule() == Rule::number {
-            let num: f64 = inner.as_str().parse()
+            let num: f64 = inner
+                .as_str()
+                .parse()
                 .map_err(|_| format!("Invalid number: {}", inner.as_str()))?;
             numbers.push(num);
         }
@@ -318,7 +310,8 @@ fn extract_data_array(pair: pest::iterators::Pair<Rule>) -> Result<Vec<f64>, Str
             for num_pair in inner.into_inner() {
                 if num_pair.as_rule() == Rule::signed_number {
                     let num_str = num_pair.as_str().trim();
-                    let num: f64 = num_str.parse()
+                    let num: f64 = num_str
+                        .parse()
                         .map_err(|_| format!("Invalid number: {}", num_str))?;
                     values.push(num);
                 }
@@ -332,7 +325,7 @@ fn extract_data_array(pair: pest::iterators::Pair<Rule>) -> Result<Vec<f64>, Str
 /// Remove surrounding quotes from a string
 fn unquote(s: &str) -> String {
     if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
-        s[1..s.len()-1].to_string()
+        s[1..s.len() - 1].to_string()
     } else {
         s.to_string()
     }
@@ -479,7 +472,8 @@ mod tests {
 
         #[test]
         fn should_parse_line_data() {
-            let result = parse("xychart\nx-axis xAxisName\ny-axis yAxisName\nline lineTitle [23, 45, 56.6]");
+            let result =
+                parse("xychart\nx-axis xAxisName\ny-axis yAxisName\nline lineTitle [23, 45, 56.6]");
             assert!(result.is_ok(), "Parse error: {:?}", result.err());
             let db = result.unwrap();
             let plots = db.get_plots();

--- a/src/diagrams/xychart/types.rs
+++ b/src/diagrams/xychart/types.rs
@@ -190,7 +190,10 @@ mod tests {
     #[test]
     fn test_x_axis_band() {
         let mut db = XYChartDb::new();
-        db.set_x_axis_band("Categories", vec!["A".to_string(), "B".to_string(), "C".to_string()]);
+        db.set_x_axis_band(
+            "Categories",
+            vec!["A".to_string(), "B".to_string(), "C".to_string()],
+        );
 
         if let Some(XAxisData::Band(axis)) = &db.x_axis {
             assert_eq!(axis.title, "Categories");
@@ -232,8 +235,14 @@ mod tests {
     fn test_add_line_plot() {
         let mut db = XYChartDb::new();
         let data = vec![
-            DataPoint { label: "A".to_string(), value: 10.0 },
-            DataPoint { label: "B".to_string(), value: 20.0 },
+            DataPoint {
+                label: "A".to_string(),
+                value: 10.0,
+            },
+            DataPoint {
+                label: "B".to_string(),
+                value: 20.0,
+            },
         ];
         db.add_line_plot(data);
 
@@ -247,9 +256,18 @@ mod tests {
     fn test_add_bar_plot() {
         let mut db = XYChartDb::new();
         let data = vec![
-            DataPoint { label: "Q1".to_string(), value: 100.0 },
-            DataPoint { label: "Q2".to_string(), value: 150.0 },
-            DataPoint { label: "Q3".to_string(), value: 200.0 },
+            DataPoint {
+                label: "Q1".to_string(),
+                value: 100.0,
+            },
+            DataPoint {
+                label: "Q2".to_string(),
+                value: 150.0,
+            },
+            DataPoint {
+                label: "Q3".to_string(),
+                value: 200.0,
+            },
         ];
         db.add_bar_plot(data);
 
@@ -262,8 +280,14 @@ mod tests {
     #[test]
     fn test_multiple_plots() {
         let mut db = XYChartDb::new();
-        db.add_line_plot(vec![DataPoint { label: "A".to_string(), value: 10.0 }]);
-        db.add_bar_plot(vec![DataPoint { label: "B".to_string(), value: 20.0 }]);
+        db.add_line_plot(vec![DataPoint {
+            label: "A".to_string(),
+            value: 10.0,
+        }]);
+        db.add_bar_plot(vec![DataPoint {
+            label: "B".to_string(),
+            value: 20.0,
+        }]);
 
         let plots = db.get_plots();
         assert_eq!(plots.len(), 2);
@@ -275,7 +299,10 @@ mod tests {
     fn test_clear() {
         let mut db = XYChartDb::new();
         db.set_title("Test");
-        db.add_line_plot(vec![DataPoint { label: "A".to_string(), value: 10.0 }]);
+        db.add_line_plot(vec![DataPoint {
+            label: "A".to_string(),
+            value: 10.0,
+        }]);
         db.clear();
 
         assert_eq!(db.title, "");

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -452,3 +452,96 @@ fn read_with_timeout(fd: c_int, timeout_ms: u64) -> String {
 
     response
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_background_color_luminance() {
+        // Black should have zero luminance
+        let black = BackgroundColor { r: 0, g: 0, b: 0 };
+        assert!(black.luminance() < 1.0);
+
+        // White should have high luminance
+        let white = BackgroundColor {
+            r: 255,
+            g: 255,
+            b: 255,
+        };
+        assert!(white.luminance() > 250.0);
+
+        // Pure green has highest weight in luminance formula
+        let green = BackgroundColor { r: 0, g: 255, b: 0 };
+        let red = BackgroundColor { r: 255, g: 0, b: 0 };
+        assert!(green.luminance() > red.luminance());
+    }
+
+    #[test]
+    fn test_background_color_is_dark() {
+        // Black is dark
+        let black = BackgroundColor { r: 0, g: 0, b: 0 };
+        assert!(black.is_dark());
+
+        // White is not dark
+        let white = BackgroundColor {
+            r: 255,
+            g: 255,
+            b: 255,
+        };
+        assert!(!white.is_dark());
+
+        // Typical dark theme background (#1e1e1e)
+        let dark_bg = BackgroundColor {
+            r: 30,
+            g: 30,
+            b: 30,
+        };
+        assert!(dark_bg.is_dark());
+
+        // Typical light theme background (#f5f5f5)
+        let light_bg = BackgroundColor {
+            r: 245,
+            g: 245,
+            b: 245,
+        };
+        assert!(!light_bg.is_dark());
+    }
+
+    #[test]
+    fn test_parse_rgb_response_standard() {
+        // Standard 16-bit response format
+        let response = "\x1b]11;rgb:1e1e/1e1e/1e1e\x1b\\";
+        let color = parse_rgb_response(response).unwrap();
+        assert_eq!(color.r, 0x1e);
+        assert_eq!(color.g, 0x1e);
+        assert_eq!(color.b, 0x1e);
+    }
+
+    #[test]
+    fn test_parse_rgb_response_white() {
+        let response = "\x1b]11;rgb:ffff/ffff/ffff\x1b\\";
+        let color = parse_rgb_response(response).unwrap();
+        assert_eq!(color.r, 0xff);
+        assert_eq!(color.g, 0xff);
+        assert_eq!(color.b, 0xff);
+    }
+
+    #[test]
+    fn test_parse_rgb_response_invalid() {
+        // No rgb: prefix
+        assert!(parse_rgb_response("invalid response").is_none());
+
+        // Incomplete
+        assert!(parse_rgb_response("rgb:ff/ff").is_none());
+    }
+
+    #[test]
+    fn test_display_error_display() {
+        let decode_err = DisplayError::ImageDecode("test error".to_string());
+        assert!(decode_err.to_string().contains("decode"));
+
+        let write_err = DisplayError::Write("write failed".to_string());
+        assert!(write_err.to_string().contains("write"));
+    }
+}

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -1,0 +1,454 @@
+//! Display images in terminals using the Kitty graphics protocol.
+//!
+//! The Kitty graphics protocol allows displaying pixel graphics directly
+//! in the terminal. This module provides functions to display PNG images
+//! using the protocol.
+//!
+//! Supported terminals:
+//! - [Kitty](https://sw.kovidgoyal.net/kitty/)
+//! - [Ghostty](https://ghostty.org/)
+//!
+//! # References
+//! - <https://sw.kovidgoyal.net/kitty/graphics-protocol/>
+
+use std::io::{self, Read, Write};
+use std::sync::OnceLock;
+
+use base64::Engine;
+
+/// Cached result of kitty support detection.
+static KITTY_SUPPORT: OnceLock<bool> = OnceLock::new();
+
+/// Check if the current terminal supports the Kitty graphics protocol.
+///
+/// Uses the Kitty graphics protocol query mechanism to detect support.
+/// Falls back to environment variable checks if the query fails.
+///
+/// The result is cached after the first call.
+pub fn is_supported() -> bool {
+    *KITTY_SUPPORT.get_or_init(|| {
+        // Try query-based detection first
+        if query_kitty_support() {
+            return true;
+        }
+        // Fall back to environment variable checks
+        check_env_for_support()
+    })
+}
+
+/// Query the terminal for Kitty graphics protocol support.
+///
+/// Sends a test query and checks for a valid response.
+#[cfg(unix)]
+fn query_kitty_support() -> bool {
+    use std::os::unix::io::AsRawFd;
+
+    // Only works with a real TTY
+    if !atty::is(atty::Stream::Stdin) || !atty::is(atty::Stream::Stdout) {
+        return false;
+    }
+
+    let stdin = io::stdin();
+    let fd = stdin.as_raw_fd();
+
+    // Save terminal settings
+    let old_termios = match termios_get(fd) {
+        Some(t) => t,
+        None => return false,
+    };
+
+    let result = (|| {
+        // Set terminal to raw mode
+        if !termios_set_raw(fd) {
+            return false;
+        }
+
+        // Send kitty graphics query
+        // a=q means query, i=31 is a test image id, s/v=1 is 1x1 pixel
+        let query = "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\";
+        if io::stdout().write_all(query.as_bytes()).is_err() {
+            return false;
+        }
+        if io::stdout().flush().is_err() {
+            return false;
+        }
+
+        // Read response with timeout
+        let response = read_with_timeout(fd, 100);
+
+        // Check for valid kitty graphics response
+        response.contains("_G") && response.contains("i=31")
+    })();
+
+    // Restore terminal settings
+    termios_restore(fd, &old_termios);
+
+    result
+}
+
+#[cfg(not(unix))]
+fn query_kitty_support() -> bool {
+    false
+}
+
+/// Check environment variables for Kitty graphics support hints.
+fn check_env_for_support() -> bool {
+    // Check TERM environment variable
+    if let Ok(term) = std::env::var("TERM") {
+        let term_lower = term.to_lowercase();
+        if term_lower.contains("kitty") || term_lower.contains("ghostty") {
+            return true;
+        }
+    }
+
+    // Check TERM_PROGRAM
+    if let Ok(term_program) = std::env::var("TERM_PROGRAM") {
+        let tp_lower = term_program.to_lowercase();
+        if tp_lower.contains("kitty") || tp_lower.contains("ghostty") {
+            return true;
+        }
+    }
+
+    // Check for kitty-specific environment
+    if std::env::var("KITTY_WINDOW_ID").is_ok() {
+        return true;
+    }
+
+    // Check for Ghostty-specific environment
+    if std::env::var("GHOSTTY_RESOURCES_DIR").is_ok() {
+        return true;
+    }
+
+    false
+}
+
+/// Terminal background color as RGB values (0-255).
+#[derive(Debug, Clone, Copy)]
+pub struct BackgroundColor {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+}
+
+impl BackgroundColor {
+    /// Calculate relative luminance using ITU-R BT.709 formula.
+    pub fn luminance(&self) -> f32 {
+        0.2126 * (self.r as f32) + 0.7152 * (self.g as f32) + 0.0722 * (self.b as f32)
+    }
+
+    /// Check if this background color is considered "dark".
+    ///
+    /// Uses luminance threshold of ~40% (102/255).
+    pub fn is_dark(&self) -> bool {
+        self.luminance() < 102.0
+    }
+}
+
+/// Get the terminal's background color.
+///
+/// Tries OSC 11 query first, then falls back to reading config files.
+#[cfg(unix)]
+pub fn get_terminal_background() -> Option<BackgroundColor> {
+    // Try OSC 11 query first
+    if let Some(bg) = query_terminal_color(11) {
+        return Some(bg);
+    }
+
+    // Try reading from Ghostty config if in Ghostty
+    if std::env::var("GHOSTTY_RESOURCES_DIR").is_ok() {
+        if let Some(bg) = get_ghostty_background() {
+            return Some(bg);
+        }
+    }
+
+    None
+}
+
+#[cfg(not(unix))]
+pub fn get_terminal_background() -> Option<BackgroundColor> {
+    None
+}
+
+/// Detect if the terminal is using a dark color scheme.
+///
+/// Uses OSC 11 to query background color and calculates luminance.
+/// Falls back to environment variables and config files.
+pub fn is_terminal_dark() -> bool {
+    // Try querying the actual background color
+    if let Some(bg) = get_terminal_background() {
+        return bg.is_dark();
+    }
+
+    // Fall back to COLORFGBG environment variable
+    if let Ok(colorfgbg) = std::env::var("COLORFGBG") {
+        let parts: Vec<&str> = colorfgbg.split(';').collect();
+        if parts.len() >= 2 {
+            if let Ok(bg_color) = parts.last().unwrap_or(&"").parse::<u8>() {
+                // 0 = black (dark), 15 = white (light)
+                return bg_color < 8;
+            }
+        }
+    }
+
+    // Default: assume dark (more common for terminal users)
+    true
+}
+
+/// Query terminal for a color using OSC escape sequence.
+#[cfg(unix)]
+fn query_terminal_color(osc_code: u8) -> Option<BackgroundColor> {
+    use std::os::unix::io::AsRawFd;
+
+    if !atty::is(atty::Stream::Stdin) || !atty::is(atty::Stream::Stdout) {
+        return None;
+    }
+
+    let stdin = io::stdin();
+    let fd = stdin.as_raw_fd();
+
+    let old_termios = termios_get(fd)?;
+
+    let result = (|| {
+        if !termios_set_raw(fd) {
+            return None;
+        }
+
+        // Query color: OSC 11 = background
+        let query = format!("\x1b]{};?\x1b\\", osc_code);
+        io::stdout().write_all(query.as_bytes()).ok()?;
+        io::stdout().flush().ok()?;
+
+        let response = read_with_timeout(fd, 100);
+
+        // Parse response: OSC 11 ; rgb:RRRR/GGGG/BBBB ST
+        parse_rgb_response(&response)
+    })();
+
+    termios_restore(fd, &old_termios);
+    result
+}
+
+/// Parse RGB color from terminal response.
+fn parse_rgb_response(response: &str) -> Option<BackgroundColor> {
+    // Look for rgb:RRRR/GGGG/BBBB pattern
+    let rgb_start = response.find("rgb:")?;
+    let rgb_part = &response[rgb_start + 4..];
+
+    let parts: Vec<&str> = rgb_part.split('/').take(3).collect();
+    if parts.len() < 3 {
+        return None;
+    }
+
+    // Clean up the last part (remove trailing escape sequences)
+    let b_part = parts[2].chars().take_while(|c| c.is_ascii_hexdigit()).collect::<String>();
+
+    // Convert 16-bit hex to 8-bit (take first 2 hex digits)
+    let r = u8::from_str_radix(&parts[0].chars().take(2).collect::<String>(), 16).ok()?;
+    let g = u8::from_str_radix(&parts[1].chars().take(2).collect::<String>(), 16).ok()?;
+    let b = u8::from_str_radix(&b_part.chars().take(2).collect::<String>(), 16).ok()?;
+
+    Some(BackgroundColor { r, g, b })
+}
+
+/// Try to read background color from Ghostty config file.
+fn get_ghostty_background() -> Option<BackgroundColor> {
+    let home = std::env::var("HOME").ok()?;
+    let config_path = format!("{}/.config/ghostty/config", home);
+
+    let content = std::fs::read_to_string(&config_path).ok()?;
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with("background") {
+            if let Some(value) = line.split('=').nth(1) {
+                let value = value.trim();
+                if value.starts_with('#') && value.len() >= 7 {
+                    let r = u8::from_str_radix(&value[1..3], 16).ok()?;
+                    let g = u8::from_str_radix(&value[3..5], 16).ok()?;
+                    let b = u8::from_str_radix(&value[5..7], 16).ok()?;
+                    return Some(BackgroundColor { r, g, b });
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Display PNG image data in the terminal using Kitty graphics protocol.
+///
+/// The PNG data is converted to RGBA format and transmitted in chunks.
+///
+/// # Arguments
+/// * `png_data` - Raw PNG image data (not base64 encoded)
+///
+/// # Errors
+/// Returns an error if the image cannot be decoded or displayed.
+pub fn display_png(png_data: &[u8]) -> Result<(), DisplayError> {
+    // Decode PNG to RGBA
+    let img = image::load_from_memory(png_data)
+        .map_err(|e| DisplayError::ImageDecode(e.to_string()))?;
+
+    let rgba = img.to_rgba8();
+    let (width, height) = rgba.dimensions();
+    let raw_data = rgba.into_raw();
+
+    // Base64 encode
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&raw_data);
+
+    // Send via chunked protocol
+    write_chunked_rgba(&encoded, width, height)?;
+
+    // Add newline after image
+    println!();
+
+    Ok(())
+}
+
+/// Write RGBA image data in chunks using Kitty graphics protocol.
+fn write_chunked_rgba(data: &str, width: u32, height: u32) -> Result<(), DisplayError> {
+    const CHUNK_SIZE: usize = 4096;
+
+    let mut remaining = data;
+    let mut first_chunk = true;
+    let mut stdout = io::stdout().lock();
+
+    while !remaining.is_empty() {
+        let (chunk, rest) = if remaining.len() > CHUNK_SIZE {
+            remaining.split_at(CHUNK_SIZE)
+        } else {
+            (remaining, "")
+        };
+        remaining = rest;
+
+        // m=1 means more data coming, m=0 means final chunk
+        let more = if remaining.is_empty() { "0" } else { "1" };
+
+        if first_chunk {
+            // First chunk: a=T (transmit+display), f=32 (RGBA), s=width, v=height
+            write!(
+                stdout,
+                "\x1b_Ga=T,f=32,s={},v={},t=d,m={};{}\x1b\\",
+                width, height, more, chunk
+            )
+            .map_err(|e| DisplayError::Write(e.to_string()))?;
+            first_chunk = false;
+        } else {
+            // Subsequent chunks only need the more flag
+            write!(stdout, "\x1b_Gm={};{}\x1b\\", more, chunk)
+                .map_err(|e| DisplayError::Write(e.to_string()))?;
+        }
+    }
+
+    stdout.flush().map_err(|e| DisplayError::Write(e.to_string()))?;
+    Ok(())
+}
+
+/// Clear all images from the terminal screen.
+pub fn clear_images() {
+    // a=d means delete, d=A means all images
+    let _ = io::stdout().write_all(b"\x1b_Ga=d,d=A\x1b\\");
+    let _ = io::stdout().flush();
+}
+
+/// Errors that can occur when displaying images.
+#[derive(Debug)]
+pub enum DisplayError {
+    /// Failed to decode the image
+    ImageDecode(String),
+    /// Failed to write to stdout
+    Write(String),
+}
+
+impl std::fmt::Display for DisplayError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DisplayError::ImageDecode(e) => write!(f, "Failed to decode image: {}", e),
+            DisplayError::Write(e) => write!(f, "Failed to write to terminal: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for DisplayError {}
+
+// ============================================================================
+// Unix terminal handling
+// ============================================================================
+
+#[cfg(unix)]
+use libc::{c_int, tcgetattr, tcsetattr, termios, ECHO, ICANON, TCSADRAIN};
+
+#[cfg(unix)]
+fn termios_get(fd: c_int) -> Option<termios> {
+    unsafe {
+        let mut t: termios = std::mem::zeroed();
+        if tcgetattr(fd, &mut t) == 0 {
+            Some(t)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(unix)]
+fn termios_set_raw(fd: c_int) -> bool {
+    unsafe {
+        let mut t: termios = std::mem::zeroed();
+        if tcgetattr(fd, &mut t) != 0 {
+            return false;
+        }
+        // Disable canonical mode and echo
+        t.c_lflag &= !(ICANON | ECHO);
+        tcsetattr(fd, TCSADRAIN, &t) == 0
+    }
+}
+
+#[cfg(unix)]
+fn termios_restore(fd: c_int, t: &termios) {
+    unsafe {
+        tcsetattr(fd, TCSADRAIN, t);
+    }
+}
+
+#[cfg(unix)]
+fn read_with_timeout(fd: c_int, timeout_ms: u64) -> String {
+    use std::time::{Duration, Instant};
+
+    let mut response = String::new();
+    let start = Instant::now();
+    let timeout = Duration::from_millis(timeout_ms);
+
+    // Set non-blocking read
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+    }
+
+    let stdin = io::stdin();
+    let mut handle = stdin.lock();
+    let mut buf = [0u8; 1];
+
+    while start.elapsed() < timeout {
+        match handle.read(&mut buf) {
+            Ok(1) => {
+                response.push(buf[0] as char);
+                if buf[0] == b'\\' {
+                    break;
+                }
+            }
+            Ok(_) => break,
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(_) => break,
+        }
+    }
+
+    // Restore blocking mode
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        libc::fcntl(fd, libc::F_SETFL, flags & !libc::O_NONBLOCK);
+    }
+
+    response
+}

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -240,7 +240,10 @@ fn parse_rgb_response(response: &str) -> Option<BackgroundColor> {
     }
 
     // Clean up the last part (remove trailing escape sequences)
-    let b_part = parts[2].chars().take_while(|c| c.is_ascii_hexdigit()).collect::<String>();
+    let b_part = parts[2]
+        .chars()
+        .take_while(|c| c.is_ascii_hexdigit())
+        .collect::<String>();
 
     // Convert 16-bit hex to 8-bit (take first 2 hex digits)
     let r = u8::from_str_radix(&parts[0].chars().take(2).collect::<String>(), 16).ok()?;
@@ -286,8 +289,8 @@ fn get_ghostty_background() -> Option<BackgroundColor> {
 /// Returns an error if the image cannot be decoded or displayed.
 pub fn display_png(png_data: &[u8]) -> Result<(), DisplayError> {
     // Decode PNG to RGBA
-    let img = image::load_from_memory(png_data)
-        .map_err(|e| DisplayError::ImageDecode(e.to_string()))?;
+    let img =
+        image::load_from_memory(png_data).map_err(|e| DisplayError::ImageDecode(e.to_string()))?;
 
     let rgba = img.to_rgba8();
     let (width, height) = rgba.dimensions();
@@ -340,7 +343,9 @@ fn write_chunked_rgba(data: &str, width: u32, height: u32) -> Result<(), Display
         }
     }
 
-    stdout.flush().map_err(|e| DisplayError::Write(e.to_string()))?;
+    stdout
+        .flush()
+        .map_err(|e| DisplayError::Write(e.to_string()))?;
     Ok(())
 }
 

--- a/src/layout/dagre/acyclic.rs
+++ b/src/layout/dagre/acyclic.rs
@@ -36,7 +36,10 @@ pub fn run(g: &mut DagreGraph, method: Acyclicer) {
             let rev_key = EdgeKey::with_name(&edge_key.w, &edge_key.v, &rev_name);
 
             g.edges.insert(rev_key.clone(), label);
-            g.out_edges.get_mut(&edge_key.w).unwrap().push(rev_key.clone());
+            g.out_edges
+                .get_mut(&edge_key.w)
+                .unwrap()
+                .push(rev_key.clone());
             g.in_edges.get_mut(&edge_key.v).unwrap().push(rev_key);
         }
     }
@@ -271,7 +274,14 @@ mod tests {
 
         for v in g.nodes() {
             if !visited.contains(v) {
-                dfs(g, v, &mut visited, &mut rec_stack, &mut rec_set, &mut cycles);
+                dfs(
+                    g,
+                    v,
+                    &mut visited,
+                    &mut rec_stack,
+                    &mut rec_set,
+                    &mut cycles,
+                );
             }
         }
 
@@ -328,7 +338,15 @@ mod tests {
     #[test]
     fn test_undo_does_not_change_acyclic_graph() {
         let mut g = DagreGraph::new();
-        g.set_edge("a", "b", EdgeLabel { minlen: 2, weight: 3, ..Default::default() });
+        g.set_edge(
+            "a",
+            "b",
+            EdgeLabel {
+                minlen: 2,
+                weight: 3,
+                ..Default::default()
+            },
+        );
 
         run(&mut g, Acyclicer::Dfs);
         undo(&mut g);
@@ -342,8 +360,24 @@ mod tests {
     #[test]
     fn test_undo_restores_reversed_edges() {
         let mut g = DagreGraph::new();
-        g.set_edge("a", "b", EdgeLabel { minlen: 2, weight: 3, ..Default::default() });
-        g.set_edge("b", "a", EdgeLabel { minlen: 3, weight: 4, ..Default::default() });
+        g.set_edge(
+            "a",
+            "b",
+            EdgeLabel {
+                minlen: 2,
+                weight: 3,
+                ..Default::default()
+            },
+        );
+        g.set_edge(
+            "b",
+            "a",
+            EdgeLabel {
+                minlen: 3,
+                weight: 4,
+                ..Default::default()
+            },
+        );
 
         run(&mut g, Acyclicer::Dfs);
         undo(&mut g);
@@ -360,10 +394,42 @@ mod tests {
     fn test_greedy_prefers_low_weight_edges() {
         let mut g = DagreGraph::new();
         // Set default weight to 2
-        g.set_edge("a", "b", EdgeLabel { minlen: 1, weight: 2, ..Default::default() });
-        g.set_edge("b", "c", EdgeLabel { minlen: 1, weight: 2, ..Default::default() });
-        g.set_edge("c", "d", EdgeLabel { minlen: 1, weight: 1, ..Default::default() }); // Low weight
-        g.set_edge("d", "a", EdgeLabel { minlen: 1, weight: 2, ..Default::default() });
+        g.set_edge(
+            "a",
+            "b",
+            EdgeLabel {
+                minlen: 1,
+                weight: 2,
+                ..Default::default()
+            },
+        );
+        g.set_edge(
+            "b",
+            "c",
+            EdgeLabel {
+                minlen: 1,
+                weight: 2,
+                ..Default::default()
+            },
+        );
+        g.set_edge(
+            "c",
+            "d",
+            EdgeLabel {
+                minlen: 1,
+                weight: 1,
+                ..Default::default()
+            },
+        ); // Low weight
+        g.set_edge(
+            "d",
+            "a",
+            EdgeLabel {
+                minlen: 1,
+                weight: 2,
+                ..Default::default()
+            },
+        );
 
         run(&mut g, Acyclicer::Greedy);
 

--- a/src/layout/dagre/graph.rs
+++ b/src/layout/dagre/graph.rs
@@ -138,8 +138,8 @@ pub struct EdgeLabel {
 impl Default for EdgeLabel {
     fn default() -> Self {
         Self {
-            minlen: 1,  // dagre.js defaults to 1
-            weight: 1,  // dagre.js defaults to 1
+            minlen: 1, // dagre.js defaults to 1
+            weight: 1, // dagre.js defaults to 1
             width: 0.0,
             height: 0.0,
             x: None,
@@ -405,7 +405,8 @@ impl DagreGraph {
 
     /// Get outgoing edges from a node (sorted for deterministic iteration)
     pub fn out_edges(&self, v: &str) -> Vec<&EdgeKey> {
-        let mut edges: Vec<&EdgeKey> = self.out_edges
+        let mut edges: Vec<&EdgeKey> = self
+            .out_edges
             .get(v)
             .map(|edges| edges.iter().collect())
             .unwrap_or_default();
@@ -415,7 +416,8 @@ impl DagreGraph {
 
     /// Get outgoing edges from v to w specifically (sorted for deterministic iteration)
     pub fn out_edges_to(&self, v: &str, w: &str) -> Vec<&EdgeKey> {
-        let mut edges: Vec<&EdgeKey> = self.out_edges
+        let mut edges: Vec<&EdgeKey> = self
+            .out_edges
             .get(v)
             .map(|edges| edges.iter().filter(|e| e.w == w).collect())
             .unwrap_or_default();
@@ -425,7 +427,8 @@ impl DagreGraph {
 
     /// Get incoming edges to a node (sorted for deterministic iteration)
     pub fn in_edges(&self, w: &str) -> Vec<&EdgeKey> {
-        let mut edges: Vec<&EdgeKey> = self.in_edges
+        let mut edges: Vec<&EdgeKey> = self
+            .in_edges
             .get(w)
             .map(|edges| edges.iter().collect())
             .unwrap_or_default();
@@ -435,7 +438,8 @@ impl DagreGraph {
 
     /// Get predecessor nodes (sorted for deterministic iteration)
     pub fn predecessors(&self, v: &str) -> Vec<&String> {
-        let mut preds: Vec<&String> = self.in_edges
+        let mut preds: Vec<&String> = self
+            .in_edges
             .get(v)
             .map(|edges| edges.iter().map(|e| &e.v).collect())
             .unwrap_or_default();
@@ -445,7 +449,8 @@ impl DagreGraph {
 
     /// Get successor nodes (sorted for deterministic iteration)
     pub fn successors(&self, v: &str) -> Vec<&String> {
-        let mut succs: Vec<&String> = self.out_edges
+        let mut succs: Vec<&String> = self
+            .out_edges
             .get(v)
             .map(|edges| edges.iter().map(|e| &e.w).collect())
             .unwrap_or_default();
@@ -495,10 +500,7 @@ impl DagreGraph {
 
         // Set new parent
         self.parent.insert(v.clone(), parent.clone());
-        self.children
-            .entry(parent)
-            .or_default()
-            .insert(v);
+        self.children.entry(parent).or_default().insert(v);
     }
 
     /// Get parent of a node
@@ -508,7 +510,8 @@ impl DagreGraph {
 
     /// Get children of a node (sorted for deterministic iteration)
     pub fn children(&self, v: &str) -> Vec<&String> {
-        let mut children: Vec<&String> = self.children
+        let mut children: Vec<&String> = self
+            .children
             .get(v)
             .map(|c| c.iter().collect())
             .unwrap_or_default();
@@ -545,7 +548,14 @@ mod tests {
     #[test]
     fn test_set_and_get_node() {
         let mut g = DagreGraph::new();
-        g.set_node("a", NodeLabel { width: 100.0, height: 50.0, ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                width: 100.0,
+                height: 50.0,
+                ..Default::default()
+            },
+        );
 
         assert!(g.has_node("a"));
         assert!(!g.has_node("b"));
@@ -558,7 +568,15 @@ mod tests {
     #[test]
     fn test_set_and_get_edge() {
         let mut g = DagreGraph::new();
-        g.set_edge("a", "b", EdgeLabel { minlen: 2, weight: 3, ..Default::default() });
+        g.set_edge(
+            "a",
+            "b",
+            EdgeLabel {
+                minlen: 2,
+                weight: 3,
+                ..Default::default()
+            },
+        );
 
         assert!(g.has_edge("a", "b"));
         assert!(!g.has_edge("b", "a"));
@@ -572,7 +590,15 @@ mod tests {
     fn test_multigraph() {
         let mut g = DagreGraph::new();
         g.set_edge("a", "b", EdgeLabel::default());
-        g.set_edge_with_name("a", "b", EdgeLabel { weight: 5, ..Default::default() }, "edge2");
+        g.set_edge_with_name(
+            "a",
+            "b",
+            EdgeLabel {
+                weight: 5,
+                ..Default::default()
+            },
+            "edge2",
+        );
 
         // Should have 2 edges from a to b
         let out = g.out_edges("a");

--- a/src/layout/dagre/mod.rs
+++ b/src/layout/dagre/mod.rs
@@ -139,7 +139,8 @@ fn reverse_points_for_reversed_edges(graph: &mut DagreGraph) {
     let edge_keys: Vec<graph::EdgeKey> = graph.edges().into_iter().cloned().collect();
 
     // Second pass: find which ones need reversal
-    let keys_to_reverse: Vec<graph::EdgeKey> = edge_keys.into_iter()
+    let keys_to_reverse: Vec<graph::EdgeKey> = edge_keys
+        .into_iter()
         .filter(|key| graph.edge_by_key(key).map(|e| e.reversed).unwrap_or(false))
         .collect();
 
@@ -321,7 +322,14 @@ mod tests {
     #[test]
     fn can_layout_single_node() {
         let mut g = new_graph();
-        g.set_node("a", graph::NodeLabel { width: 50.0, height: 100.0, ..Default::default() });
+        g.set_node(
+            "a",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 100.0,
+                ..Default::default()
+            },
+        );
 
         layout(&mut g, &DagreConfig::default());
 
@@ -334,10 +342,30 @@ mod tests {
     fn can_layout_two_nodes_same_rank() {
         let mut g = new_graph();
         g.graph_mut().nodesep = 200.0;
-        g.set_node("a", graph::NodeLabel { width: 50.0, height: 100.0, ..Default::default() });
-        g.set_node("b", graph::NodeLabel { width: 75.0, height: 200.0, ..Default::default() });
+        g.set_node(
+            "a",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 100.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            graph::NodeLabel {
+                width: 75.0,
+                height: 200.0,
+                ..Default::default()
+            },
+        );
 
-        layout(&mut g, &DagreConfig { nodesep: 200.0, ..Default::default() });
+        layout(
+            &mut g,
+            &DagreConfig {
+                nodesep: 200.0,
+                ..Default::default()
+            },
+        );
 
         let a = g.node("a").unwrap();
         let b = g.node("b").unwrap();
@@ -352,7 +380,9 @@ mod tests {
         // Nodes should be separated by at least nodesep
         let a_right = a.x.unwrap() + a.width / 2.0;
         let b_left = b.x.unwrap() - b.width / 2.0;
-        let _separation = (b_left - a_right).abs().min((a.x.unwrap() - b.x.unwrap()).abs() - (a.width + b.width) / 2.0);
+        let _separation = (b_left - a_right)
+            .abs()
+            .min((a.x.unwrap() - b.x.unwrap()).abs() - (a.width + b.width) / 2.0);
         // Note: disconnected nodes may be placed closer than nodesep - just verify they don't overlap
         assert!(a.x != b.x, "Nodes should have different x positions");
     }
@@ -361,11 +391,31 @@ mod tests {
     fn can_layout_two_nodes_connected_by_edge() {
         let mut g = new_graph();
         g.graph_mut().ranksep = 300.0;
-        g.set_node("a", graph::NodeLabel { width: 50.0, height: 100.0, ..Default::default() });
-        g.set_node("b", graph::NodeLabel { width: 75.0, height: 200.0, ..Default::default() });
+        g.set_node(
+            "a",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 100.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            graph::NodeLabel {
+                width: 75.0,
+                height: 200.0,
+                ..Default::default()
+            },
+        );
         g.set_edge("a", "b", graph::EdgeLabel::default());
 
-        layout(&mut g, &DagreConfig { ranksep: 300.0, ..Default::default() });
+        layout(
+            &mut g,
+            &DagreConfig {
+                ranksep: 300.0,
+                ..Default::default()
+            },
+        );
 
         let a = g.node("a").unwrap();
         let b = g.node("b").unwrap();
@@ -383,23 +433,60 @@ mod tests {
     fn can_layout_short_cycle() {
         let mut g = new_graph();
         g.graph_mut().ranksep = 200.0;
-        g.set_node("a", graph::NodeLabel { width: 100.0, height: 100.0, ..Default::default() });
-        g.set_node("b", graph::NodeLabel { width: 100.0, height: 100.0, ..Default::default() });
-        g.set_edge("a", "b", graph::EdgeLabel { weight: 2, ..Default::default() });
+        g.set_node(
+            "a",
+            graph::NodeLabel {
+                width: 100.0,
+                height: 100.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            graph::NodeLabel {
+                width: 100.0,
+                height: 100.0,
+                ..Default::default()
+            },
+        );
+        g.set_edge(
+            "a",
+            "b",
+            graph::EdgeLabel {
+                weight: 2,
+                ..Default::default()
+            },
+        );
         g.set_edge("b", "a", graph::EdgeLabel::default());
 
-        layout(&mut g, &DagreConfig { ranksep: 200.0, ..Default::default() });
+        layout(
+            &mut g,
+            &DagreConfig {
+                ranksep: 200.0,
+                ..Default::default()
+            },
+        );
 
         let a = g.node("a").unwrap();
         let b = g.node("b").unwrap();
 
         // Both should have positions
-        assert!(a.x.is_some() && a.y.is_some(), "Node a should have position");
-        assert!(b.x.is_some() && b.y.is_some(), "Node b should have position");
+        assert!(
+            a.x.is_some() && a.y.is_some(),
+            "Node a should have position"
+        );
+        assert!(
+            b.x.is_some() && b.y.is_some(),
+            "Node b should have position"
+        );
 
         // Nodes should be close in x (vertically aligned or nearly so)
         let x_diff = (a.x.unwrap() - b.x.unwrap()).abs();
-        assert!(x_diff < 50.0, "Nodes should be roughly vertically aligned, x diff = {}", x_diff);
+        assert!(
+            x_diff < 50.0,
+            "Nodes should be roughly vertically aligned, x diff = {}",
+            x_diff
+        );
 
         // Nodes should be vertically separated (on different ranks)
         let y_diff = (a.y.unwrap() - b.y.unwrap()).abs();
@@ -418,14 +505,28 @@ mod tests {
         g.graph_mut().nodesep = 50.0;
 
         for v in ["a", "b", "c", "d"] {
-            g.set_node(v, graph::NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
+            g.set_node(
+                v,
+                graph::NodeLabel {
+                    width: 50.0,
+                    height: 50.0,
+                    ..Default::default()
+                },
+            );
         }
         g.set_edge("a", "b", graph::EdgeLabel::default());
         g.set_edge("a", "c", graph::EdgeLabel::default());
         g.set_edge("b", "d", graph::EdgeLabel::default());
         g.set_edge("c", "d", graph::EdgeLabel::default());
 
-        layout(&mut g, &DagreConfig { ranksep: 50.0, nodesep: 50.0, ..Default::default() });
+        layout(
+            &mut g,
+            &DagreConfig {
+                ranksep: 50.0,
+                nodesep: 50.0,
+                ..Default::default()
+            },
+        );
 
         let a = g.node("a").unwrap();
         let b = g.node("b").unwrap();
@@ -448,7 +549,14 @@ mod tests {
     #[test]
     fn can_layout_with_subgraphs() {
         let mut g = new_graph();
-        g.set_node("a", graph::NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
+        g.set_node(
+            "a",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 50.0,
+                ..Default::default()
+            },
+        );
         g.set_node("sg1", graph::NodeLabel::default());
         g.set_parent("a", "sg1");
 
@@ -463,49 +571,118 @@ mod tests {
     fn layout_respects_rankdir_lr() {
         let mut g = new_graph();
         g.graph_mut().rankdir = "LR".to_string();
-        g.set_node("a", graph::NodeLabel { width: 50.0, height: 100.0, ..Default::default() });
-        g.set_node("b", graph::NodeLabel { width: 75.0, height: 200.0, ..Default::default() });
+        g.set_node(
+            "a",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 100.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            graph::NodeLabel {
+                width: 75.0,
+                height: 200.0,
+                ..Default::default()
+            },
+        );
         g.set_edge("a", "b", graph::EdgeLabel::default());
 
-        layout(&mut g, &DagreConfig { rankdir: RankDir::LR, ..Default::default() });
+        layout(
+            &mut g,
+            &DagreConfig {
+                rankdir: RankDir::LR,
+                ..Default::default()
+            },
+        );
 
         let a = g.node("a").unwrap();
         let b = g.node("b").unwrap();
 
         // In LR, nodes should be horizontally arranged
-        assert!(b.x.unwrap() > a.x.unwrap(), "B should be to the right of A in LR layout");
+        assert!(
+            b.x.unwrap() > a.x.unwrap(),
+            "B should be to the right of A in LR layout"
+        );
     }
 
     #[test]
     fn layout_respects_rankdir_bt() {
         let mut g = new_graph();
-        g.set_node("a", graph::NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
-        g.set_node("b", graph::NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
+        g.set_node(
+            "a",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 50.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 50.0,
+                ..Default::default()
+            },
+        );
         g.set_edge("a", "b", graph::EdgeLabel::default());
 
-        layout(&mut g, &DagreConfig { rankdir: RankDir::BT, ..Default::default() });
+        layout(
+            &mut g,
+            &DagreConfig {
+                rankdir: RankDir::BT,
+                ..Default::default()
+            },
+        );
 
         let a = g.node("a").unwrap();
         let b = g.node("b").unwrap();
 
         // In BT, A (source) should be below B (target)
-        assert!(a.y.unwrap() > b.y.unwrap(), "A should be below B in BT layout");
+        assert!(
+            a.y.unwrap() > b.y.unwrap(),
+            "A should be below B in BT layout"
+        );
     }
 
     #[test]
     fn layout_respects_rankdir_rl() {
         let mut g = new_graph();
-        g.set_node("a", graph::NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
-        g.set_node("b", graph::NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
+        g.set_node(
+            "a",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 50.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 50.0,
+                ..Default::default()
+            },
+        );
         g.set_edge("a", "b", graph::EdgeLabel::default());
 
-        layout(&mut g, &DagreConfig { rankdir: RankDir::RL, ..Default::default() });
+        layout(
+            &mut g,
+            &DagreConfig {
+                rankdir: RankDir::RL,
+                ..Default::default()
+            },
+        );
 
         let a = g.node("a").unwrap();
         let b = g.node("b").unwrap();
 
         // In RL, A (source) should be to the right of B (target)
-        assert!(a.x.unwrap() > b.x.unwrap(), "A should be to the right of B in RL layout");
+        assert!(
+            a.x.unwrap() > b.x.unwrap(),
+            "A should be to the right of B in RL layout"
+        );
     }
 
     #[test]
@@ -513,11 +690,32 @@ mod tests {
     fn minimizes_height_of_subgraphs() {
         let mut g = new_graph();
         for v in ["a", "b", "c", "d", "x", "y"] {
-            g.set_node(v, graph::NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
+            g.set_node(
+                v,
+                graph::NodeLabel {
+                    width: 50.0,
+                    height: 50.0,
+                    ..Default::default()
+                },
+            );
         }
         g.set_path(&["a", "b", "c", "d"]);
-        g.set_edge("a", "x", graph::EdgeLabel { weight: 100, ..Default::default() });
-        g.set_edge("y", "d", graph::EdgeLabel { weight: 100, ..Default::default() });
+        g.set_edge(
+            "a",
+            "x",
+            graph::EdgeLabel {
+                weight: 100,
+                ..Default::default()
+            },
+        );
+        g.set_edge(
+            "y",
+            "d",
+            graph::EdgeLabel {
+                weight: 100,
+                ..Default::default()
+            },
+        );
         g.set_node("sg", graph::NodeLabel::default());
         g.set_parent("x", "sg");
         g.set_parent("y", "sg");
@@ -533,7 +731,14 @@ mod tests {
     #[test]
     fn adds_dimensions_to_graph() {
         let mut g = new_graph();
-        g.set_node("a", graph::NodeLabel { width: 100.0, height: 50.0, ..Default::default() });
+        g.set_node(
+            "a",
+            graph::NodeLabel {
+                width: 100.0,
+                height: 50.0,
+                ..Default::default()
+            },
+        );
 
         layout(&mut g, &DagreConfig::default());
 
@@ -547,11 +752,24 @@ mod tests {
         g.graph_mut().ranksep = 50.0;
 
         for v in ["a", "b", "c", "d", "e"] {
-            g.set_node(v, graph::NodeLabel { width: 50.0, height: 30.0, ..Default::default() });
+            g.set_node(
+                v,
+                graph::NodeLabel {
+                    width: 50.0,
+                    height: 30.0,
+                    ..Default::default()
+                },
+            );
         }
         g.set_path(&["a", "b", "c", "d", "e"]);
 
-        layout(&mut g, &DagreConfig { ranksep: 50.0, ..Default::default() });
+        layout(
+            &mut g,
+            &DagreConfig {
+                ranksep: 50.0,
+                ..Default::default()
+            },
+        );
 
         // All nodes should be vertically aligned
         let a = g.node("a").unwrap();
@@ -564,8 +782,22 @@ mod tests {
     #[test]
     fn handles_disconnected_nodes() {
         let mut g = new_graph();
-        g.set_node("a", graph::NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
-        g.set_node("b", graph::NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
+        g.set_node(
+            "a",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 50.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 50.0,
+                ..Default::default()
+            },
+        );
         // No edges - disconnected
 
         layout(&mut g, &DagreConfig::default());
@@ -581,8 +813,22 @@ mod tests {
     #[test]
     fn handles_multigraph_edges() {
         let mut g = new_graph();
-        g.set_node("a", graph::NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
-        g.set_node("b", graph::NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
+        g.set_node(
+            "a",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 50.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            graph::NodeLabel {
+                width: 50.0,
+                height: 50.0,
+                ..Default::default()
+            },
+        );
         g.set_edge("a", "b", graph::EdgeLabel::default());
         g.set_edge_with_name("a", "b", graph::EdgeLabel::default(), "edge2");
 
@@ -604,7 +850,14 @@ mod tests {
         g.graph_mut().nodesep = 50.0;
 
         for v in ["A", "B", "C", "D", "E", "F"] {
-            g.set_node(v, graph::NodeLabel { width: 100.0, height: 50.0, ..Default::default() });
+            g.set_node(
+                v,
+                graph::NodeLabel {
+                    width: 100.0,
+                    height: 50.0,
+                    ..Default::default()
+                },
+            );
         }
 
         // Set edges exactly as flowchart would
@@ -615,7 +868,14 @@ mod tests {
         g.set_edge("D", "F", graph::EdgeLabel::default());
         g.set_edge("E", "F", graph::EdgeLabel::default());
 
-        layout(&mut g, &DagreConfig { ranksep: 50.0, nodesep: 50.0, ..Default::default() });
+        layout(
+            &mut g,
+            &DagreConfig {
+                ranksep: 50.0,
+                nodesep: 50.0,
+                ..Default::default()
+            },
+        );
 
         let a = g.node("A").unwrap();
         let b = g.node("B").unwrap();
@@ -633,15 +893,43 @@ mod tests {
         eprintln!("  F: y={:?}", f.y);
 
         // A should be above B
-        assert!(a.y.unwrap() < b.y.unwrap(), "A should be above B: A.y={:?}, B.y={:?}", a.y, b.y);
+        assert!(
+            a.y.unwrap() < b.y.unwrap(),
+            "A should be above B: A.y={:?}, B.y={:?}",
+            a.y,
+            b.y
+        );
         // B should be above C
-        assert!(b.y.unwrap() < c.y.unwrap(), "B should be above C: B.y={:?}, C.y={:?}", b.y, c.y);
+        assert!(
+            b.y.unwrap() < c.y.unwrap(),
+            "B should be above C: B.y={:?}, C.y={:?}",
+            b.y,
+            c.y
+        );
         // C should be above D and E
-        assert!(c.y.unwrap() < d.y.unwrap(), "C should be above D: C.y={:?}, D.y={:?}", c.y, d.y);
-        assert!(c.y.unwrap() < e.y.unwrap(), "C should be above E: C.y={:?}, E.y={:?}", c.y, e.y);
+        assert!(
+            c.y.unwrap() < d.y.unwrap(),
+            "C should be above D: C.y={:?}, D.y={:?}",
+            c.y,
+            d.y
+        );
+        assert!(
+            c.y.unwrap() < e.y.unwrap(),
+            "C should be above E: C.y={:?}, E.y={:?}",
+            c.y,
+            e.y
+        );
         // D and E should be on the same level
-        assert!((d.y.unwrap() - e.y.unwrap()).abs() < 1.0, "D and E should be on same level");
+        assert!(
+            (d.y.unwrap() - e.y.unwrap()).abs() < 1.0,
+            "D and E should be on same level"
+        );
         // F should be below D and E
-        assert!(d.y.unwrap() < f.y.unwrap(), "D should be above F: D.y={:?}, F.y={:?}", d.y, f.y);
+        assert!(
+            d.y.unwrap() < f.y.unwrap(),
+            "D should be above F: D.y={:?}, F.y={:?}",
+            d.y,
+            f.y
+        );
     }
 }

--- a/src/layout/dagre/mod.rs
+++ b/src/layout/dagre/mod.rs
@@ -352,7 +352,7 @@ mod tests {
         // Nodes should be separated by at least nodesep
         let a_right = a.x.unwrap() + a.width / 2.0;
         let b_left = b.x.unwrap() - b.width / 2.0;
-        let separation = (b_left - a_right).abs().min((a.x.unwrap() - b.x.unwrap()).abs() - (a.width + b.width) / 2.0);
+        let _separation = (b_left - a_right).abs().min((a.x.unwrap() - b.x.unwrap()).abs() - (a.width + b.width) / 2.0);
         // Note: disconnected nodes may be placed closer than nodesep - just verify they don't overlap
         assert!(a.x != b.x, "Nodes should have different x positions");
     }

--- a/src/layout/dagre/normalize.rs
+++ b/src/layout/dagre/normalize.rs
@@ -71,7 +71,14 @@ pub fn run(graph: &mut DagreGraph) {
             graph.set_node(&dummy_id, dummy_label);
 
             // Connect previous node to this dummy
-            graph.set_edge(&prev_node, &dummy_id, EdgeLabel { weight, ..Default::default() });
+            graph.set_edge(
+                &prev_node,
+                &dummy_id,
+                EdgeLabel {
+                    weight,
+                    ..Default::default()
+                },
+            );
 
             if first_dummy.is_none() {
                 first_dummy = Some(dummy_id.clone());
@@ -81,7 +88,14 @@ pub fn run(graph: &mut DagreGraph) {
         }
 
         // Connect last dummy to the target
-        graph.set_edge(&prev_node, &w, EdgeLabel { weight, ..Default::default() });
+        graph.set_edge(
+            &prev_node,
+            &w,
+            EdgeLabel {
+                weight,
+                ..Default::default()
+            },
+        );
 
         // Track the first dummy in this chain
         if let Some(dummy) = first_dummy {
@@ -112,7 +126,11 @@ pub fn undo(graph: &mut DagreGraph) {
                 None => continue,
             };
 
-            let label = node.edge_label.as_ref().map(|b| (**b).clone()).unwrap_or_default();
+            let label = node
+                .edge_label
+                .as_ref()
+                .map(|b| (**b).clone())
+                .unwrap_or_default();
             (edge_obj.0, edge_obj.1, edge_obj.2, label)
         };
 
@@ -210,7 +228,10 @@ pub fn intersect_rect(node: &NodeLabel, p: &super::graph::Point) -> super::graph
         (sx, sy)
     };
 
-    super::graph::Point { x: cx + sx, y: cy + sy }
+    super::graph::Point {
+        x: cx + sx,
+        y: cy + sy,
+    }
 }
 
 /// Compute intersection point for a diamond (rhombus) shape
@@ -301,24 +322,35 @@ pub fn intersect_ellipse(node: &NodeLabel, p: &super::graph::Point) -> super::gr
 }
 
 fn sy_for_sx(dx: f64, dy: f64, sx: f64) -> f64 {
-    if dx == 0.0 { 0.0 } else { dy * sx / dx }
+    if dx == 0.0 {
+        0.0
+    } else {
+        dy * sx / dx
+    }
 }
 
 fn sx_for_sy(dx: f64, dy: f64, sy: f64) -> f64 {
-    if dy == 0.0 { 0.0 } else { dx * sy / dy }
+    if dy == 0.0 {
+        0.0
+    } else {
+        dx * sy / dy
+    }
 }
 
 /// Assign node intersection points to edges
 /// This adds the start and end points where edges meet node boundaries
 pub fn assign_node_intersects(graph: &mut DagreGraph) {
     // Collect edge data (v, w, points) upfront to avoid borrow issues
-    let edge_data: Vec<_> = graph.edges().iter()
+    let edge_data: Vec<_> = graph
+        .edges()
+        .iter()
         .filter_map(|key| {
             let v = key.v.clone();
             let w = key.w.clone();
             let node_v = graph.node(&v)?.clone();
             let node_w = graph.node(&w)?.clone();
-            let points = graph.edge(&v, &w)
+            let points = graph
+                .edge(&v, &w)
                 .map(|e| e.points.clone())
                 .unwrap_or_default();
             Some((v, w, node_v, node_w, points))
@@ -331,11 +363,11 @@ pub fn assign_node_intersects(graph: &mut DagreGraph) {
             // No intermediate points - use node centers
             let p1 = super::graph::Point {
                 x: node_w.x.unwrap_or(0.0),
-                y: node_w.y.unwrap_or(0.0)
+                y: node_w.y.unwrap_or(0.0),
             };
             let p2 = super::graph::Point {
                 x: node_v.x.unwrap_or(0.0),
-                y: node_v.y.unwrap_or(0.0)
+                y: node_v.y.unwrap_or(0.0),
             };
             (p1, p2)
         } else {
@@ -443,8 +475,16 @@ mod tests {
         let intersection = intersect_diamond(&node, &p);
 
         // Should intersect at right vertex (125, 100)
-        assert!((intersection.x - 125.0).abs() < 0.01, "x={}", intersection.x);
-        assert!((intersection.y - 100.0).abs() < 0.01, "y={}", intersection.y);
+        assert!(
+            (intersection.x - 125.0).abs() < 0.01,
+            "x={}",
+            intersection.x
+        );
+        assert!(
+            (intersection.y - 100.0).abs() < 0.01,
+            "y={}",
+            intersection.y
+        );
     }
 
     #[test]
@@ -463,8 +503,16 @@ mod tests {
         let intersection = intersect_diamond(&node, &p);
 
         // Should intersect at bottom vertex (100, 125)
-        assert!((intersection.x - 100.0).abs() < 0.01, "x={}", intersection.x);
-        assert!((intersection.y - 125.0).abs() < 0.01, "y={}", intersection.y);
+        assert!(
+            (intersection.x - 100.0).abs() < 0.01,
+            "x={}",
+            intersection.x
+        );
+        assert!(
+            (intersection.y - 125.0).abs() < 0.01,
+            "y={}",
+            intersection.y
+        );
     }
 
     #[test]
@@ -490,8 +538,16 @@ mod tests {
         // Wait, w = width/2 = 25, h = height/2 = 25
         // t = 1/(100/25 + 100/25) = 1/(4+4) = 1/8
         // point = (100 + 100/8, 100 + 100/8) = (112.5, 112.5)
-        assert!((intersection.x - 112.5).abs() < 0.01, "x={}", intersection.x);
-        assert!((intersection.y - 112.5).abs() < 0.01, "y={}", intersection.y);
+        assert!(
+            (intersection.x - 112.5).abs() < 0.01,
+            "x={}",
+            intersection.x
+        );
+        assert!(
+            (intersection.y - 112.5).abs() < 0.01,
+            "y={}",
+            intersection.y
+        );
     }
 
     #[test]
@@ -510,8 +566,16 @@ mod tests {
         let intersection = intersect_circle(&node, &p);
 
         // Should intersect at (125, 100) - radius 25 from center
-        assert!((intersection.x - 125.0).abs() < 0.01, "x={}", intersection.x);
-        assert!((intersection.y - 100.0).abs() < 0.01, "y={}", intersection.y);
+        assert!(
+            (intersection.x - 125.0).abs() < 0.01,
+            "x={}",
+            intersection.x
+        );
+        assert!(
+            (intersection.y - 100.0).abs() < 0.01,
+            "y={}",
+            intersection.y
+        );
     }
 
     #[test]
@@ -560,7 +624,15 @@ mod tests {
         // Diamond should intersect differently
         // t = 1/(|dx|/w + |dy|/h) = 1/(100/25 + 50/25) = 1/(4+2) = 1/6
         // intersection = (100 + 100/6, 100 + 50/6) = (116.67, 108.33)
-        assert!((diamond_diag.x - 116.67).abs() < 0.1, "diamond x={}", diamond_diag.x);
-        assert!((diamond_diag.y - 108.33).abs() < 0.1, "diamond y={}", diamond_diag.y);
+        assert!(
+            (diamond_diag.x - 116.67).abs() < 0.1,
+            "diamond x={}",
+            diamond_diag.x
+        );
+        assert!(
+            (diamond_diag.y - 108.33).abs() < 0.1,
+            "diamond y={}",
+            diamond_diag.y
+        );
     }
 }

--- a/src/layout/dagre/order/barycenter.rs
+++ b/src/layout/dagre/order/barycenter.rs
@@ -18,46 +18,50 @@ pub struct BarycenterEntry {
 /// For each node, the barycenter is the weighted average of the order positions
 /// of its predecessors.
 pub fn barycenter(g: &DagreGraph, movable: &[String]) -> Vec<BarycenterEntry> {
-    movable.iter().map(|v| {
-        let in_edges = g.in_edges(v);
-        if in_edges.is_empty() {
-            return BarycenterEntry {
-                v: v.clone(),
-                barycenter: None,
-                weight: 0.0,
-            };
-        }
+    movable
+        .iter()
+        .map(|v| {
+            let in_edges = g.in_edges(v);
+            if in_edges.is_empty() {
+                return BarycenterEntry {
+                    v: v.clone(),
+                    barycenter: None,
+                    weight: 0.0,
+                };
+            }
 
-        let mut sum = 0.0;
-        let mut weight = 0.0;
+            let mut sum = 0.0;
+            let mut weight = 0.0;
 
-        for e in &in_edges {
-            let edge_weight = g.edge_by_key(e)
-                .map(|edge| edge.weight as f64)
-                .unwrap_or(1.0);
+            for e in &in_edges {
+                let edge_weight = g
+                    .edge_by_key(e)
+                    .map(|edge| edge.weight as f64)
+                    .unwrap_or(1.0);
 
-            if let Some(node_u) = g.node(&e.v) {
-                if let Some(order) = node_u.order {
-                    sum += edge_weight * (order as f64);
-                    weight += edge_weight;
+                if let Some(node_u) = g.node(&e.v) {
+                    if let Some(order) = node_u.order {
+                        sum += edge_weight * (order as f64);
+                        weight += edge_weight;
+                    }
                 }
             }
-        }
 
-        if weight > 0.0 {
-            BarycenterEntry {
-                v: v.clone(),
-                barycenter: Some(sum / weight),
-                weight,
+            if weight > 0.0 {
+                BarycenterEntry {
+                    v: v.clone(),
+                    barycenter: Some(sum / weight),
+                    weight,
+                }
+            } else {
+                BarycenterEntry {
+                    v: v.clone(),
+                    barycenter: None,
+                    weight: 0.0,
+                }
             }
-        } else {
-            BarycenterEntry {
-                v: v.clone(),
-                barycenter: None,
-                weight: 0.0,
-            }
-        }
-    }).collect()
+        })
+        .collect()
 }
 
 /// Calculate barycenters for movable nodes based on out-edges
@@ -65,58 +69,74 @@ pub fn barycenter(g: &DagreGraph, movable: &[String]) -> Vec<BarycenterEntry> {
 /// For each node, the barycenter is the weighted average of the order positions
 /// of its successors.
 pub fn barycenter_down(g: &DagreGraph, movable: &[String]) -> Vec<BarycenterEntry> {
-    movable.iter().map(|v| {
-        let out_edges = g.out_edges(v);
-        if out_edges.is_empty() {
-            return BarycenterEntry {
-                v: v.clone(),
-                barycenter: None,
-                weight: 0.0,
-            };
-        }
+    movable
+        .iter()
+        .map(|v| {
+            let out_edges = g.out_edges(v);
+            if out_edges.is_empty() {
+                return BarycenterEntry {
+                    v: v.clone(),
+                    barycenter: None,
+                    weight: 0.0,
+                };
+            }
 
-        let mut sum = 0.0;
-        let mut weight = 0.0;
+            let mut sum = 0.0;
+            let mut weight = 0.0;
 
-        for e in &out_edges {
-            let edge_weight = g.edge_by_key(e)
-                .map(|edge| edge.weight as f64)
-                .unwrap_or(1.0);
+            for e in &out_edges {
+                let edge_weight = g
+                    .edge_by_key(e)
+                    .map(|edge| edge.weight as f64)
+                    .unwrap_or(1.0);
 
-            if let Some(node_w) = g.node(&e.w) {
-                if let Some(order) = node_w.order {
-                    sum += edge_weight * (order as f64);
-                    weight += edge_weight;
+                if let Some(node_w) = g.node(&e.w) {
+                    if let Some(order) = node_w.order {
+                        sum += edge_weight * (order as f64);
+                        weight += edge_weight;
+                    }
                 }
             }
-        }
 
-        if weight > 0.0 {
-            BarycenterEntry {
-                v: v.clone(),
-                barycenter: Some(sum / weight),
-                weight,
+            if weight > 0.0 {
+                BarycenterEntry {
+                    v: v.clone(),
+                    barycenter: Some(sum / weight),
+                    weight,
+                }
+            } else {
+                BarycenterEntry {
+                    v: v.clone(),
+                    barycenter: None,
+                    weight: 0.0,
+                }
             }
-        } else {
-            BarycenterEntry {
-                v: v.clone(),
-                barycenter: None,
-                weight: 0.0,
-            }
-        }
-    }).collect()
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::layout::dagre::graph::{NodeLabel, EdgeLabel};
+    use crate::layout::dagre::graph::{EdgeLabel, NodeLabel};
 
     #[test]
     fn test_barycenter_single_predecessor() {
         let mut g = DagreGraph::new();
-        g.set_node("a", NodeLabel { order: Some(0), ..Default::default() });
-        g.set_node("b", NodeLabel { order: Some(2), ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                order: Some(0),
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            NodeLabel {
+                order: Some(2),
+                ..Default::default()
+            },
+        );
         g.set_node("c", NodeLabel::default());
         g.set_edge("a", "c", EdgeLabel::default());
 
@@ -130,8 +150,20 @@ mod tests {
     #[test]
     fn test_barycenter_multiple_predecessors() {
         let mut g = DagreGraph::new();
-        g.set_node("a", NodeLabel { order: Some(0), ..Default::default() });
-        g.set_node("b", NodeLabel { order: Some(2), ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                order: Some(0),
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            NodeLabel {
+                order: Some(2),
+                ..Default::default()
+            },
+        );
         g.set_node("c", NodeLabel::default());
         g.set_edge("a", "c", EdgeLabel::default());
         g.set_edge("b", "c", EdgeLabel::default());
@@ -147,11 +179,37 @@ mod tests {
     #[test]
     fn test_barycenter_weighted() {
         let mut g = DagreGraph::new();
-        g.set_node("a", NodeLabel { order: Some(0), ..Default::default() });
-        g.set_node("b", NodeLabel { order: Some(2), ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                order: Some(0),
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            NodeLabel {
+                order: Some(2),
+                ..Default::default()
+            },
+        );
         g.set_node("c", NodeLabel::default());
-        g.set_edge("a", "c", EdgeLabel { weight: 3, ..Default::default() });
-        g.set_edge("b", "c", EdgeLabel { weight: 1, ..Default::default() });
+        g.set_edge(
+            "a",
+            "c",
+            EdgeLabel {
+                weight: 3,
+                ..Default::default()
+            },
+        );
+        g.set_edge(
+            "b",
+            "c",
+            EdgeLabel {
+                weight: 1,
+                ..Default::default()
+            },
+        );
 
         let result = barycenter(&g, &["c".to_string()]);
 

--- a/src/layout/dagre/order/cross_count.rs
+++ b/src/layout/dagre/order/cross_count.rs
@@ -31,7 +31,8 @@ fn two_layer_cross_count(g: &DagreGraph, north_layer: &[String], south_layer: &[
     // Collect all edges from north to south with their positions and weights
     let mut south_entries: Vec<(usize, i32)> = Vec::new();
     for v in north_layer {
-        let mut edges_for_v: Vec<(usize, i32)> = g.out_edges(v)
+        let mut edges_for_v: Vec<(usize, i32)> = g
+            .out_edges(v)
             .iter()
             .filter_map(|e| {
                 south_pos.get(e.w.as_str()).map(|&pos| {
@@ -131,7 +132,14 @@ mod tests {
     fn test_weighted_crossing() {
         // Same as one_crossing but with weight 3 on one edge
         let mut g = DagreGraph::new();
-        g.set_edge("a", "d", EdgeLabel { weight: 3, ..Default::default() });
+        g.set_edge(
+            "a",
+            "d",
+            EdgeLabel {
+                weight: 3,
+                ..Default::default()
+            },
+        );
         g.set_edge("b", "c", EdgeLabel::default());
 
         let layering = vec![

--- a/src/layout/dagre/order/init_order.rs
+++ b/src/layout/dagre/order/init_order.rs
@@ -17,7 +17,8 @@ pub fn init_order(g: &DagreGraph) -> Vec<Vec<String>> {
     let mut visited = HashSet::new();
 
     // Find max rank
-    let max_rank = g.nodes()
+    let max_rank = g
+        .nodes()
         .iter()
         .filter_map(|v| g.node(v).and_then(|n| n.rank))
         .max()
@@ -27,12 +28,7 @@ pub fn init_order(g: &DagreGraph) -> Vec<Vec<String>> {
     let mut layers: Vec<Vec<String>> = (0..=max_rank).map(|_| Vec::new()).collect();
 
     // DFS function to visit nodes
-    fn dfs(
-        g: &DagreGraph,
-        v: &str,
-        visited: &mut HashSet<String>,
-        layers: &mut Vec<Vec<String>>
-    ) {
+    fn dfs(g: &DagreGraph, v: &str, visited: &mut HashSet<String>, layers: &mut Vec<Vec<String>>) {
         if visited.contains(v) {
             return;
         }
@@ -85,7 +81,13 @@ mod tests {
     #[test]
     fn test_init_order_single_node() {
         let mut g = DagreGraph::new();
-        g.set_node("a", NodeLabel { rank: Some(0), ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                rank: Some(0),
+                ..Default::default()
+            },
+        );
 
         let layers = init_order(&g);
 

--- a/src/layout/dagre/order/mod.rs
+++ b/src/layout/dagre/order/mod.rs
@@ -12,9 +12,9 @@ mod sort;
 
 use crate::layout::dagre::graph::DagreGraph;
 
-pub use cross_count::cross_count;
-pub use init_order::{init_order, assign_order};
 pub use barycenter::{barycenter, barycenter_down, BarycenterEntry};
+pub use cross_count::cross_count;
+pub use init_order::{assign_order, init_order};
 pub use sort::{sort, SortResult};
 
 /// Assign order to nodes to minimize edge crossings
@@ -24,7 +24,8 @@ pub fn order(g: &mut DagreGraph) {
     assign_order(g, &layering);
 
     // Find max rank for iteration
-    let max_rank = g.nodes()
+    let max_rank = g
+        .nodes()
         .iter()
         .filter_map(|v| g.node(v).and_then(|n| n.rank))
         .max()
@@ -40,7 +41,8 @@ pub fn order(g: &mut DagreGraph) {
 
     // Iterate: alternate between down sweep and up sweep
     let mut last_best = 0;
-    for i in 0..24 {  // Max 24 iterations like dagre.js
+    for i in 0..24 {
+        // Max 24 iterations like dagre.js
         if last_best >= 4 {
             break; // Stop if no improvement in 4 iterations
         }
@@ -76,7 +78,8 @@ pub fn order(g: &mut DagreGraph) {
 fn sweep_down(g: &mut DagreGraph, max_rank: usize, bias_right: bool) {
     for rank in 1..=max_rank {
         // Collect nodes and sort by current order to preserve stable ordering
-        let mut layer: Vec<(String, usize)> = g.nodes()
+        let mut layer: Vec<(String, usize)> = g
+            .nodes()
             .iter()
             .filter_map(|v| {
                 let node = g.node(v)?;
@@ -108,7 +111,8 @@ fn sweep_down(g: &mut DagreGraph, max_rank: usize, bias_right: bool) {
 fn sweep_up(g: &mut DagreGraph, max_rank: usize, bias_right: bool) {
     for rank in (0..max_rank).rev() {
         // Collect nodes and sort by current order to preserve stable ordering
-        let mut layer: Vec<(String, usize)> = g.nodes()
+        let mut layer: Vec<(String, usize)> = g
+            .nodes()
             .iter()
             .filter_map(|v| {
                 let node = g.node(v)?;
@@ -155,7 +159,8 @@ fn build_layer_matrix(g: &DagreGraph, max_rank: usize) -> Vec<Vec<String>> {
         layer.sort_by_key(|(_, order)| *order);
     }
 
-    layers.into_iter()
+    layers
+        .into_iter()
         .map(|layer| layer.into_iter().map(|(v, _)| v).collect())
         .collect()
 }
@@ -228,10 +233,18 @@ mod tests {
         rank::assign_ranks(&mut g, Ranker::LongestPath);
 
         // Force initial order with crossing
-        if let Some(node) = g.node_mut("a") { node.order = Some(0); }
-        if let Some(node) = g.node_mut("b") { node.order = Some(1); }
-        if let Some(node) = g.node_mut("c") { node.order = Some(0); }
-        if let Some(node) = g.node_mut("d") { node.order = Some(1); }
+        if let Some(node) = g.node_mut("a") {
+            node.order = Some(0);
+        }
+        if let Some(node) = g.node_mut("b") {
+            node.order = Some(1);
+        }
+        if let Some(node) = g.node_mut("c") {
+            node.order = Some(0);
+        }
+        if let Some(node) = g.node_mut("d") {
+            node.order = Some(1);
+        }
 
         let initial_layering = vec![
             vec!["a".to_string(), "b".to_string()],
@@ -259,8 +272,8 @@ mod tests {
         let mut g = DagreGraph::new();
 
         // Add edges in specific order - C first, then D
-        g.set_edge("B", "C", EdgeLabel::default());  // "Yes" branch
-        g.set_edge("B", "D", EdgeLabel::default());  // "No" branch
+        g.set_edge("B", "C", EdgeLabel::default()); // "Yes" branch
+        g.set_edge("B", "D", EdgeLabel::default()); // "No" branch
 
         rank::assign_ranks(&mut g, Ranker::LongestPath);
         order(&mut g);

--- a/src/layout/dagre/order/sort.rs
+++ b/src/layout/dagre/order/sort.rs
@@ -71,7 +71,11 @@ pub fn sort(entries: Vec<BarycenterEntry>, bias_right: bool) -> SortResult {
 
     SortResult {
         vs,
-        barycenter: if weight > 0.0 { Some(sum / weight) } else { None },
+        barycenter: if weight > 0.0 {
+            Some(sum / weight)
+        } else {
+            None
+        },
         weight,
     }
 }
@@ -79,7 +83,7 @@ pub fn sort(entries: Vec<BarycenterEntry>, bias_right: bool) -> SortResult {
 fn consume_unsortable(
     vs: &mut Vec<String>,
     unsortable: &mut Vec<(usize, BarycenterEntry)>,
-    index: &mut usize
+    index: &mut usize,
 ) {
     while let Some((i, _)) = unsortable.last() {
         if *i <= *index {
@@ -99,9 +103,21 @@ mod tests {
     #[test]
     fn test_sort_by_barycenter() {
         let entries = vec![
-            BarycenterEntry { v: "a".to_string(), barycenter: Some(2.0), weight: 1.0 },
-            BarycenterEntry { v: "b".to_string(), barycenter: Some(1.0), weight: 1.0 },
-            BarycenterEntry { v: "c".to_string(), barycenter: Some(3.0), weight: 1.0 },
+            BarycenterEntry {
+                v: "a".to_string(),
+                barycenter: Some(2.0),
+                weight: 1.0,
+            },
+            BarycenterEntry {
+                v: "b".to_string(),
+                barycenter: Some(1.0),
+                weight: 1.0,
+            },
+            BarycenterEntry {
+                v: "c".to_string(),
+                barycenter: Some(3.0),
+                weight: 1.0,
+            },
         ];
 
         let result = sort(entries, false);
@@ -112,9 +128,21 @@ mod tests {
     #[test]
     fn test_sort_preserves_order_for_equal_barycenter() {
         let entries = vec![
-            BarycenterEntry { v: "a".to_string(), barycenter: Some(1.0), weight: 1.0 },
-            BarycenterEntry { v: "b".to_string(), barycenter: Some(1.0), weight: 1.0 },
-            BarycenterEntry { v: "c".to_string(), barycenter: Some(1.0), weight: 1.0 },
+            BarycenterEntry {
+                v: "a".to_string(),
+                barycenter: Some(1.0),
+                weight: 1.0,
+            },
+            BarycenterEntry {
+                v: "b".to_string(),
+                barycenter: Some(1.0),
+                weight: 1.0,
+            },
+            BarycenterEntry {
+                v: "c".to_string(),
+                barycenter: Some(1.0),
+                weight: 1.0,
+            },
         ];
 
         let result = sort(entries, false);
@@ -125,8 +153,16 @@ mod tests {
     #[test]
     fn test_sort_bias_right() {
         let entries = vec![
-            BarycenterEntry { v: "a".to_string(), barycenter: Some(1.0), weight: 1.0 },
-            BarycenterEntry { v: "b".to_string(), barycenter: Some(1.0), weight: 1.0 },
+            BarycenterEntry {
+                v: "a".to_string(),
+                barycenter: Some(1.0),
+                weight: 1.0,
+            },
+            BarycenterEntry {
+                v: "b".to_string(),
+                barycenter: Some(1.0),
+                weight: 1.0,
+            },
         ];
 
         let result = sort(entries, true);
@@ -137,9 +173,21 @@ mod tests {
     #[test]
     fn test_sort_handles_no_barycenter() {
         let entries = vec![
-            BarycenterEntry { v: "a".to_string(), barycenter: Some(2.0), weight: 1.0 },
-            BarycenterEntry { v: "b".to_string(), barycenter: None, weight: 0.0 },
-            BarycenterEntry { v: "c".to_string(), barycenter: Some(1.0), weight: 1.0 },
+            BarycenterEntry {
+                v: "a".to_string(),
+                barycenter: Some(2.0),
+                weight: 1.0,
+            },
+            BarycenterEntry {
+                v: "b".to_string(),
+                barycenter: None,
+                weight: 0.0,
+            },
+            BarycenterEntry {
+                v: "c".to_string(),
+                barycenter: Some(1.0),
+                weight: 1.0,
+            },
         ];
 
         let result = sort(entries, false);

--- a/src/layout/dagre/position/bk.rs
+++ b/src/layout/dagre/position/bk.rs
@@ -31,7 +31,10 @@ pub fn position_x(g: &DagreGraph) -> HashMap<String, f64> {
 
         for horiz in ["l", "r"] {
             let aligned_layers: Vec<Vec<String>> = if horiz == "r" {
-                adjusted_layers.iter().map(|layer| layer.iter().rev().cloned().collect()).collect()
+                adjusted_layers
+                    .iter()
+                    .map(|layer| layer.iter().rev().cloned().collect())
+                    .collect()
             } else {
                 adjusted_layers.clone()
             };
@@ -40,7 +43,15 @@ pub fn position_x(g: &DagreGraph) -> HashMap<String, f64> {
             let (root, align) = vertical_alignment(g, &aligned_layers, vert == "u");
 
             // Compact horizontally
-            let mut xs = horizontal_compaction(g, &aligned_layers, &root, &align, nodesep, edgesep, horiz == "r");
+            let mut xs = horizontal_compaction(
+                g,
+                &aligned_layers,
+                &root,
+                &align,
+                nodesep,
+                edgesep,
+                horiz == "r",
+            );
 
             // Flip for right alignment
             if horiz == "r" {
@@ -68,7 +79,8 @@ pub fn position_x(g: &DagreGraph) -> HashMap<String, f64> {
 
 /// Build a matrix of nodes organized by layer
 fn build_layer_matrix(g: &DagreGraph) -> Vec<Vec<String>> {
-    let max_rank = g.nodes()
+    let max_rank = g
+        .nodes()
         .iter()
         .filter_map(|v| g.node(v).and_then(|n| n.rank))
         .max()
@@ -87,7 +99,8 @@ fn build_layer_matrix(g: &DagreGraph) -> Vec<Vec<String>> {
     }
 
     // Sort each layer by order and extract just the node IDs
-    layers.iter_mut()
+    layers
+        .iter_mut()
         .map(|layer| {
             layer.sort_by_key(|(_, order)| *order);
             layer.iter().map(|(v, _)| v.clone()).collect()
@@ -231,7 +244,8 @@ fn resolve_overlaps_ordered(
     }
 
     // Get current positions and widths
-    let mut positions: Vec<(String, f64, f64)> = layer.iter()
+    let mut positions: Vec<(String, f64, f64)> = layer
+        .iter()
         .filter_map(|v| {
             let x = xs.get(v)?;
             let width = g.node(v).map(|n| n.width).unwrap_or(0.0);
@@ -248,10 +262,20 @@ fn resolve_overlaps_ordered(
         let prev_width = positions[i - 1].2;
         let curr_width = positions[i].2;
 
-        let prev_is_dummy = g.node(&positions[i - 1].0).map(|n| n.dummy.is_some()).unwrap_or(false);
-        let curr_is_dummy = g.node(&positions[i].0).map(|n| n.dummy.is_some()).unwrap_or(false);
+        let prev_is_dummy = g
+            .node(&positions[i - 1].0)
+            .map(|n| n.dummy.is_some())
+            .unwrap_or(false);
+        let curr_is_dummy = g
+            .node(&positions[i].0)
+            .map(|n| n.dummy.is_some())
+            .unwrap_or(false);
 
-        let sep = if prev_is_dummy || curr_is_dummy { edgesep } else { nodesep };
+        let sep = if prev_is_dummy || curr_is_dummy {
+            edgesep
+        } else {
+            nodesep
+        };
         let min_x = prev_x + prev_width / 2.0 + sep + curr_width / 2.0;
 
         if positions[i].1 < min_x {
@@ -276,8 +300,9 @@ fn balance(
     let mut align_to: Option<&str> = None;
 
     for (&name, xs) in xss {
-        let (min_x, max_x) = xs.values()
-            .fold((f64::MAX, f64::MIN), |(min, max), &x| (min.min(x), max.max(x)));
+        let (min_x, max_x) = xs.values().fold((f64::MAX, f64::MIN), |(min, max), &x| {
+            (min.min(x), max.max(x))
+        });
         let width = max_x - min_x;
         if width < min_width {
             min_width = width;
@@ -316,7 +341,8 @@ fn balance(
 
     // Take median of four alignments for each node
     for v in all_nodes {
-        let mut coords: Vec<f64> = aligned_xss.values()
+        let mut coords: Vec<f64> = aligned_xss
+            .values()
             .filter_map(|xs| xs.get(v).copied())
             .collect();
 
@@ -342,15 +368,22 @@ fn balance(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::layout::dagre::graph::{NodeLabel, EdgeLabel};
-    use crate::layout::dagre::rank;
+    use crate::layout::dagre::graph::{EdgeLabel, NodeLabel};
     use crate::layout::dagre::order;
+    use crate::layout::dagre::rank;
     use crate::layout::dagre::Ranker;
 
     #[test]
     fn test_position_x_single_node() {
         let mut g = DagreGraph::new();
-        g.set_node("a", NodeLabel { width: 50.0, height: 100.0, ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                width: 50.0,
+                height: 100.0,
+                ..Default::default()
+            },
+        );
         rank::assign_ranks(&mut g, Ranker::LongestPath);
         order::order(&mut g);
 
@@ -366,8 +399,26 @@ mod tests {
     fn test_position_x_two_nodes_same_rank() {
         let mut g = DagreGraph::new();
         g.graph_mut().nodesep = 50.0;
-        g.set_node("a", NodeLabel { width: 50.0, height: 100.0, rank: Some(0), order: Some(0), ..Default::default() });
-        g.set_node("b", NodeLabel { width: 50.0, height: 100.0, rank: Some(0), order: Some(1), ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                width: 50.0,
+                height: 100.0,
+                rank: Some(0),
+                order: Some(0),
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            NodeLabel {
+                width: 50.0,
+                height: 100.0,
+                rank: Some(0),
+                order: Some(1),
+                ..Default::default()
+            },
+        );
 
         let xs = position_x(&g);
 
@@ -375,19 +426,42 @@ mod tests {
         assert!(xs.contains_key("b"));
 
         // b should be to the right of a
-        assert!(xs["b"] > xs["a"], "b ({}) should be to the right of a ({})", xs["b"], xs["a"]);
+        assert!(
+            xs["b"] > xs["a"],
+            "b ({}) should be to the right of a ({})",
+            xs["b"],
+            xs["a"]
+        );
 
         // They should be separated appropriately (no overlap)
         let half_widths = 25.0 + 25.0; // Each node is 50 wide, half = 25
         let actual_sep = xs["b"] - xs["a"] - half_widths;
-        assert!(actual_sep >= 0.0, "Nodes should not overlap, separation = {}", actual_sep);
+        assert!(
+            actual_sep >= 0.0,
+            "Nodes should not overlap, separation = {}",
+            actual_sep
+        );
     }
 
     #[test]
     fn test_position_x_chain() {
         let mut g = DagreGraph::new();
-        g.set_node("a", NodeLabel { width: 50.0, height: 40.0, ..Default::default() });
-        g.set_node("b", NodeLabel { width: 50.0, height: 40.0, ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                width: 50.0,
+                height: 40.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            NodeLabel {
+                width: 50.0,
+                height: 40.0,
+                ..Default::default()
+            },
+        );
         g.set_edge("a", "b", EdgeLabel::default());
         rank::assign_ranks(&mut g, Ranker::LongestPath);
         order::order(&mut g);
@@ -401,7 +475,8 @@ mod tests {
         assert!(
             (xs["a"] - xs["b"]).abs() < 100.0,
             "a ({}) and b ({}) should be vertically aligned",
-            xs["a"], xs["b"]
+            xs["a"],
+            xs["b"]
         );
     }
 
@@ -411,7 +486,14 @@ mod tests {
         let mut g = DagreGraph::new();
         g.graph_mut().nodesep = 50.0;
         for v in ["a", "b", "c", "d"] {
-            g.set_node(v, NodeLabel { width: 50.0, height: 50.0, ..Default::default() });
+            g.set_node(
+                v,
+                NodeLabel {
+                    width: 50.0,
+                    height: 50.0,
+                    ..Default::default()
+                },
+            );
         }
         g.set_edge("a", "b", EdgeLabel::default());
         g.set_edge("a", "c", EdgeLabel::default());
@@ -433,7 +515,8 @@ mod tests {
         assert!(
             (xs["b"] - xs["c"]).abs() >= 50.0,
             "b ({}) and c ({}) should be separated",
-            xs["b"], xs["c"]
+            xs["b"],
+            xs["c"]
         );
     }
 }

--- a/src/layout/dagre/position/mod.rs
+++ b/src/layout/dagre/position/mod.rs
@@ -27,7 +27,8 @@ fn position_y(g: &mut DagreGraph) {
     let ranksep = g.graph().ranksep;
 
     // Build layer matrix
-    let max_rank = g.nodes()
+    let max_rank = g
+        .nodes()
         .iter()
         .filter_map(|v| g.node(v).and_then(|n| n.rank))
         .max()
@@ -50,7 +51,8 @@ fn position_y(g: &mut DagreGraph) {
 
     for layer in &layers {
         // Find max height in this layer
-        let max_height = layer.iter()
+        let max_height = layer
+            .iter()
             .filter_map(|v| g.node(v).map(|n| n.height))
             .fold(0.0_f64, f64::max);
 
@@ -70,15 +72,22 @@ fn position_y(g: &mut DagreGraph) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::layout::dagre::graph::{NodeLabel, EdgeLabel};
-    use crate::layout::dagre::rank;
+    use crate::layout::dagre::graph::{EdgeLabel, NodeLabel};
     use crate::layout::dagre::order;
+    use crate::layout::dagre::rank;
     use crate::layout::dagre::Ranker;
 
     #[test]
     fn test_position_single_node() {
         let mut g = DagreGraph::new();
-        g.set_node("a", NodeLabel { width: 50.0, height: 100.0, ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                width: 50.0,
+                height: 100.0,
+                ..Default::default()
+            },
+        );
         rank::assign_ranks(&mut g, Ranker::LongestPath);
         order::order(&mut g);
 
@@ -94,8 +103,22 @@ mod tests {
     fn test_position_chain() {
         let mut g = DagreGraph::new();
         g.graph_mut().ranksep = 100.0;
-        g.set_node("a", NodeLabel { width: 50.0, height: 40.0, ..Default::default() });
-        g.set_node("b", NodeLabel { width: 50.0, height: 60.0, ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                width: 50.0,
+                height: 40.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            NodeLabel {
+                width: 50.0,
+                height: 60.0,
+                ..Default::default()
+            },
+        );
         g.set_edge("a", "b", EdgeLabel::default());
         rank::assign_ranks(&mut g, Ranker::LongestPath);
         order::order(&mut g);
@@ -114,9 +137,30 @@ mod tests {
     #[test]
     fn test_position_parallel_nodes() {
         let mut g = DagreGraph::new();
-        g.set_node("a", NodeLabel { width: 50.0, height: 40.0, ..Default::default() });
-        g.set_node("b", NodeLabel { width: 50.0, height: 40.0, ..Default::default() });
-        g.set_node("c", NodeLabel { width: 50.0, height: 40.0, ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                width: 50.0,
+                height: 40.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            NodeLabel {
+                width: 50.0,
+                height: 40.0,
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "c",
+            NodeLabel {
+                width: 50.0,
+                height: 40.0,
+                ..Default::default()
+            },
+        );
         g.set_edge("a", "b", EdgeLabel::default());
         g.set_edge("a", "c", EdgeLabel::default());
         rank::assign_ranks(&mut g, Ranker::LongestPath);

--- a/src/layout/dagre/rank/longest_path.rs
+++ b/src/layout/dagre/rank/longest_path.rs
@@ -104,7 +104,14 @@ mod tests {
     #[test]
     fn test_respects_minlen() {
         let mut g = DagreGraph::new();
-        g.set_edge("a", "b", EdgeLabel { minlen: 3, ..Default::default() });
+        g.set_edge(
+            "a",
+            "b",
+            EdgeLabel {
+                minlen: 3,
+                ..Default::default()
+            },
+        );
 
         run(&mut g);
 

--- a/src/layout/dagre/rank/mod.rs
+++ b/src/layout/dagre/rank/mod.rs
@@ -10,7 +10,9 @@ mod util;
 use super::graph::DagreGraph;
 use super::Ranker;
 
-pub use network_simplex::{init_low_lim_values, init_cut_values, calc_cut_value, leave_edge, enter_edge, exchange_edges};
+pub use network_simplex::{
+    calc_cut_value, enter_edge, exchange_edges, init_cut_values, init_low_lim_values, leave_edge,
+};
 
 /// Assign ranks to all nodes in the graph
 pub fn assign_ranks(g: &mut DagreGraph, method: Ranker) {
@@ -73,7 +75,14 @@ mod tests {
         let mut g = DagreGraph::new();
         g.set_path(&["a", "b", "d"]);
         g.set_edge("a", "c", EdgeLabel::default());
-        g.set_edge("c", "d", EdgeLabel { minlen: 2, ..Default::default() });
+        g.set_edge(
+            "c",
+            "d",
+            EdgeLabel {
+                minlen: 2,
+                ..Default::default()
+            },
+        );
 
         // Use LongestPath - NetworkSimplex has a bug in exchange_edges
         // that can create negative slack. TODO: Fix network simplex.

--- a/src/layout/dagre/rank/network_simplex.rs
+++ b/src/layout/dagre/rank/network_simplex.rs
@@ -45,7 +45,8 @@ impl SpanningTree {
     }
 
     pub fn set_edge(&mut self, v: &str, w: &str, edge: TreeEdge) {
-        self.edges.insert((v.to_string(), w.to_string()), edge.clone());
+        self.edges
+            .insert((v.to_string(), w.to_string()), edge.clone());
         self.edges.insert((w.to_string(), v.to_string()), edge);
     }
 
@@ -101,7 +102,8 @@ impl SpanningTree {
 
     /// Get neighbors of a node in the tree
     pub fn neighbors(&self, v: &str) -> Vec<String> {
-        let mut neighbors: Vec<String> = self.edges
+        let mut neighbors: Vec<String> = self
+            .edges
             .keys()
             .filter(|(a, _)| a == v)
             .map(|(_, b)| b.clone())
@@ -191,7 +193,11 @@ fn feasible_tree(g: &DagreGraph) -> SpanningTree {
         if !in_tree.contains(v) {
             // Find an edge connecting this node to the tree
             for edge_key in g.in_edges(v).iter().chain(g.out_edges(v).iter()) {
-                let other = if edge_key.v == *v { &edge_key.w } else { &edge_key.v };
+                let other = if edge_key.v == *v {
+                    &edge_key.w
+                } else {
+                    &edge_key.v
+                };
                 if in_tree.contains(other) {
                     tree.set_edge(v, other, TreeEdge::default());
                     in_tree.insert(v.clone());
@@ -251,7 +257,11 @@ fn dfs_assign(tree: &mut SpanningTree, v: &str, parent: Option<&str>, counter: &
 
 /// Initialize cut values for all tree edges
 pub fn init_cut_values(tree: &mut SpanningTree, g: &DagreGraph) {
-    let edges: Vec<(String, String)> = tree.edges_list().iter().map(|(v, w)| (v.to_string(), w.to_string())).collect();
+    let edges: Vec<(String, String)> = tree
+        .edges_list()
+        .iter()
+        .map(|(v, w)| (v.to_string(), w.to_string()))
+        .collect();
 
     for (v, w) in edges {
         let cutvalue = calc_cut_value(tree, g, &v, &w);
@@ -336,7 +346,11 @@ pub fn leave_edge(tree: &SpanningTree) -> Option<(String, String)> {
 }
 
 /// Find an edge to enter the tree
-pub fn enter_edge(tree: &SpanningTree, g: &DagreGraph, leave: &(String, String)) -> Option<EdgeKey> {
+pub fn enter_edge(
+    tree: &SpanningTree,
+    g: &DagreGraph,
+    leave: &(String, String),
+) -> Option<EdgeKey> {
     let (tail, _head) = (&leave.0, &leave.1);
 
     // Find the non-tree edge with minimum slack that crosses the cut
@@ -367,7 +381,12 @@ pub fn enter_edge(tree: &SpanningTree, g: &DagreGraph, leave: &(String, String))
 }
 
 /// Exchange edges in the tree and update the graph
-pub fn exchange_edges(tree: &mut SpanningTree, g: &mut DagreGraph, leave: &(String, String), enter: &EdgeKey) {
+pub fn exchange_edges(
+    tree: &mut SpanningTree,
+    g: &mut DagreGraph,
+    leave: &(String, String),
+    enter: &EdgeKey,
+) {
     // Remove leaving edge from tree
     tree.remove_edge(&leave.0, &leave.1);
 
@@ -407,7 +426,7 @@ pub fn exchange_edges(tree: &mut SpanningTree, g: &mut DagreGraph, leave: &(Stri
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::layout::dagre::graph::{NodeLabel, EdgeLabel};
+    use crate::layout::dagre::graph::{EdgeLabel, NodeLabel};
 
     #[test]
     fn test_single_node() {

--- a/src/layout/dagre/rank/util.rs
+++ b/src/layout/dagre/rank/util.rs
@@ -35,13 +35,25 @@ pub fn slack(g: &DagreGraph, v: &str, w: &str) -> Option<i32> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::layout::dagre::graph::{NodeLabel, EdgeLabel};
+    use crate::layout::dagre::graph::{EdgeLabel, NodeLabel};
 
     #[test]
     fn test_normalize_ranks() {
         let mut g = DagreGraph::new();
-        g.set_node("a", NodeLabel { rank: Some(2), ..Default::default() });
-        g.set_node("b", NodeLabel { rank: Some(4), ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                rank: Some(2),
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            NodeLabel {
+                rank: Some(4),
+                ..Default::default()
+            },
+        );
 
         normalize_ranks(&mut g);
 
@@ -52,9 +64,28 @@ mod tests {
     #[test]
     fn test_slack() {
         let mut g = DagreGraph::new();
-        g.set_node("a", NodeLabel { rank: Some(0), ..Default::default() });
-        g.set_node("b", NodeLabel { rank: Some(3), ..Default::default() });
-        g.set_edge("a", "b", EdgeLabel { minlen: 1, ..Default::default() });
+        g.set_node(
+            "a",
+            NodeLabel {
+                rank: Some(0),
+                ..Default::default()
+            },
+        );
+        g.set_node(
+            "b",
+            NodeLabel {
+                rank: Some(3),
+                ..Default::default()
+            },
+        );
+        g.set_edge(
+            "a",
+            "b",
+            EdgeLabel {
+                minlen: 1,
+                ..Default::default()
+            },
+        );
 
         assert_eq!(slack(&g, "a", "b"), Some(2)); // 3 - 0 - 1 = 2
     }

--- a/src/layout/graph.rs
+++ b/src/layout/graph.rs
@@ -144,7 +144,9 @@ impl LayoutGraph {
         for edge in &self.edges {
             for source in &edge.sources {
                 for target in &edge.targets {
-                    adj.entry(source.as_str()).or_default().push(target.as_str());
+                    adj.entry(source.as_str())
+                        .or_default()
+                        .push(target.as_str());
                 }
             }
         }
@@ -174,8 +176,10 @@ impl LayoutGraph {
         });
 
         if min_x != f64::MAX {
-            self.width = Some(max_x - min_x + self.options.padding.left + self.options.padding.right);
-            self.height = Some(max_y - min_y + self.options.padding.top + self.options.padding.bottom);
+            self.width =
+                Some(max_x - min_x + self.options.padding.left + self.options.padding.right);
+            self.height =
+                Some(max_y - min_y + self.options.padding.top + self.options.padding.bottom);
         }
     }
 

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -150,10 +150,8 @@ fn apply_dagre_results(graph: &mut LayoutGraph, dg: &DagreGraph) {
                         // Average the two middle points if even number of points
                         let p1 = &edge.bend_points[mid_idx - 1];
                         let p2 = &edge.bend_points[mid_idx];
-                        edge.label_position = Some(Point::new(
-                            (p1.x + p2.x) / 2.0,
-                            (p1.y + p2.y) / 2.0,
-                        ));
+                        edge.label_position =
+                            Some(Point::new((p1.x + p2.x) / 2.0, (p1.y + p2.y) / 2.0));
                     } else {
                         // Use the middle point if odd number
                         edge.label_position = Some(edge.bend_points[mid_idx].clone());
@@ -293,7 +291,11 @@ mod tests {
 
         // Check that edge points exist for LR layout
         let edge = result.edges.first().expect("Should have an edge");
-        eprintln!("LR Edge {} has {} bend points:", edge.id, edge.bend_points.len());
+        eprintln!(
+            "LR Edge {} has {} bend points:",
+            edge.id,
+            edge.bend_points.len()
+        );
         for (i, p) in edge.bend_points.iter().enumerate() {
             eprintln!("  Point {}: ({:.1}, {:.1})", i, p.x, p.y);
         }
@@ -358,7 +360,9 @@ mod tests {
         assert!(
             label_pos.x > a_right && label_pos.x < b_left,
             "Label x ({}) should be between A right edge ({}) and B left edge ({})",
-            label_pos.x, a_right, b_left
+            label_pos.x,
+            a_right,
+            b_left
         );
     }
 }

--- a/src/layout/size.rs
+++ b/src/layout/size.rs
@@ -178,27 +178,18 @@ mod tests {
         let estimator = CharacterSizeEstimator::default();
         let config = NodeSizeConfig::default();
 
-        let (rect_w, rect_h) = estimator.estimate_node_size(
-            Some("Test"),
-            NodeShape::Rectangle,
-            &config,
-        );
+        let (rect_w, rect_h) =
+            estimator.estimate_node_size(Some("Test"), NodeShape::Rectangle, &config);
 
         // Diamond should be larger than rectangle for same text
-        let (diamond_w, diamond_h) = estimator.estimate_node_size(
-            Some("Test"),
-            NodeShape::Diamond,
-            &config,
-        );
+        let (diamond_w, diamond_h) =
+            estimator.estimate_node_size(Some("Test"), NodeShape::Diamond, &config);
         assert!(diamond_w > rect_w);
         assert!(diamond_h > rect_h);
 
         // Circle should have equal width and height
-        let (circle_w, circle_h) = estimator.estimate_node_size(
-            Some("Test"),
-            NodeShape::Circle,
-            &config,
-        );
+        let (circle_w, circle_h) =
+            estimator.estimate_node_size(Some("Test"), NodeShape::Circle, &config);
         assert!((circle_w - circle_h).abs() < 0.001);
     }
 

--- a/src/layout/types.rs
+++ b/src/layout/types.rs
@@ -215,7 +215,11 @@ pub struct LayoutEdge {
 }
 
 impl LayoutEdge {
-    pub fn new(id: impl Into<String>, source: impl Into<String>, target: impl Into<String>) -> Self {
+    pub fn new(
+        id: impl Into<String>,
+        source: impl Into<String>,
+        target: impl Into<String>,
+    ) -> Self {
         Self {
             id: id.into(),
             sources: vec![source.into()],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ pub mod error;
 pub mod layout;
 pub mod render;
 
+#[cfg(feature = "kitty")]
+pub mod kitty;
+
 pub use config::Config;
 pub use error::{MermaidError, Result};
 pub use render::{render, render_with_config, RenderConfig, Theme};

--- a/src/render/class.rs
+++ b/src/render/class.rs
@@ -41,7 +41,8 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
         } else {
             (class.annotations.len() as f64) * member_height
         };
-        let total_height = header_height + annotations_height + content_height + class_padding * 2.0;
+        let total_height =
+            header_height + annotations_height + content_height + class_padding * 2.0;
         let height = total_height.max(class_min_height);
         class_heights.insert(class.id.clone(), height);
     }
@@ -78,7 +79,9 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
     for relation in &db.relations {
         let is_composition_or_aggregation = |t: i32| t == 0 || t == 2;
 
-        if is_composition_or_aggregation(relation.relation.type1) && !parent_of.contains_key(&relation.id2) {
+        if is_composition_or_aggregation(relation.relation.type1)
+            && !parent_of.contains_key(&relation.id2)
+        {
             // id1 has the composition marker, so id1 contains id2
             // id2 should be below id1
             children_of
@@ -86,7 +89,9 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
                 .or_default()
                 .push(relation.id2.clone());
             parent_of.insert(relation.id2.clone(), relation.id1.clone());
-        } else if is_composition_or_aggregation(relation.relation.type2) && !parent_of.contains_key(&relation.id1) {
+        } else if is_composition_or_aggregation(relation.relation.type2)
+            && !parent_of.contains_key(&relation.id1)
+        {
             // id2 has the composition marker, so id2 contains id1
             children_of
                 .entry(relation.id2.clone())
@@ -108,10 +113,8 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
         .collect();
 
     // BFS to assign levels
-    let mut queue: std::collections::VecDeque<(String, usize)> = roots
-        .iter()
-        .map(|id| (id.clone(), 0))
-        .collect();
+    let mut queue: std::collections::VecDeque<(String, usize)> =
+        roots.iter().map(|id| (id.clone(), 0)).collect();
 
     while let Some((id, level)) = queue.pop_front() {
         if class_levels.contains_key(&id) {
@@ -162,7 +165,10 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
 
             let mut current_y = margin;
             for class_id in level_classes {
-                let height = class_heights.get(class_id).copied().unwrap_or(class_min_height);
+                let height = class_heights
+                    .get(class_id)
+                    .copied()
+                    .unwrap_or(class_min_height);
                 class_positions.insert(class_id.clone(), (current_x, current_y));
                 current_y += height + class_spacing_y;
             }
@@ -179,7 +185,8 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
         // Process levels from bottom to top
         for level in (0..=max_level).rev() {
             for class_id in &levels[level] {
-                let children: Vec<_> = children_of.get(class_id)
+                let children: Vec<_> = children_of
+                    .get(class_id)
                     .map(|c| c.clone())
                     .unwrap_or_default();
 
@@ -188,9 +195,8 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
                     subtree_widths.insert(class_id.clone(), class_width);
                 } else {
                     // Parent node: width is sum of children's subtree widths + spacing
-                    let children_width: f64 = children.iter()
-                        .filter_map(|c| subtree_widths.get(c))
-                        .sum();
+                    let children_width: f64 =
+                        children.iter().filter_map(|c| subtree_widths.get(c)).sum();
                     let spacing = (children.len().saturating_sub(1) as f64) * class_spacing_x;
                     let total_width = (children_width + spacing).max(class_width);
                     subtree_widths.insert(class_id.clone(), total_width);
@@ -315,8 +321,20 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
     // Render each class
     for class in &classes {
         if let Some(&(x, y)) = class_positions.get(&class.id) {
-            let height = class_heights.get(&class.id).copied().unwrap_or(class_min_height);
-            let class_elem = render_class_box(class, x, y, class_width, height, class_padding, member_height, header_height);
+            let height = class_heights
+                .get(&class.id)
+                .copied()
+                .unwrap_or(class_min_height);
+            let class_elem = render_class_box(
+                class,
+                x,
+                y,
+                class_width,
+                height,
+                class_padding,
+                member_height,
+                header_height,
+            );
             doc.add_element(class_elem);
         }
     }
@@ -327,8 +345,14 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
             class_positions.get(&relation.id1),
             class_positions.get(&relation.id2),
         ) {
-            let h1 = class_heights.get(&relation.id1).copied().unwrap_or(class_min_height);
-            let h2 = class_heights.get(&relation.id2).copied().unwrap_or(class_min_height);
+            let h1 = class_heights
+                .get(&relation.id1)
+                .copied()
+                .unwrap_or(class_min_height);
+            let h2 = class_heights
+                .get(&relation.id2)
+                .copied()
+                .unwrap_or(class_min_height);
             let relation_elem = render_relation(
                 x1,
                 y1,
@@ -542,9 +566,8 @@ fn render_relation(
     let mut children = Vec::new();
 
     // Calculate edge connection points based on relative positions
-    let (start_x, start_y, end_x, end_y) = calculate_connection_points(
-        x1, y1, h1, x2, y2, h2, class_width,
-    );
+    let (start_x, start_y, end_x, end_y) =
+        calculate_connection_points(x1, y1, h1, x2, y2, h2, class_width);
 
     // Determine marker based on relation type
     let marker_start = match type1 {
@@ -599,8 +622,16 @@ fn render_relation(
 
         // Offset perpendicular to the line
         let perp_offset = 12.0;
-        let perp_x = if len > 0.0 { -perp_offset * dy / len } else { perp_offset };
-        let perp_y = if len > 0.0 { perp_offset * dx / len } else { 0.0 };
+        let perp_x = if len > 0.0 {
+            -perp_offset * dy / len
+        } else {
+            perp_offset
+        };
+        let perp_y = if len > 0.0 {
+            perp_offset * dx / len
+        } else {
+            0.0
+        };
 
         children.push(SvgElement::Text {
             x: start_x + offset_x + perp_x,
@@ -624,8 +655,16 @@ fn render_relation(
 
         // Offset perpendicular to the line
         let perp_offset = 12.0;
-        let perp_x = if len > 0.0 { -perp_offset * dy / len } else { perp_offset };
-        let perp_y = if len > 0.0 { perp_offset * dx / len } else { 0.0 };
+        let perp_x = if len > 0.0 {
+            -perp_offset * dy / len
+        } else {
+            perp_offset
+        };
+        let perp_y = if len > 0.0 {
+            perp_offset * dx / len
+        } else {
+            0.0
+        };
 
         children.push(SvgElement::Text {
             x: end_x - offset_x + perp_x,
@@ -790,7 +829,7 @@ fn create_inheritance_marker() -> SvgElement {
     SvgElement::Marker {
         id: "inheritance".to_string(),
         view_box: "0 0 20 14".to_string(),
-        ref_x: 18.0,  // Line connects at x=18, arrow points back toward x=1
+        ref_x: 18.0, // Line connects at x=18, arrow points back toward x=1
         ref_y: 7.0,
         marker_width: 10.0,
         marker_height: 10.0,
@@ -800,7 +839,7 @@ fn create_inheritance_marker() -> SvgElement {
             // Path from mermaid.js extensionStart: apex at x=1, opens toward x=18
             d: "M 1 7 L 18 13 V 1 Z".to_string(),
             attrs: Attrs::new()
-                .with_fill("none")  // Hollow/transparent per UML convention
+                .with_fill("none") // Hollow/transparent per UML convention
                 .with_stroke("#333333")
                 .with_stroke_width(1.0),
         }],
@@ -813,7 +852,7 @@ fn create_aggregation_marker() -> SvgElement {
     SvgElement::Marker {
         id: "aggregation".to_string(),
         view_box: "0 0 20 14".to_string(),
-        ref_x: 18.0,  // Like inheritance, line connects at right side
+        ref_x: 18.0, // Like inheritance, line connects at right side
         ref_y: 7.0,
         marker_width: 10.0,
         marker_height: 10.0,
@@ -823,7 +862,7 @@ fn create_aggregation_marker() -> SvgElement {
             // Diamond shape: apex left, points at top and bottom, flat right
             d: "M 18 7 L 9 13 L 1 7 L 9 1 Z".to_string(),
             attrs: Attrs::new()
-                .with_fill("none")  // Hollow per UML aggregation convention
+                .with_fill("none") // Hollow per UML aggregation convention
                 .with_stroke("#333333")
                 .with_stroke_width(1.0),
         }],
@@ -836,7 +875,7 @@ fn create_composition_marker() -> SvgElement {
     SvgElement::Marker {
         id: "composition".to_string(),
         view_box: "0 0 20 14".to_string(),
-        ref_x: 18.0,  // Consistent with other markers
+        ref_x: 18.0, // Consistent with other markers
         ref_y: 7.0,
         marker_width: 10.0,
         marker_height: 10.0,
@@ -846,7 +885,7 @@ fn create_composition_marker() -> SvgElement {
             // Same diamond shape as aggregation
             d: "M 18 7 L 9 13 L 1 7 L 9 1 Z".to_string(),
             attrs: Attrs::new()
-                .with_fill("#333333")  // Filled per UML composition convention
+                .with_fill("#333333") // Filled per UML composition convention
                 .with_stroke("#333333")
                 .with_stroke_width(1.0),
         }],
@@ -945,7 +984,7 @@ fn generate_class_css() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::diagrams::class::{ClassDb, ClassRelation, RelationDetails, LineType};
+    use crate::diagrams::class::{ClassDb, ClassRelation, LineType, RelationDetails};
 
     #[test]
     fn test_hierarchical_layout_levels() {
@@ -969,7 +1008,11 @@ mod tests {
             title: String::new(),
             text: String::new(),
             style: vec![],
-            relation: RelationDetails { type1: 1, type2: -1, line_type: LineType::Solid },
+            relation: RelationDetails {
+                type1: 1,
+                type2: -1,
+                line_type: LineType::Solid,
+            },
         });
         db.add_relation(ClassRelation {
             id1: "Animal".to_string(),
@@ -980,7 +1023,11 @@ mod tests {
             title: String::new(),
             text: String::new(),
             style: vec![],
-            relation: RelationDetails { type1: 1, type2: -1, line_type: LineType::Solid },
+            relation: RelationDetails {
+                type1: 1,
+                type2: -1,
+                line_type: LineType::Solid,
+            },
         });
         db.add_relation(ClassRelation {
             id1: "Animal".to_string(),
@@ -991,7 +1038,11 @@ mod tests {
             title: String::new(),
             text: String::new(),
             style: vec![],
-            relation: RelationDetails { type1: 1, type2: -1, line_type: LineType::Solid },
+            relation: RelationDetails {
+                type1: 1,
+                type2: -1,
+                line_type: LineType::Solid,
+            },
         });
         // Composition: Duck *-- Egg
         db.add_relation(ClassRelation {
@@ -1003,7 +1054,11 @@ mod tests {
             title: "has".to_string(),
             text: String::new(),
             style: vec![],
-            relation: RelationDetails { type1: 2, type2: -1, line_type: LineType::Solid },
+            relation: RelationDetails {
+                type1: 2,
+                type2: -1,
+                line_type: LineType::Solid,
+            },
         });
 
         let config = RenderConfig::default();

--- a/src/render/er.rs
+++ b/src/render/er.rs
@@ -2,11 +2,11 @@
 
 use std::collections::HashMap;
 
-use crate::diagrams::er::{Cardinality, Direction, ErDb, Entity, Identification};
+use crate::diagrams::er::{Cardinality, Direction, Entity, ErDb, Identification};
 use crate::error::Result;
 use crate::layout::{
-    layout, CharacterSizeEstimator, LayoutDirection, LayoutEdge, LayoutGraph,
-    LayoutNode, LayoutOptions, NodeShape, Padding, SizeEstimator, ToLayoutGraph,
+    layout, CharacterSizeEstimator, LayoutDirection, LayoutEdge, LayoutGraph, LayoutNode,
+    LayoutOptions, NodeShape, Padding, SizeEstimator, ToLayoutGraph,
 };
 use crate::render::svg::{Attrs, RenderConfig, SvgDocument, SvgElement};
 
@@ -58,7 +58,8 @@ impl ToLayoutGraph for ErDb {
             let edge_id = format!("relationship-{}", i);
 
             // Create edge from source (entity_a) to target (entity_b)
-            let mut edge = LayoutEdge::new(&edge_id, &relationship.entity_a, &relationship.entity_b);
+            let mut edge =
+                LayoutEdge::new(&edge_id, &relationship.entity_a, &relationship.entity_b);
 
             if !relationship.role_a.is_empty() {
                 edge = edge.with_label(&relationship.role_a);
@@ -115,8 +116,13 @@ pub fn render_er(db: &ErDb, config: &RenderConfig) -> Result<String> {
     // Calculate entity heights
     let mut entity_heights: HashMap<String, f64> = HashMap::new();
     for (name, entity) in entities {
-        let height = entity_header_height + (entity.attributes.len() as f64) * attr_row_height + padding * 2.0;
-        entity_heights.insert(name.clone(), height.max(entity_header_height + padding * 2.0));
+        let height = entity_header_height
+            + (entity.attributes.len() as f64) * attr_row_height
+            + padding * 2.0;
+        entity_heights.insert(
+            name.clone(),
+            height.max(entity_header_height + padding * 2.0),
+        );
     }
 
     // Sort entities for consistent ordering
@@ -147,7 +153,11 @@ pub fn render_er(db: &ErDb, config: &RenderConfig) -> Result<String> {
     }
 
     // Title offset
-    let title_offset = if !db.diagram_title.is_empty() { 40.0 } else { 0.0 };
+    let title_offset = if !db.diagram_title.is_empty() {
+        40.0
+    } else {
+        0.0
+    };
 
     // Calculate diagram bounds from layout
     let max_width = layout_result.width.unwrap_or(400.0) + margin * 2.0;
@@ -179,7 +189,10 @@ pub fn render_er(db: &ErDb, config: &RenderConfig) -> Result<String> {
     // Render each entity
     for (name, entity) in &sorted_entities {
         if let Some(&(x, y)) = entity_positions.get(*name) {
-            let height = entity_heights.get(*name).copied().unwrap_or(entity_header_height);
+            let height = entity_heights
+                .get(*name)
+                .copied()
+                .unwrap_or(entity_header_height);
             let entity_elem = render_entity(
                 entity,
                 x,
@@ -207,12 +220,17 @@ pub fn render_er(db: &ErDb, config: &RenderConfig) -> Result<String> {
         let entity_b_name = entity_id_to_name.get(&relationship.entity_b);
 
         if let (Some(a_name), Some(b_name)) = (entity_a_name, entity_b_name) {
-            if let (Some(&(x1, y1)), Some(&(x2, y2))) = (
-                entity_positions.get(a_name),
-                entity_positions.get(b_name),
-            ) {
-                let h1 = entity_heights.get(a_name).copied().unwrap_or(entity_header_height);
-                let h2 = entity_heights.get(b_name).copied().unwrap_or(entity_header_height);
+            if let (Some(&(x1, y1)), Some(&(x2, y2))) =
+                (entity_positions.get(a_name), entity_positions.get(b_name))
+            {
+                let h1 = entity_heights
+                    .get(a_name)
+                    .copied()
+                    .unwrap_or(entity_header_height);
+                let h2 = entity_heights
+                    .get(b_name)
+                    .copied()
+                    .unwrap_or(entity_header_height);
 
                 let rel_elem = render_relationship(
                     x1,
@@ -328,9 +346,7 @@ fn render_entity(
 
     SvgElement::Group {
         children,
-        attrs: Attrs::new()
-            .with_class("entity-node")
-            .with_id(&entity.id),
+        attrs: Attrs::new().with_class("entity-node").with_id(&entity.id),
     }
 }
 
@@ -457,9 +473,7 @@ fn render_cardinality(x: f64, y: f64, angle: f64, card: Cardinality, at_end: boo
                     y1: ly + perp_sin,
                     x2: lx - perp_cos,
                     y2: ly - perp_sin,
-                    attrs: Attrs::new()
-                        .with_stroke("#333333")
-                        .with_stroke_width(1.0),
+                    attrs: Attrs::new().with_stroke("#333333").with_stroke_width(1.0),
                 });
             }
         }
@@ -481,9 +495,7 @@ fn render_cardinality(x: f64, y: f64, angle: f64, card: Cardinality, at_end: boo
                 y1: base_y + perp_sin,
                 x2: base_x - perp_cos,
                 y2: base_y - perp_sin,
-                attrs: Attrs::new()
-                    .with_stroke("#333333")
-                    .with_stroke_width(1.0),
+                attrs: Attrs::new().with_stroke("#333333").with_stroke_width(1.0),
             });
         }
         Cardinality::ZeroOrMore => {
@@ -505,8 +517,14 @@ fn render_cardinality(x: f64, y: f64, angle: f64, card: Cardinality, at_end: boo
             children.push(SvgElement::Path {
                 d: format!(
                     "M {} {} L {} {} M {} {} L {} {}",
-                    x, y, foot_x + perp_cos, foot_y + perp_sin,
-                    x, y, foot_x - perp_cos, foot_y - perp_sin
+                    x,
+                    y,
+                    foot_x + perp_cos,
+                    foot_y + perp_sin,
+                    x,
+                    y,
+                    foot_x - perp_cos,
+                    foot_y - perp_sin
                 ),
                 attrs: Attrs::new()
                     .with_fill("none")
@@ -521,9 +539,7 @@ fn render_cardinality(x: f64, y: f64, angle: f64, card: Cardinality, at_end: boo
                 y1: base_y + perp_sin,
                 x2: base_x - perp_cos,
                 y2: base_y - perp_sin,
-                attrs: Attrs::new()
-                    .with_stroke("#333333")
-                    .with_stroke_width(1.0),
+                attrs: Attrs::new().with_stroke("#333333").with_stroke_width(1.0),
             });
             // Crow's foot
             let foot_x = base_x + 5.0 * cos_a;
@@ -531,8 +547,14 @@ fn render_cardinality(x: f64, y: f64, angle: f64, card: Cardinality, at_end: boo
             children.push(SvgElement::Path {
                 d: format!(
                     "M {} {} L {} {} M {} {} L {} {}",
-                    x, y, foot_x + perp_cos, foot_y + perp_sin,
-                    x, y, foot_x - perp_cos, foot_y - perp_sin
+                    x,
+                    y,
+                    foot_x + perp_cos,
+                    foot_y + perp_sin,
+                    x,
+                    y,
+                    foot_x - perp_cos,
+                    foot_y - perp_sin
                 ),
                 attrs: Attrs::new()
                     .with_fill("none")
@@ -547,9 +569,7 @@ fn render_cardinality(x: f64, y: f64, angle: f64, card: Cardinality, at_end: boo
                 y1: base_y + perp_sin,
                 x2: base_x - perp_cos,
                 y2: base_y - perp_sin,
-                attrs: Attrs::new()
-                    .with_stroke("#333333")
-                    .with_stroke_width(2.0),
+                attrs: Attrs::new().with_stroke("#333333").with_stroke_width(2.0),
             });
         }
     }

--- a/src/render/flowchart.rs
+++ b/src/render/flowchart.rs
@@ -1,10 +1,10 @@
 //! Flowchart adapter for layout
 
-use crate::diagrams::flowchart::{Direction, FlowchartDb, FlowVertexType};
+use crate::diagrams::flowchart::{Direction, FlowVertexType, FlowchartDb};
 use crate::error::Result;
 use crate::layout::{
-    LayoutDirection, LayoutEdge, LayoutGraph, LayoutNode, LayoutOptions,
-    NodeShape, NodeSizeConfig, Padding, SizeEstimator, ToLayoutGraph,
+    LayoutDirection, LayoutEdge, LayoutGraph, LayoutNode, LayoutOptions, NodeShape, NodeSizeConfig,
+    Padding, SizeEstimator, ToLayoutGraph,
 };
 
 impl ToLayoutGraph for FlowchartDb {
@@ -34,17 +34,18 @@ impl ToLayoutGraph for FlowchartDb {
             let label = vertex.text.as_deref();
             let (width, height) = size_estimator.estimate_node_size(label, shape, &config);
 
-            let mut node = LayoutNode::new(id, width, height)
-                .with_shape(shape);
+            let mut node = LayoutNode::new(id, width, height).with_shape(shape);
 
             if let Some(label) = label {
                 node = node.with_label(label);
             }
 
             // Store original metadata
-            node.metadata.insert("dom_id".to_string(), vertex.dom_id.clone());
+            node.metadata
+                .insert("dom_id".to_string(), vertex.dom_id.clone());
             if let Some(vt) = &vertex.vertex_type {
-                node.metadata.insert("vertex_type".to_string(), format!("{:?}", vt));
+                node.metadata
+                    .insert("vertex_type".to_string(), format!("{:?}", vt));
             }
 
             graph.add_node(node);
@@ -52,9 +53,10 @@ impl ToLayoutGraph for FlowchartDb {
 
         // Convert edges
         for edge in self.edges() {
-            let edge_id = edge.id.clone().unwrap_or_else(|| {
-                format!("{}-{}", edge.start, edge.end)
-            });
+            let edge_id = edge
+                .id
+                .clone()
+                .unwrap_or_else(|| format!("{}-{}", edge.start, edge.end));
 
             let mut layout_edge = LayoutEdge::new(&edge_id, &edge.start, &edge.end);
 
@@ -69,9 +71,13 @@ impl ToLayoutGraph for FlowchartDb {
 
             // Store edge type for rendering
             if let Some(et) = &edge.edge_type {
-                layout_edge.metadata.insert("edge_type".to_string(), et.clone());
+                layout_edge
+                    .metadata
+                    .insert("edge_type".to_string(), et.clone());
             }
-            layout_edge.metadata.insert("stroke".to_string(), format!("{:?}", edge.stroke));
+            layout_edge
+                .metadata
+                .insert("stroke".to_string(), format!("{:?}", edge.stroke));
 
             graph.add_edge(layout_edge);
         }
@@ -172,15 +178,28 @@ mod tests {
         let graph = db.to_layout_graph(&estimator).unwrap();
 
         eprintln!("Before layout:");
-        eprintln!("  Nodes: {:?}", graph.nodes.iter().map(|n| &n.id).collect::<Vec<_>>());
-        eprintln!("  Edges: {:?}", graph.edges.iter().map(|e| (&e.id, &e.sources, &e.targets)).collect::<Vec<_>>());
+        eprintln!(
+            "  Nodes: {:?}",
+            graph.nodes.iter().map(|n| &n.id).collect::<Vec<_>>()
+        );
+        eprintln!(
+            "  Edges: {:?}",
+            graph
+                .edges
+                .iter()
+                .map(|e| (&e.id, &e.sources, &e.targets))
+                .collect::<Vec<_>>()
+        );
 
         // Run layout
         let graph = layout::layout(graph).unwrap();
 
         eprintln!("\nAfter layout:");
         for edge in &graph.edges {
-            eprintln!("  Edge {} ({:?} -> {:?}):", edge.id, edge.sources, edge.targets);
+            eprintln!(
+                "  Edge {} ({:?} -> {:?}):",
+                edge.id, edge.sources, edge.targets
+            );
             eprintln!("    bend_points: {:?}", edge.bend_points);
             eprintln!("    label_position: {:?}", edge.label_position);
         }

--- a/src/render/gantt.rs
+++ b/src/render/gantt.rs
@@ -128,7 +128,7 @@ pub fn render_gantt(db: &mut GanttDb, config: &RenderConfig) -> Result<String> {
     let section_colors = [
         "rgba(102, 102, 255, 0.49)", // section0 - purple
         "rgba(255, 255, 255, 0.2)",  // section1 - white with opacity
-        "#fff400",                    // section2 - yellow
+        "#fff400",                   // section2 - yellow
         "rgba(255, 255, 255, 0.2)",  // section3 - white with opacity
     ];
 
@@ -317,13 +317,17 @@ fn render_timeline_axis(
         y1: y + height,
         x2: x + width,
         y2: y + height,
-        attrs: Attrs::new()
-            .with_stroke("#333333")
-            .with_stroke_width(1.0),
+        attrs: Attrs::new().with_stroke("#333333").with_stroke_width(1.0),
     });
 
     // Grid lines and day markers
-    let tick_interval = if days > 30 { 7 } else if days > 14 { 2 } else { 1 };
+    let tick_interval = if days > 30 {
+        7
+    } else if days > 14 {
+        2
+    } else {
+        1
+    };
 
     if let Some(start) = start_date {
         use chrono::Datelike;
@@ -352,9 +356,7 @@ fn render_timeline_axis(
                 y1: y + height - 5.0,
                 x2: tick_x,
                 y2: y + height,
-                attrs: Attrs::new()
-                    .with_stroke("#333333")
-                    .with_stroke_width(1.0),
+                attrs: Attrs::new().with_stroke("#333333").with_stroke_width(1.0),
             });
 
             // Date label (YYYY-MM-DD format like mermaid.js)

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -35,9 +35,10 @@ pub fn render_with_config(diagram: &Diagram, config: &RenderConfig) -> Result<St
             let mut db_clone = db.clone();
             gantt::render_gantt(&mut db_clone, config)
         }
-        _ => Err(MermaidError::RenderError(
-            format!("Diagram type {:?} not yet supported for rendering", diagram_type_name(diagram)),
-        )),
+        _ => Err(MermaidError::RenderError(format!(
+            "Diagram type {:?} not yet supported for rendering",
+            diagram_type_name(diagram)
+        ))),
     }
 }
 

--- a/src/render/pie.rs
+++ b/src/render/pie.rs
@@ -11,12 +11,12 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
     let mut doc = SvgDocument::new();
 
     // Default pie chart dimensions (sized to match mermaid.js)
-    let radius = 185.0;  // mermaid.js uses 185
+    let radius = 185.0; // mermaid.js uses 185
     let pie_diameter = radius * 2.0;
-    let pie_width = pie_diameter + 50.0;  // Space for pie + padding
-    let legend_width = 180.0;  // Space for legend
+    let pie_width = pie_diameter + 50.0; // Space for pie + padding
+    let legend_width = 180.0; // Space for legend
     let width = pie_width + legend_width;
-    let height = 450.0;  // mermaid.js uses 450
+    let height = 450.0; // mermaid.js uses 450
     let cx = pie_width / 2.0; // center x (in pie area)
     let cy = height / 2.0; // center y
 
@@ -83,14 +83,18 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
     let mut start_angle = -PI / 2.0; // Start at top (12 o'clock)
 
     // Title offset
-    let title_height = if db.get_diagram_title().is_some() { 40.0 } else { 0.0 };
+    let title_height = if db.get_diagram_title().is_some() {
+        40.0
+    } else {
+        0.0
+    };
     let pie_cy = cy + title_height / 2.0;
 
     // Legend dimensions (positioned to the right of the pie)
     let legend_x = pie_width + 10.0;
-    let legend_y = height / 2.0 - 50.0;  // Vertically centered
+    let legend_y = height / 2.0 - 50.0; // Vertically centered
     let legend_item_height = 22.0;
-    let legend_box_size = 18.0;  // mermaid.js uses 18x18
+    let legend_box_size = 18.0; // mermaid.js uses 18x18
 
     // Render title
     if let Some(title) = db.get_diagram_title() {
@@ -139,11 +143,15 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
         // Create pie slice path
         let path = format!(
             "M {} {} L {} {} A {} {} 0 {} 1 {} {} Z",
-            cx, pie_cy, // Move to center
-            x1, y1,     // Line to start of arc
-            radius, radius, // Arc radii
-            large_arc,  // Large arc flag
-            x2, y2      // End of arc
+            cx,
+            pie_cy, // Move to center
+            x1,
+            y1, // Line to start of arc
+            radius,
+            radius,    // Arc radii
+            large_arc, // Large arc flag
+            x2,
+            y2 // End of arc
         );
 
         // Use color based on ORIGINAL input order, not sorted order
@@ -161,9 +169,10 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
         doc.add_element(slice);
 
         // Add percentage label inside slice (for larger slices)
-        if percentage >= 0.05 {  // Only show if slice is at least 5%
+        if percentage >= 0.05 {
+            // Only show if slice is at least 5%
             let mid_angle = start_angle + angle / 2.0;
-            let label_radius = radius * 0.75;  // Position inside slice (mermaid.js uses ~0.75)
+            let label_radius = radius * 0.75; // Position inside slice (mermaid.js uses ~0.75)
             let label_x = cx + label_radius * mid_angle.cos();
             let label_y = pie_cy + label_radius * mid_angle.sin();
 
@@ -195,7 +204,13 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
         .collect();
 
     // Render legend
-    let legend_group = render_legend(&legend_items, legend_x, legend_y, legend_item_height, legend_box_size);
+    let legend_group = render_legend(
+        &legend_items,
+        legend_x,
+        legend_y,
+        legend_item_height,
+        legend_box_size,
+    );
     doc.add_element(legend_group);
 
     Ok(doc.to_string())
@@ -203,7 +218,7 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
 
 /// Render a legend for the pie chart
 fn render_legend(
-    items: &[(String, String, f64)],  // (color, label, percentage)
+    items: &[(String, String, f64)], // (color, label, percentage)
     x: f64,
     y: f64,
     item_height: f64,
@@ -232,7 +247,7 @@ fn render_legend(
         // mermaid.js uses x="22" relative to rect x (i.e., box_size + 4)
         children.push(SvgElement::Text {
             x: x + box_size + 4.0,
-            y: item_y + 14.0,  // mermaid.js uses y="14" relative to rect
+            y: item_y + 14.0, // mermaid.js uses y="14" relative to rect
             content: label.clone(),
             attrs: Attrs::new()
                 .with_class("legend")

--- a/src/render/sequence.rs
+++ b/src/render/sequence.rs
@@ -10,12 +10,12 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
 
     // Layout constants (matching mermaid.js default theme)
     let actor_spacing = 200.0;
-    let actor_width = 150.0;  // mermaid.js uses 150
-    let actor_height = 65.0;  // mermaid.js uses 65
-    let message_spacing = 44.0;  // mermaid.js uses ~44px
-    let margin_top = 10.0;  // Small top margin (viewBox offset handles visual padding)
-    let _margin_left = 0.0;  // No left margin (handled by viewBox offset)
-    let actor_box_padding = 0.0;  // No padding - full width box
+    let actor_width = 150.0; // mermaid.js uses 150
+    let actor_height = 65.0; // mermaid.js uses 65
+    let message_spacing = 44.0; // mermaid.js uses ~44px
+    let margin_top = 10.0; // Small top margin (viewBox offset handles visual padding)
+    let _margin_left = 0.0; // No left margin (handled by viewBox offset)
+    let actor_box_padding = 0.0; // No padding - full width box
 
     // Get actors in order
     let actors = db.get_actors_in_order();
@@ -47,11 +47,11 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
         + message_spacing  // Gap before first message
         + (messages.len() as f64) * message_spacing  // Messages
         + 20.0  // Gap after last message to bottom actor
-        + actor_height;  // Bottom actor
+        + actor_height; // Bottom actor
 
     // Add visual padding via width/viewBox (mermaid.js style)
-    let width = content_width + 100.0;  // Total viewBox width with padding
-    let height = content_height + 20.0;  // Total viewBox height with padding
+    let width = content_width + 100.0; // Total viewBox width with padding
+    let height = content_height + 20.0; // Total viewBox height with padding
 
     doc.set_size(width, height);
 
@@ -69,7 +69,11 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
     ]);
 
     // Title offset
-    let title_offset = if !db.diagram_title.is_empty() { 40.0 } else { 0.0 };
+    let title_offset = if !db.diagram_title.is_empty() {
+        40.0
+    } else {
+        0.0
+    };
 
     // Render title
     if !db.diagram_title.is_empty() {
@@ -87,17 +91,19 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
     }
 
     // Calculate actor positions (with padding offset for visual alignment)
-    let padding_x = 50.0;  // Horizontal padding offset
-    let padding_y = margin_top;  // Vertical padding offset
+    let padding_x = 50.0; // Horizontal padding offset
+    let padding_y = margin_top; // Vertical padding offset
 
     let actor_y = padding_y + title_offset;
     let lifeline_start_y = actor_y + actor_height;
     // Bottom actor position: after all messages + 20px gap
-    let bottom_actor_y = lifeline_start_y + message_spacing + (messages.len() as f64) * message_spacing + 20.0;
+    let bottom_actor_y =
+        lifeline_start_y + message_spacing + (messages.len() as f64) * message_spacing + 20.0;
     let lifeline_end_y = bottom_actor_y;
 
     // Create actor position map
-    let mut actor_positions: std::collections::HashMap<String, f64> = std::collections::HashMap::new();
+    let mut actor_positions: std::collections::HashMap<String, f64> =
+        std::collections::HashMap::new();
     for (i, actor) in actors.iter().enumerate() {
         let x = padding_x + (i as f64) * actor_spacing + actor_width / 2.0;
         actor_positions.insert(actor.name.clone(), x);
@@ -156,7 +162,9 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
         }
 
         if let (Some(from), Some(to)) = (&message.from, &message.to) {
-            if let (Some(&from_x), Some(&to_x)) = (actor_positions.get(from), actor_positions.get(to)) {
+            if let (Some(&from_x), Some(&to_x)) =
+                (actor_positions.get(from), actor_positions.get(to))
+            {
                 let msg_element = render_message(
                     from_x,
                     to_x,
@@ -353,8 +361,8 @@ fn render_actor(
                 rx: Some(3.0),
                 ry: Some(3.0),
                 attrs: Attrs::new()
-                    .with_fill("#eaeaea")  // mermaid.js gray
-                    .with_stroke("#666")    // mermaid.js stroke
+                    .with_fill("#eaeaea") // mermaid.js gray
+                    .with_stroke("#666") // mermaid.js stroke
                     .with_stroke_width(1.0)
                     .with_class("actor actor-box"),
             });
@@ -380,13 +388,7 @@ fn render_actor(
 }
 
 /// Render a message between two actors
-fn render_message(
-    from_x: f64,
-    to_x: f64,
-    y: f64,
-    label: &str,
-    msg_type: LineType,
-) -> SvgElement {
+fn render_message(from_x: f64, to_x: f64, y: f64, label: &str, msg_type: LineType) -> SvgElement {
     let mut children = Vec::new();
 
     let (is_dotted, marker_id) = match msg_type {

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use crate::diagrams::state::{Direction, NotePosition, State, StateDb, StateType};
 use crate::error::Result;
 use crate::layout::{
-    layout, CharacterSizeEstimator, LayoutDirection, LayoutEdge, LayoutGraph,
-    LayoutNode, LayoutOptions, NodeShape, NodeSizeConfig, Padding, SizeEstimator, ToLayoutGraph,
+    layout, CharacterSizeEstimator, LayoutDirection, LayoutEdge, LayoutGraph, LayoutNode,
+    LayoutOptions, NodeShape, NodeSizeConfig, Padding, SizeEstimator, ToLayoutGraph,
 };
 use crate::render::svg::{Attrs, RenderConfig, SvgDocument, SvgElement};
 
@@ -62,7 +62,9 @@ impl ToLayoutGraph for StateDb {
             };
 
             let label_text = label.unwrap_or(if id.starts_with("[*]") { "" } else { &state.id });
-            let (width, height) = if id.starts_with("[*]") || matches!(state.state_type, StateType::Start | StateType::End) {
+            let (width, height) = if id.starts_with("[*]")
+                || matches!(state.state_type, StateType::Start | StateType::End)
+            {
                 // Small fixed size for start/end circles
                 (24.0, 24.0)
             } else if matches!(state.state_type, StateType::Fork | StateType::Join) {
@@ -78,7 +80,8 @@ impl ToLayoutGraph for StateDb {
             }
 
             // Store state type in metadata
-            node.metadata.insert("state_type".to_string(), format!("{:?}", state.state_type));
+            node.metadata
+                .insert("state_type".to_string(), format!("{:?}", state.state_type));
 
             graph.add_node(node);
         }
@@ -154,7 +157,11 @@ pub fn render_state(db: &StateDb, config: &RenderConfig) -> Result<String> {
     }
 
     // Title offset
-    let title_offset = if !db.diagram_title.is_empty() { 40.0 } else { 0.0 };
+    let title_offset = if !db.diagram_title.is_empty() {
+        40.0
+    } else {
+        0.0
+    };
 
     // Calculate diagram bounds
     let max_width = layout_result.width.unwrap_or(400.0) + margin * 2.0;
@@ -273,9 +280,7 @@ fn render_state_node(
                 cx: x + width / 2.0,
                 cy: y + height / 2.0,
                 r: start_end_radius,
-                attrs: Attrs::new()
-                    .with_fill("#333333")
-                    .with_class("state-start"),
+                attrs: Attrs::new().with_fill("#333333").with_class("state-start"),
             });
         }
         StateType::End => {
@@ -303,10 +308,22 @@ fn render_state_node(
 
             children.push(SvgElement::Polygon {
                 points: vec![
-                    crate::layout::Point { x: cx, y: cy - size },
-                    crate::layout::Point { x: cx + size, y: cy },
-                    crate::layout::Point { x: cx, y: cy + size },
-                    crate::layout::Point { x: cx - size, y: cy },
+                    crate::layout::Point {
+                        x: cx,
+                        y: cy - size,
+                    },
+                    crate::layout::Point {
+                        x: cx + size,
+                        y: cy,
+                    },
+                    crate::layout::Point {
+                        x: cx,
+                        y: cy + size,
+                    },
+                    crate::layout::Point {
+                        x: cx - size,
+                        y: cy,
+                    },
                 ],
                 attrs: Attrs::new()
                     .with_fill("#ECECFF")
@@ -341,9 +358,7 @@ fn render_state_node(
                         cx: x + width / 2.0,
                         cy: y + height / 2.0,
                         r: start_end_radius,
-                        attrs: Attrs::new()
-                            .with_fill("#333333")
-                            .with_class("state-start"),
+                        attrs: Attrs::new().with_fill("#333333").with_class("state-start"),
                     });
                 }
             } else {
@@ -499,7 +514,10 @@ fn calculate_exit_point(
             let dy = target_y - cy;
             let dist = (dx * dx + dy * dy).sqrt();
             if dist > 0.0 {
-                (cx + dx / dist * start_end_radius, cy + dy / dist * start_end_radius)
+                (
+                    cx + dx / dist * start_end_radius,
+                    cy + dy / dist * start_end_radius,
+                )
             } else {
                 (cx + start_end_radius, cy)
             }
@@ -545,7 +563,10 @@ fn calculate_entry_point(
             let dy = source_y - cy;
             let dist = (dx * dx + dy * dy).sqrt();
             if dist > 0.0 {
-                (cx + dx / dist * start_end_radius, cy + dy / dist * start_end_radius)
+                (
+                    cx + dx / dist * start_end_radius,
+                    cy + dy / dist * start_end_radius,
+                )
             } else {
                 (cx - start_end_radius, cy)
             }
@@ -683,7 +704,12 @@ fn determine_start_end_states(db: &StateDb) -> HashMap<&str, StartEndInfo> {
             let is_target = relations.iter().any(|r| r.state2 == "[*]");
 
             // Start if it's only a source, end if it's only a target or both
-            result.insert("[*]", StartEndInfo { is_start: is_source && !is_target });
+            result.insert(
+                "[*]",
+                StartEndInfo {
+                    is_start: is_source && !is_target,
+                },
+            );
         }
     }
 

--- a/src/render/svg/document.rs
+++ b/src/render/svg/document.rs
@@ -155,8 +155,7 @@ impl SvgDocument {
 
     /// Render a container group with elements
     fn render_container_group(&self, result: &mut String, class: &str, elements: &[SvgElement]) {
-        let group = SvgElement::group(elements.to_vec())
-            .with_attrs(Attrs::new().with_class(class));
+        let group = SvgElement::group(elements.to_vec()).with_attrs(Attrs::new().with_class(class));
         result.push_str(&group.to_svg(2));
         result.push('\n');
     }

--- a/src/render/svg/edges.rs
+++ b/src/render/svg/edges.rs
@@ -16,16 +16,18 @@ pub struct EdgeRenderResult {
 }
 
 /// Render an edge with separate path and label for container groups
-pub fn render_edge_parts(layout_edge: &LayoutEdge, flow_edge: &FlowEdge, _theme: &Theme) -> EdgeRenderResult {
+pub fn render_edge_parts(
+    layout_edge: &LayoutEdge,
+    flow_edge: &FlowEdge,
+    _theme: &Theme,
+) -> EdgeRenderResult {
     let edge_id = &layout_edge.id;
 
     // Build edge path
     let path = if !layout_edge.bend_points.is_empty() {
         let path_d = build_curved_path(&layout_edge.bend_points);
 
-        let mut attrs = Attrs::new()
-            .with_class("edge-path")
-            .with_fill("none");
+        let mut attrs = Attrs::new().with_class("edge-path").with_fill("none");
 
         // Apply stroke style
         match flow_edge.stroke {
@@ -36,9 +38,7 @@ pub fn render_edge_parts(layout_edge: &LayoutEdge, flow_edge: &FlowEdge, _theme:
                 attrs = attrs.with_stroke_width(3.5);
             }
             EdgeStroke::Dotted => {
-                attrs = attrs
-                    .with_stroke_width(2.0)
-                    .with_stroke_dasharray("3,3");
+                attrs = attrs.with_stroke_width(2.0).with_stroke_dasharray("3,3");
             }
             EdgeStroke::Invisible => {
                 attrs = attrs.with_stroke_width(0.0);
@@ -49,7 +49,9 @@ pub fn render_edge_parts(layout_edge: &LayoutEdge, flow_edge: &FlowEdge, _theme:
         if let Some(marker_url) = markers::get_marker_url(flow_edge.edge_type.as_deref()) {
             attrs = attrs.with_attr("marker-end", &marker_url);
         }
-        if let Some(start_marker_url) = markers::get_start_marker_url(flow_edge.edge_type.as_deref()) {
+        if let Some(start_marker_url) =
+            markers::get_start_marker_url(flow_edge.edge_type.as_deref())
+        {
             attrs = attrs.with_attr("marker-start", &start_marker_url);
         }
 
@@ -95,8 +97,7 @@ pub fn render_edge_parts(layout_edge: &LayoutEdge, flow_edge: &FlowEdge, _theme:
                 .with_attr("dominant-baseline", "central");
 
             label_elements.push(
-                SvgElement::text(label_pos.x, label_pos.y, &flow_edge.text)
-                    .with_attrs(label_attrs),
+                SvgElement::text(label_pos.x, label_pos.y, &flow_edge.text).with_attrs(label_attrs),
             );
 
             let group_attrs = Attrs::new()
@@ -146,7 +147,10 @@ fn build_curved_path(points: &[crate::layout::Point]) -> String {
 
     if points.len() == 2 {
         // For 2 points, use a straight line
-        return format!("M {} {} L {} {}", points[0].x, points[0].y, points[1].x, points[1].y);
+        return format!(
+            "M {} {} L {} {}",
+            points[0].x, points[0].y, points[1].x, points[1].y
+        );
     }
 
     // Use basis spline interpolation (like d3's curveBasis)
@@ -184,14 +188,20 @@ fn build_basis_path(points: &[crate::layout::Point]) -> String {
         let y2 = (points[0].y + 2.0 * points[1].y) / 3.0;
         let x3 = (points[0].x + 4.0 * points[1].x + points[2].x) / 6.0;
         let y3 = (points[0].y + 4.0 * points[1].y + points[2].y) / 6.0;
-        d.push_str(&format!(" C {:.2} {:.2}, {:.2} {:.2}, {:.2} {:.2}", x1, y1, x2, y2, x3, y3));
+        d.push_str(&format!(
+            " C {:.2} {:.2}, {:.2} {:.2}, {:.2} {:.2}",
+            x1, y1, x2, y2, x3, y3
+        ));
 
         // Finish to end point
         let x4 = (2.0 * points[1].x + points[2].x) / 3.0;
         let y4 = (2.0 * points[1].y + points[2].y) / 3.0;
         let x5 = (points[1].x + 2.0 * points[2].x) / 3.0;
         let y5 = (points[1].y + 2.0 * points[2].y) / 3.0;
-        d.push_str(&format!(" C {:.2} {:.2}, {:.2} {:.2}, {:.2} {:.2}", x4, y4, x5, y5, points[2].x, points[2].y));
+        d.push_str(&format!(
+            " C {:.2} {:.2}, {:.2} {:.2}, {:.2} {:.2}",
+            x4, y4, x5, y5, points[2].x, points[2].y
+        ));
         return d;
     }
 
@@ -203,7 +213,10 @@ fn build_basis_path(points: &[crate::layout::Point]) -> String {
     let y2 = (points[0].y + 2.0 * points[1].y) / 3.0;
     let x3 = (points[0].x + 4.0 * points[1].x + points[2].x) / 6.0;
     let y3 = (points[0].y + 4.0 * points[1].y + points[2].y) / 6.0;
-    d.push_str(&format!(" C {:.2} {:.2}, {:.2} {:.2}, {:.2} {:.2}", x1, y1, x2, y2, x3, y3));
+    d.push_str(&format!(
+        " C {:.2} {:.2}, {:.2} {:.2}, {:.2} {:.2}",
+        x1, y1, x2, y2, x3, y3
+    ));
 
     // Middle segments (cubic)
     for i in 2..n - 1 {
@@ -219,7 +232,10 @@ fn build_basis_path(points: &[crate::layout::Point]) -> String {
         let x3 = (p1.x + 4.0 * p2.x + p3.x) / 6.0;
         let y3 = (p1.y + 4.0 * p2.y + p3.y) / 6.0;
 
-        d.push_str(&format!(" C {:.2} {:.2}, {:.2} {:.2}, {:.2} {:.2}", x1, y1, x2, y2, x3, y3));
+        d.push_str(&format!(
+            " C {:.2} {:.2}, {:.2} {:.2}, {:.2} {:.2}",
+            x1, y1, x2, y2, x3, y3
+        ));
     }
 
     // Last segment (end at final point)
@@ -227,8 +243,10 @@ fn build_basis_path(points: &[crate::layout::Point]) -> String {
     let p_prev = &points[n - 2];
     let x1 = (p_prev.x + 2.0 * p_last.x) / 3.0;
     let y1 = (p_prev.y + 2.0 * p_last.y) / 3.0;
-    d.push_str(&format!(" C {:.2} {:.2}, {:.2} {:.2}, {:.2} {:.2}",
-                       x1, y1, p_last.x, p_last.y, p_last.x, p_last.y));
+    d.push_str(&format!(
+        " C {:.2} {:.2}, {:.2} {:.2}, {:.2} {:.2}",
+        x1, y1, p_last.x, p_last.y, p_last.x, p_last.y
+    ));
 
     d
 }
@@ -279,16 +297,16 @@ mod tests {
         );
         // Should NOT be all straight lines
         let l_count = path.matches(" L ").count();
-        assert!(l_count < points.len() - 1, "Curved path should not use only L commands");
+        assert!(
+            l_count < points.len() - 1,
+            "Curved path should not use only L commands"
+        );
     }
 
     #[test]
     fn test_build_curved_path_two_points() {
         // With only two points, should be a straight line (no curve possible)
-        let points = vec![
-            Point::new(0.0, 0.0),
-            Point::new(100.0, 100.0),
-        ];
+        let points = vec![Point::new(0.0, 0.0), Point::new(100.0, 100.0)];
 
         let path = build_curved_path(&points);
         assert!(path.starts_with("M"));
@@ -297,7 +315,7 @@ mod tests {
 
     #[test]
     fn test_edge_label_has_background_rect() {
-        use crate::diagrams::flowchart::{FlowEdge, EdgeStroke, FlowTextType};
+        use crate::diagrams::flowchart::{EdgeStroke, FlowEdge, FlowTextType};
         use std::collections::HashMap;
 
         let layout_edge = LayoutEdge {
@@ -305,10 +323,7 @@ mod tests {
             sources: vec!["a".to_string()],
             targets: vec!["b".to_string()],
             label: Some("label".to_string()),
-            bend_points: vec![
-                Point::new(0.0, 0.0),
-                Point::new(100.0, 100.0),
-            ],
+            bend_points: vec![Point::new(0.0, 0.0), Point::new(100.0, 100.0)],
             label_position: Some(Point::new(50.0, 50.0)),
             weight: 1,
             reversed: false,

--- a/src/render/svg/elements.rs
+++ b/src/render/svg/elements.rs
@@ -33,7 +33,8 @@ impl Attrs {
     }
 
     pub fn with_transform(mut self, transform: &str) -> Self {
-        self.attrs.insert("transform".to_string(), transform.to_string());
+        self.attrs
+            .insert("transform".to_string(), transform.to_string());
         self
     }
 
@@ -48,12 +49,14 @@ impl Attrs {
     }
 
     pub fn with_stroke_width(mut self, width: f64) -> Self {
-        self.attrs.insert("stroke-width".to_string(), format!("{}", width));
+        self.attrs
+            .insert("stroke-width".to_string(), format!("{}", width));
         self
     }
 
     pub fn with_stroke_dasharray(mut self, dasharray: &str) -> Self {
-        self.attrs.insert("stroke-dasharray".to_string(), dasharray.to_string());
+        self.attrs
+            .insert("stroke-dasharray".to_string(), dasharray.to_string());
         self
     }
 
@@ -111,15 +114,9 @@ pub enum SvgElement {
         attrs: Attrs,
     },
     /// Polygon element
-    Polygon {
-        points: Vec<Point>,
-        attrs: Attrs,
-    },
+    Polygon { points: Vec<Point>, attrs: Attrs },
     /// Path element
-    Path {
-        d: String,
-        attrs: Attrs,
-    },
+    Path { d: String, attrs: Attrs },
     /// Line element
     Line {
         x1: f64,
@@ -129,10 +126,7 @@ pub enum SvgElement {
         attrs: Attrs,
     },
     /// Polyline element
-    Polyline {
-        points: Vec<Point>,
-        attrs: Attrs,
-    },
+    Polyline { points: Vec<Point>, attrs: Attrs },
     /// Text element
     Text {
         x: f64,
@@ -146,9 +140,7 @@ pub enum SvgElement {
         attrs: Attrs,
     },
     /// Definitions element
-    Defs {
-        children: Vec<SvgElement>,
-    },
+    Defs { children: Vec<SvgElement> },
     /// Marker element
     Marker {
         id: String,
@@ -162,13 +154,9 @@ pub enum SvgElement {
         children: Vec<SvgElement>,
     },
     /// Style element (for embedded CSS)
-    Style {
-        content: String,
-    },
+    Style { content: String },
     /// Raw SVG content
-    Raw {
-        content: String,
-    },
+    Raw { content: String },
 }
 
 impl SvgElement {
@@ -253,33 +241,48 @@ impl SvgElement {
     /// Add attributes
     pub fn with_attrs(self, attrs: Attrs) -> Self {
         match self {
-            Self::Rect { x, y, width, height, rx, ry, .. } => {
-                Self::Rect { x, y, width, height, rx, ry, attrs }
-            }
-            Self::Circle { cx, cy, r, .. } => {
-                Self::Circle { cx, cy, r, attrs }
-            }
-            Self::Ellipse { cx, cy, rx, ry, .. } => {
-                Self::Ellipse { cx, cy, rx, ry, attrs }
-            }
-            Self::Polygon { points, .. } => {
-                Self::Polygon { points, attrs }
-            }
-            Self::Path { d, .. } => {
-                Self::Path { d, attrs }
-            }
-            Self::Line { x1, y1, x2, y2, .. } => {
-                Self::Line { x1, y1, x2, y2, attrs }
-            }
-            Self::Polyline { points, .. } => {
-                Self::Polyline { points, attrs }
-            }
-            Self::Text { x, y, content, .. } => {
-                Self::Text { x, y, content, attrs }
-            }
-            Self::Group { children, .. } => {
-                Self::Group { children, attrs }
-            }
+            Self::Rect {
+                x,
+                y,
+                width,
+                height,
+                rx,
+                ry,
+                ..
+            } => Self::Rect {
+                x,
+                y,
+                width,
+                height,
+                rx,
+                ry,
+                attrs,
+            },
+            Self::Circle { cx, cy, r, .. } => Self::Circle { cx, cy, r, attrs },
+            Self::Ellipse { cx, cy, rx, ry, .. } => Self::Ellipse {
+                cx,
+                cy,
+                rx,
+                ry,
+                attrs,
+            },
+            Self::Polygon { points, .. } => Self::Polygon { points, attrs },
+            Self::Path { d, .. } => Self::Path { d, attrs },
+            Self::Line { x1, y1, x2, y2, .. } => Self::Line {
+                x1,
+                y1,
+                x2,
+                y2,
+                attrs,
+            },
+            Self::Polyline { points, .. } => Self::Polyline { points, attrs },
+            Self::Text { x, y, content, .. } => Self::Text {
+                x,
+                y,
+                content,
+                attrs,
+            },
+            Self::Group { children, .. } => Self::Group { children, attrs },
             other => other,
         }
     }
@@ -289,24 +292,54 @@ impl SvgElement {
         let indent_str = "  ".repeat(indent);
 
         match self {
-            Self::Rect { x, y, width, height, rx, ry, attrs } => {
+            Self::Rect {
+                x,
+                y,
+                width,
+                height,
+                rx,
+                ry,
+                attrs,
+            } => {
                 let rx_str = rx.map(|v| format!(" rx=\"{}\"", v)).unwrap_or_default();
                 let ry_str = ry.map(|v| format!(" ry=\"{}\"", v)).unwrap_or_default();
                 format!(
                     "{}<rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\"{}{}{}/>",
-                    indent_str, x, y, width, height, rx_str, ry_str, attrs.to_string()
+                    indent_str,
+                    x,
+                    y,
+                    width,
+                    height,
+                    rx_str,
+                    ry_str,
+                    attrs.to_string()
                 )
             }
             Self::Circle { cx, cy, r, attrs } => {
                 format!(
                     "{}<circle cx=\"{}\" cy=\"{}\" r=\"{}\"{}/>",
-                    indent_str, cx, cy, r, attrs.to_string()
+                    indent_str,
+                    cx,
+                    cy,
+                    r,
+                    attrs.to_string()
                 )
             }
-            Self::Ellipse { cx, cy, rx, ry, attrs } => {
+            Self::Ellipse {
+                cx,
+                cy,
+                rx,
+                ry,
+                attrs,
+            } => {
                 format!(
                     "{}<ellipse cx=\"{}\" cy=\"{}\" rx=\"{}\" ry=\"{}\"{}/>",
-                    indent_str, cx, cy, rx, ry, attrs.to_string()
+                    indent_str,
+                    cx,
+                    cy,
+                    rx,
+                    ry,
+                    attrs.to_string()
                 )
             }
             Self::Polygon { points, attrs } => {
@@ -317,19 +350,29 @@ impl SvgElement {
                     .join(" ");
                 format!(
                     "{}<polygon points=\"{}\"{}/>",
-                    indent_str, points_str, attrs.to_string()
+                    indent_str,
+                    points_str,
+                    attrs.to_string()
                 )
             }
             Self::Path { d, attrs } => {
-                format!(
-                    "{}<path d=\"{}\"{}/>",
-                    indent_str, d, attrs.to_string()
-                )
+                format!("{}<path d=\"{}\"{}/>", indent_str, d, attrs.to_string())
             }
-            Self::Line { x1, y1, x2, y2, attrs } => {
+            Self::Line {
+                x1,
+                y1,
+                x2,
+                y2,
+                attrs,
+            } => {
                 format!(
                     "{}<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\"{}/>",
-                    indent_str, x1, y1, x2, y2, attrs.to_string()
+                    indent_str,
+                    x1,
+                    y1,
+                    x2,
+                    y2,
+                    attrs.to_string()
                 )
             }
             Self::Polyline { points, attrs } => {
@@ -340,13 +383,24 @@ impl SvgElement {
                     .join(" ");
                 format!(
                     "{}<polyline points=\"{}\"{}/>",
-                    indent_str, points_str, attrs.to_string()
+                    indent_str,
+                    points_str,
+                    attrs.to_string()
                 )
             }
-            Self::Text { x, y, content, attrs } => {
+            Self::Text {
+                x,
+                y,
+                content,
+                attrs,
+            } => {
                 format!(
                     "{}<text x=\"{}\" y=\"{}\"{}>{}</text>",
-                    indent_str, x, y, attrs.to_string(), escape_xml(content)
+                    indent_str,
+                    x,
+                    y,
+                    attrs.to_string(),
+                    escape_xml(content)
                 )
             }
             Self::Group { children, attrs } => {
@@ -357,7 +411,10 @@ impl SvgElement {
                     .join("\n");
                 format!(
                     "{}<g{}>\n{}\n{}</g>",
-                    indent_str, attrs.to_string(), children_str, indent_str
+                    indent_str,
+                    attrs.to_string(),
+                    children_str,
+                    indent_str
                 )
             }
             Self::Defs { children } => {

--- a/src/render/svg/markers.rs
+++ b/src/render/svg/markers.rs
@@ -12,7 +12,7 @@ pub fn create_arrow_markers(_theme: &Theme) -> Vec<SvgElement> {
         SvgElement::Marker {
             id: "arrow_point".to_string(),
             view_box: "0 0 10 10".to_string(),
-            ref_x: 10.0,  // Tip of arrow at line endpoint
+            ref_x: 10.0, // Tip of arrow at line endpoint
             ref_y: 5.0,
             marker_width: 8.0,
             marker_height: 8.0,
@@ -25,7 +25,7 @@ pub fn create_arrow_markers(_theme: &Theme) -> Vec<SvgElement> {
         SvgElement::Marker {
             id: "arrow_open".to_string(),
             view_box: "0 0 10 10".to_string(),
-            ref_x: 9.0,  // Tip of arrow at line endpoint
+            ref_x: 9.0, // Tip of arrow at line endpoint
             ref_y: 5.0,
             marker_width: 8.0,
             marker_height: 8.0,
@@ -41,11 +41,11 @@ pub fn create_arrow_markers(_theme: &Theme) -> Vec<SvgElement> {
         // Arrow cross (X shape) - like mermaid.js cross marker
         SvgElement::Marker {
             id: "arrow_cross".to_string(),
-            view_box: "0 0 11 11".to_string(),  // mermaid.js uses 11x11
-            ref_x: 12.0,  // mermaid.js uses refX: 12
-            ref_y: 5.2,   // mermaid.js uses refY: 5.2
-            marker_width: 11.0,  // mermaid.js uses 11
-            marker_height: 11.0, // mermaid.js uses 11
+            view_box: "0 0 11 11".to_string(), // mermaid.js uses 11x11
+            ref_x: 12.0,                       // mermaid.js uses refX: 12
+            ref_y: 5.2,                        // mermaid.js uses refY: 5.2
+            marker_width: 11.0,                // mermaid.js uses 11
+            marker_height: 11.0,               // mermaid.js uses 11
             orient: "auto".to_string(),
             marker_units: Some("userSpaceOnUse".to_string()),
             children: vec![SvgElement::Path {
@@ -59,19 +59,19 @@ pub fn create_arrow_markers(_theme: &Theme) -> Vec<SvgElement> {
         SvgElement::Marker {
             id: "arrow_circle".to_string(),
             view_box: "0 0 10 10".to_string(),
-            ref_x: 11.0,  // mermaid.js uses refX: 11 for circleEnd
+            ref_x: 11.0, // mermaid.js uses refX: 11 for circleEnd
             ref_y: 5.0,
             marker_width: 11.0,  // mermaid.js uses 11
             marker_height: 11.0, // mermaid.js uses 11
             orient: "auto".to_string(),
             marker_units: Some("userSpaceOnUse".to_string()),
-            children: vec![SvgElement::circle(5.0, 5.0, 5.0)],  // mermaid.js uses r=5
+            children: vec![SvgElement::circle(5.0, 5.0, 5.0)], // mermaid.js uses r=5
         },
         // Arrow circle start (filled circle) - like mermaid.js circleStart marker
         SvgElement::Marker {
             id: "arrow_circle_start".to_string(),
             view_box: "0 0 10 10".to_string(),
-            ref_x: -1.0,  // mermaid.js uses refX: -1 for circleStart
+            ref_x: -1.0, // mermaid.js uses refX: -1 for circleStart
             ref_y: 5.0,
             marker_width: 11.0,
             marker_height: 11.0,
@@ -84,7 +84,7 @@ pub fn create_arrow_markers(_theme: &Theme) -> Vec<SvgElement> {
         SvgElement::Marker {
             id: "double_arrow_point_start".to_string(),
             view_box: "0 0 10 10".to_string(),
-            ref_x: 0.0,  // Tip at x=0 should be at line start
+            ref_x: 0.0, // Tip at x=0 should be at line start
             ref_y: 5.0,
             marker_width: 8.0,
             marker_height: 8.0,
@@ -97,7 +97,7 @@ pub fn create_arrow_markers(_theme: &Theme) -> Vec<SvgElement> {
         SvgElement::Marker {
             id: "double_arrow_point_end".to_string(),
             view_box: "0 0 10 10".to_string(),
-            ref_x: 10.0,  // Tip at x=10 should be at line end
+            ref_x: 10.0, // Tip at x=10 should be at line end
             ref_y: 5.0,
             marker_width: 8.0,
             marker_height: 8.0,

--- a/src/render/svg/mod.rs
+++ b/src/render/svg/mod.rs
@@ -13,7 +13,7 @@ pub use elements::{Attrs, SvgElement};
 pub use structure::{CompareConfig, ComparisonResult, SvgStructure};
 pub use theme::Theme;
 
-use crate::diagrams::flowchart::{FlowchartDb, FlowSubGraph};
+use crate::diagrams::flowchart::{FlowSubGraph, FlowchartDb};
 use crate::error::Result;
 use crate::layout::LayoutGraph;
 
@@ -115,7 +115,11 @@ impl SvgRenderer {
 
     /// Calculate bounds for the flowchart including subgraph boxes
     /// Returns (min_x, min_y, width, height) for the viewBox
-    fn calculate_flowchart_bounds(&self, db: &FlowchartDb, graph: &LayoutGraph) -> (f64, f64, f64, f64) {
+    fn calculate_flowchart_bounds(
+        &self,
+        db: &FlowchartDb,
+        graph: &LayoutGraph,
+    ) -> (f64, f64, f64, f64) {
         let padding = self.config.padding;
         let subgraph_padding = 20.0;
         let title_height = 25.0;
@@ -282,9 +286,11 @@ mod tests {
         let (vb_x, vb_y, _vb_width, _vb_height) = (parts[0], parts[1], parts[2], parts[3]);
 
         // Extract subgraph rect bounds
-        let rect_re = regex::Regex::new(r#"class="cluster"[^/]*x="([^"]+)"[^/]*y="([^"]+)""#).unwrap();
+        let rect_re =
+            regex::Regex::new(r#"class="cluster"[^/]*x="([^"]+)"[^/]*y="([^"]+)""#).unwrap();
         // Try alternate attribute order
-        let rect_re2 = regex::Regex::new(r#"<rect x="([^"]+)" y="([^"]+)"[^>]*class="cluster""#).unwrap();
+        let rect_re2 =
+            regex::Regex::new(r#"<rect x="([^"]+)" y="([^"]+)"[^>]*class="cluster""#).unwrap();
 
         let (rect_x, rect_y) = rect_re
             .captures(&svg)
@@ -352,8 +358,12 @@ mod tests {
 
         // Verify order by checking that clusters appears before nodes in the SVG
         let clusters_pos = svg.find(r#"class="clusters""#).expect("clusters not found");
-        let edge_paths_pos = svg.find(r#"class="edgePaths""#).expect("edgePaths not found");
-        let edge_labels_pos = svg.find(r#"class="edgeLabels""#).expect("edgeLabels not found");
+        let edge_paths_pos = svg
+            .find(r#"class="edgePaths""#)
+            .expect("edgePaths not found");
+        let edge_labels_pos = svg
+            .find(r#"class="edgeLabels""#)
+            .expect("edgeLabels not found");
         let nodes_pos = svg.find(r#"class="nodes""#).expect("nodes not found");
 
         assert!(
@@ -397,7 +407,9 @@ mod tests {
         );
 
         // Extract rect bounds and text x position
-        let rect_re = regex::Regex::new(r#"<rect x="([^"]+)"[^>]*width="([^"]+)"[^>]*class="cluster""#).unwrap();
+        let rect_re =
+            regex::Regex::new(r#"<rect x="([^"]+)"[^>]*width="([^"]+)"[^>]*class="cluster""#)
+                .unwrap();
 
         // If we can find both, verify the text is approximately centered
         if let Some(rect_caps) = rect_re.captures(&svg) {
@@ -406,7 +418,8 @@ mod tests {
             let rect_center = rect_x + rect_width / 2.0;
 
             // Text x position should be near center (within 10% of width)
-            let text_x_re = regex::Regex::new(r#"<text x="([^"]+)"[^>]*class="cluster-label""#).unwrap();
+            let text_x_re =
+                regex::Regex::new(r#"<text x="([^"]+)"[^>]*class="cluster-label""#).unwrap();
             if let Some(text_caps) = text_x_re.captures(&svg) {
                 let text_x: f64 = text_caps.get(1).unwrap().as_str().parse().unwrap();
                 let tolerance = rect_width * 0.4; // 40% tolerance since left-aligned is clearly wrong

--- a/src/render/svg/shapes.rs
+++ b/src/render/svg/shapes.rs
@@ -15,12 +15,13 @@ pub fn render_shape(node: &LayoutNode, vertex: &FlowVertex, _theme: &Theme) -> S
     let cx = x + w / 2.0;
     let cy = y + h / 2.0;
 
-    let shape_type = vertex.vertex_type.as_ref().unwrap_or(&FlowVertexType::Square);
+    let shape_type = vertex
+        .vertex_type
+        .as_ref()
+        .unwrap_or(&FlowVertexType::Square);
 
     let shape = match shape_type {
-        FlowVertexType::Square | FlowVertexType::Rect => {
-            SvgElement::rect(x, y, w, h)
-        }
+        FlowVertexType::Square | FlowVertexType::Rect => SvgElement::rect(x, y, w, h),
         FlowVertexType::Round => {
             let rx = 5.0;
             SvgElement::rounded_rect(x, y, w, h, rx)
@@ -43,22 +44,20 @@ pub fn render_shape(node: &LayoutNode, vertex: &FlowVertex, _theme: &Theme) -> S
                 SvgElement::circle(cx, cy, inner_r),
             ])
         }
-        FlowVertexType::Ellipse => {
-            SvgElement::Ellipse {
-                cx,
-                cy,
-                rx: w / 2.0,
-                ry: h / 2.0,
-                attrs: Attrs::new(),
-            }
-        }
+        FlowVertexType::Ellipse => SvgElement::Ellipse {
+            cx,
+            cy,
+            rx: w / 2.0,
+            ry: h / 2.0,
+            attrs: Attrs::new(),
+        },
         FlowVertexType::Diamond => {
             // Diamond shape - rotated square
             let points = vec![
-                Point::new(cx, y),           // top
-                Point::new(x + w, cy),       // right
-                Point::new(cx, y + h),       // bottom
-                Point::new(x, cy),           // left
+                Point::new(cx, y),     // top
+                Point::new(x + w, cy), // right
+                Point::new(cx, y + h), // bottom
+                Point::new(x, cy),     // left
             ];
             SvgElement::polygon(points)
         }
@@ -66,12 +65,12 @@ pub fn render_shape(node: &LayoutNode, vertex: &FlowVertex, _theme: &Theme) -> S
             // Hexagon with flat top/bottom
             let inset = w * 0.15;
             let points = vec![
-                Point::new(x + inset, y),           // top-left
-                Point::new(x + w - inset, y),       // top-right
-                Point::new(x + w, cy),              // right
-                Point::new(x + w - inset, y + h),   // bottom-right
-                Point::new(x + inset, y + h),       // bottom-left
-                Point::new(x, cy),                  // left
+                Point::new(x + inset, y),         // top-left
+                Point::new(x + w - inset, y),     // top-right
+                Point::new(x + w, cy),            // right
+                Point::new(x + w - inset, y + h), // bottom-right
+                Point::new(x + inset, y + h),     // bottom-left
+                Point::new(x, cy),                // left
             ];
             SvgElement::polygon(points)
         }
@@ -85,12 +84,19 @@ pub fn render_shape(node: &LayoutNode, vertex: &FlowVertex, _theme: &Theme) -> S
                  l 0 {} \
                  a {} {} 0 0 0 {} 0 \
                  l 0 {}",
-                x, y + ry,           // Start at top-left of body
-                w / 2.0, ry, w,      // Top ellipse first arc
-                w / 2.0, ry, -w,     // Top ellipse second arc
-                h - ry * 2.0,        // Body height
-                w / 2.0, ry, w,      // Bottom ellipse
-                -(h - ry * 2.0)      // Back to top
+                x,
+                y + ry, // Start at top-left of body
+                w / 2.0,
+                ry,
+                w, // Top ellipse first arc
+                w / 2.0,
+                ry,
+                -w,           // Top ellipse second arc
+                h - ry * 2.0, // Body height
+                w / 2.0,
+                ry,
+                w,               // Bottom ellipse
+                -(h - ry * 2.0)  // Back to top
             );
             SvgElement::path(d)
         }
@@ -100,17 +106,17 @@ pub fn render_shape(node: &LayoutNode, vertex: &FlowVertex, _theme: &Theme) -> S
             let bar_offset = 10.0;
             let points = vec![
                 // Inner rectangle (main body)
-                Point::new(x + bar_offset, y),           // inner top-left
-                Point::new(x + w - bar_offset, y),       // inner top-right
-                Point::new(x + w - bar_offset, y + h),   // inner bottom-right
-                Point::new(x + bar_offset, y + h),       // inner bottom-left
-                Point::new(x + bar_offset, y),           // back to inner top-left
+                Point::new(x + bar_offset, y),         // inner top-left
+                Point::new(x + w - bar_offset, y),     // inner top-right
+                Point::new(x + w - bar_offset, y + h), // inner bottom-right
+                Point::new(x + bar_offset, y + h),     // inner bottom-left
+                Point::new(x + bar_offset, y),         // back to inner top-left
                 // Step out to outer rectangle
-                Point::new(x, y),                        // outer top-left
-                Point::new(x + w, y),                    // outer top-right
-                Point::new(x + w, y + h),                // outer bottom-right
-                Point::new(x, y + h),                    // outer bottom-left
-                Point::new(x, y),                        // close outer path
+                Point::new(x, y),         // outer top-left
+                Point::new(x + w, y),     // outer top-right
+                Point::new(x + w, y + h), // outer bottom-right
+                Point::new(x, y + h),     // outer bottom-left
+                Point::new(x, y),         // close outer path
             ];
             SvgElement::polygon(points)
         }
@@ -118,10 +124,10 @@ pub fn render_shape(node: &LayoutNode, vertex: &FlowVertex, _theme: &Theme) -> S
             // Trapezoid - wider at bottom
             let inset = w * 0.15;
             let points = vec![
-                Point::new(x + inset, y),           // top-left
-                Point::new(x + w - inset, y),       // top-right
-                Point::new(x + w, y + h),           // bottom-right
-                Point::new(x, y + h),               // bottom-left
+                Point::new(x + inset, y),     // top-left
+                Point::new(x + w - inset, y), // top-right
+                Point::new(x + w, y + h),     // bottom-right
+                Point::new(x, y + h),         // bottom-left
             ];
             SvgElement::polygon(points)
         }
@@ -129,10 +135,10 @@ pub fn render_shape(node: &LayoutNode, vertex: &FlowVertex, _theme: &Theme) -> S
             // Inverted trapezoid - wider at top
             let inset = w * 0.15;
             let points = vec![
-                Point::new(x, y),                   // top-left
-                Point::new(x + w, y),               // top-right
-                Point::new(x + w - inset, y + h),   // bottom-right
-                Point::new(x + inset, y + h),       // bottom-left
+                Point::new(x, y),                 // top-left
+                Point::new(x + w, y),             // top-right
+                Point::new(x + w - inset, y + h), // bottom-right
+                Point::new(x + inset, y + h),     // bottom-left
             ];
             SvgElement::polygon(points)
         }
@@ -140,10 +146,10 @@ pub fn render_shape(node: &LayoutNode, vertex: &FlowVertex, _theme: &Theme) -> S
             // Parallelogram leaning right
             let inset = w * 0.15;
             let points = vec![
-                Point::new(x + inset, y),           // top-left
-                Point::new(x + w, y),               // top-right
-                Point::new(x + w - inset, y + h),   // bottom-right
-                Point::new(x, y + h),               // bottom-left
+                Point::new(x + inset, y),         // top-left
+                Point::new(x + w, y),             // top-right
+                Point::new(x + w - inset, y + h), // bottom-right
+                Point::new(x, y + h),             // bottom-left
             ];
             SvgElement::polygon(points)
         }
@@ -151,10 +157,10 @@ pub fn render_shape(node: &LayoutNode, vertex: &FlowVertex, _theme: &Theme) -> S
             // Parallelogram leaning left
             let inset = w * 0.15;
             let points = vec![
-                Point::new(x, y),                   // top-left
-                Point::new(x + w - inset, y),       // top-right
-                Point::new(x + w, y + h),           // bottom-right
-                Point::new(x + inset, y + h),       // bottom-left
+                Point::new(x, y),             // top-left
+                Point::new(x + w - inset, y), // top-right
+                Point::new(x + w, y + h),     // bottom-right
+                Point::new(x + inset, y + h), // bottom-left
             ];
             SvgElement::polygon(points)
         }
@@ -162,11 +168,11 @@ pub fn render_shape(node: &LayoutNode, vertex: &FlowVertex, _theme: &Theme) -> S
             // Odd shape (flag-like) - rectangle with notch
             let notch = w * 0.15;
             let points = vec![
-                Point::new(x, y),                   // top-left
-                Point::new(x + w, y),               // top-right
-                Point::new(x + w - notch, cy),      // right notch
-                Point::new(x + w, y + h),           // bottom-right
-                Point::new(x, y + h),               // bottom-left
+                Point::new(x, y),              // top-left
+                Point::new(x + w, y),          // top-right
+                Point::new(x + w - notch, cy), // right notch
+                Point::new(x + w, y + h),      // bottom-right
+                Point::new(x, y + h),          // bottom-left
             ];
             SvgElement::polygon(points)
         }

--- a/src/render/svg/structure.rs
+++ b/src/render/svg/structure.rs
@@ -43,8 +43,8 @@ pub struct ShapeCounts {
 impl SvgStructure {
     /// Parse an SVG string and extract its structure
     pub fn from_svg(svg: &str) -> Result<Self, String> {
-        let doc = roxmltree::Document::parse(svg)
-            .map_err(|e| format!("Failed to parse SVG: {}", e))?;
+        let doc =
+            roxmltree::Document::parse(svg).map_err(|e| format!("Failed to parse SVG: {}", e))?;
 
         let root = doc.root_element();
         if root.tag_name().name() != "svg" {
@@ -232,7 +232,12 @@ impl SvgStructure {
 
         // Compare shape counts (if strict)
         if config.strict_shape_counts {
-            compare_shape_counts(&self.shapes, &expected.shapes, &mut differences, &mut score_parts);
+            compare_shape_counts(
+                &self.shapes,
+                &expected.shapes,
+                &mut differences,
+                &mut score_parts,
+            );
         }
 
         // Check for defs and style
@@ -324,7 +329,10 @@ fn count_nodes_and_edges(doc: &roxmltree::Document) -> (usize, usize) {
             let classes: Vec<&str> = class.split_whitespace().collect();
 
             // Count nodes - elements with "node" class (both implementations)
-            if classes.iter().any(|c| *c == "node" || *c == "flowchart-node") {
+            if classes
+                .iter()
+                .any(|c| *c == "node" || *c == "flowchart-node")
+            {
                 node_count += 1;
             }
 

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the rendering engine
 
-use mermaid::{parse, render, render_with_config};
 use mermaid::render::{RenderConfig, Theme};
+use mermaid::{parse, render, render_with_config};
 
 // ============================================================================
 // Output Format Tests (PNG/PDF)
@@ -21,28 +21,27 @@ mod png_output_tests {
         let svg = render(&diagram).expect("Failed to render");
 
         // Convert to PNG using resvg
-        use resvg::usvg;
         use resvg::tiny_skia;
+        use resvg::usvg;
 
         let mut opt = usvg::Options::default();
         opt.fontdb_mut().load_system_fonts();
 
-        let tree = usvg::Tree::from_str(&svg, &opt)
-            .expect("Failed to parse SVG");
+        let tree = usvg::Tree::from_str(&svg, &opt).expect("Failed to parse SVG");
 
         let size = tree.size();
-        let mut pixmap = tiny_skia::Pixmap::new(
-            size.width() as u32,
-            size.height() as u32,
-        ).expect("Failed to create pixmap");
+        let mut pixmap = tiny_skia::Pixmap::new(size.width() as u32, size.height() as u32)
+            .expect("Failed to create pixmap");
 
         resvg::render(&tree, tiny_skia::Transform::default(), &mut pixmap.as_mut());
 
         let png_data = pixmap.encode_png().expect("Failed to encode PNG");
 
         // Verify PNG header (magic bytes)
-        assert!(png_data.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
-            "Output should be valid PNG (check magic bytes)");
+        assert!(
+            png_data.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+            "Output should be valid PNG (check magic bytes)"
+        );
 
         // Should have reasonable size
         assert!(png_data.len() > 100, "PNG should have content");
@@ -57,8 +56,8 @@ mod png_output_tests {
         let diagram = parse(input).expect("Failed to parse");
         let svg = render(&diagram).expect("Failed to render");
 
-        use resvg::usvg;
         use resvg::tiny_skia;
+        use resvg::usvg;
 
         let mut opt = usvg::Options::default();
         opt.fontdb_mut().load_system_fonts();
@@ -71,8 +70,7 @@ mod png_output_tests {
         let width = (size.width() * scale) as u32;
         let height = (size.height() * scale) as u32;
 
-        let mut pixmap = tiny_skia::Pixmap::new(width, height)
-            .expect("Failed to create pixmap");
+        let mut pixmap = tiny_skia::Pixmap::new(width, height).expect("Failed to create pixmap");
 
         let transform = tiny_skia::Transform::from_scale(scale, scale);
         resvg::render(&tree, transform, &mut pixmap.as_mut());
@@ -95,8 +93,8 @@ mod png_output_tests {
         };
         let svg = render_with_config(&diagram, &config).expect("Failed to render");
 
-        use resvg::usvg;
         use resvg::tiny_skia;
+        use resvg::usvg;
 
         let mut opt = usvg::Options::default();
         opt.fontdb_mut().load_system_fonts();
@@ -104,16 +102,16 @@ mod png_output_tests {
         let tree = usvg::Tree::from_str(&svg, &opt).expect("Failed to parse SVG");
 
         let size = tree.size();
-        let mut pixmap = tiny_skia::Pixmap::new(
-            size.width() as u32,
-            size.height() as u32,
-        ).expect("Failed to create pixmap");
+        let mut pixmap = tiny_skia::Pixmap::new(size.width() as u32, size.height() as u32)
+            .expect("Failed to create pixmap");
 
         resvg::render(&tree, tiny_skia::Transform::default(), &mut pixmap.as_mut());
 
         let png_data = pixmap.encode_png().expect("Failed to encode PNG");
-        assert!(png_data.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
-            "Dark theme should produce valid PNG");
+        assert!(
+            png_data.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
+            "Dark theme should produce valid PNG"
+        );
     }
 }
 
@@ -135,18 +133,20 @@ mod pdf_output_tests {
         let mut opt = usvg::Options::default();
         opt.fontdb_mut().load_system_fonts();
 
-        let tree = usvg::Tree::from_str(&svg, &opt)
-            .expect("Failed to parse SVG");
+        let tree = usvg::Tree::from_str(&svg, &opt).expect("Failed to parse SVG");
 
         let pdf_data = svg2pdf::to_pdf(
             &tree,
             svg2pdf::ConversionOptions::default(),
             svg2pdf::PageOptions::default(),
-        ).expect("Failed to convert to PDF");
+        )
+        .expect("Failed to convert to PDF");
 
         // Verify PDF header
-        assert!(pdf_data.starts_with(b"%PDF-"),
-            "Output should be valid PDF (check header)");
+        assert!(
+            pdf_data.starts_with(b"%PDF-"),
+            "Output should be valid PDF (check header)"
+        );
 
         // Should have reasonable size
         assert!(pdf_data.len() > 100, "PDF should have content");
@@ -156,14 +156,23 @@ mod pdf_output_tests {
     #[test]
     fn test_pdf_with_different_diagrams() {
         let diagrams = [
-            ("flowchart", r#"flowchart TB
-                A --> B --> C"#),
-            ("pie", r#"pie title Test
+            (
+                "flowchart",
+                r#"flowchart TB
+                A --> B --> C"#,
+            ),
+            (
+                "pie",
+                r#"pie title Test
                 "A" : 50
-                "B" : 50"#),
-            ("state", r#"stateDiagram-v2
+                "B" : 50"#,
+            ),
+            (
+                "state",
+                r#"stateDiagram-v2
                 [*] --> Active
-                Active --> [*]"#),
+                Active --> [*]"#,
+            ),
         ];
 
         for (name, input) in diagrams {
@@ -175,17 +184,21 @@ mod pdf_output_tests {
             let mut opt = usvg::Options::default();
             opt.fontdb_mut().load_system_fonts();
 
-            let tree = usvg::Tree::from_str(&svg, &opt)
-                .expect(&format!("Failed to parse {} SVG", name));
+            let tree =
+                usvg::Tree::from_str(&svg, &opt).expect(&format!("Failed to parse {} SVG", name));
 
             let pdf_data = svg2pdf::to_pdf(
                 &tree,
                 svg2pdf::ConversionOptions::default(),
                 svg2pdf::PageOptions::default(),
-            ).expect(&format!("Failed to convert {} to PDF", name));
+            )
+            .expect(&format!("Failed to convert {} to PDF", name));
 
-            assert!(pdf_data.starts_with(b"%PDF-"),
-                "{} should produce valid PDF", name);
+            assert!(
+                pdf_data.starts_with(b"%PDF-"),
+                "{} should produce valid PDF",
+                name
+            );
         }
     }
 }
@@ -206,11 +219,17 @@ fn test_simple_flowchart_renders_to_svg() {
     // Verify basic SVG structure
     assert!(svg.contains("<svg"), "SVG should have opening tag");
     assert!(svg.contains("</svg>"), "SVG should have closing tag");
-    assert!(svg.contains("xmlns=\"http://www.w3.org/2000/svg\""), "SVG should have namespace");
+    assert!(
+        svg.contains("xmlns=\"http://www.w3.org/2000/svg\""),
+        "SVG should have namespace"
+    );
 
     // Verify node labels are present
     assert!(svg.contains("Start"), "SVG should contain 'Start' label");
-    assert!(svg.contains("Process"), "SVG should contain 'Process' label");
+    assert!(
+        svg.contains("Process"),
+        "SVG should contain 'Process' label"
+    );
     assert!(svg.contains("End"), "SVG should contain 'End' label");
 }
 
@@ -225,11 +244,17 @@ fn test_flowchart_with_decision_diamond() {
     let svg = render(&diagram).expect("Failed to render flowchart");
 
     // Verify diamond shape (polygon) is rendered
-    assert!(svg.contains("<polygon"), "SVG should contain polygon for diamond shape");
+    assert!(
+        svg.contains("<polygon"),
+        "SVG should contain polygon for diamond shape"
+    );
 
     // Verify all labels present
     assert!(svg.contains("Start"), "SVG should contain 'Start' label");
-    assert!(svg.contains("Decision"), "SVG should contain 'Decision' label");
+    assert!(
+        svg.contains("Decision"),
+        "SVG should contain 'Decision' label"
+    );
     assert!(svg.contains("Action"), "SVG should contain 'Action' label");
 }
 
@@ -248,9 +273,18 @@ fn test_flowchart_with_various_shapes() {
     assert!(svg.contains("<svg"), "SVG should have opening tag");
 
     // Verify labels
-    assert!(svg.contains("Stadium"), "SVG should contain 'Stadium' label");
-    assert!(svg.contains("Subroutine"), "SVG should contain 'Subroutine' label");
-    assert!(svg.contains("Database"), "SVG should contain 'Database' label");
+    assert!(
+        svg.contains("Stadium"),
+        "SVG should contain 'Stadium' label"
+    );
+    assert!(
+        svg.contains("Subroutine"),
+        "SVG should contain 'Subroutine' label"
+    );
+    assert!(
+        svg.contains("Database"),
+        "SVG should contain 'Database' label"
+    );
     assert!(svg.contains("Circle"), "SVG should contain 'Circle' label");
 }
 
@@ -269,7 +303,10 @@ fn test_render_with_dark_theme() {
     // Verify SVG generated with dark theme
     assert!(svg.contains("<svg"), "SVG should have opening tag");
     // Dark theme should have dark background color in styles
-    assert!(svg.contains("<style>"), "SVG should contain embedded styles");
+    assert!(
+        svg.contains("<style>"),
+        "SVG should contain embedded styles"
+    );
 }
 
 #[test]
@@ -305,10 +342,18 @@ fn test_flowchart_all_directions() {
 
     for dir in &directions {
         let input = format!("flowchart {}\n    A --> B", dir);
-        let diagram = parse(&input).expect(&format!("Failed to parse flowchart with direction {}", dir));
-        let svg = render(&diagram).expect(&format!("Failed to render flowchart with direction {}", dir));
+        let diagram =
+            parse(&input).expect(&format!("Failed to parse flowchart with direction {}", dir));
+        let svg = render(&diagram).expect(&format!(
+            "Failed to render flowchart with direction {}",
+            dir
+        ));
 
-        assert!(svg.contains("<svg"), "SVG should have opening tag for direction {}", dir);
+        assert!(
+            svg.contains("<svg"),
+            "SVG should have opening tag for direction {}",
+            dir
+        );
     }
 }
 
@@ -340,7 +385,10 @@ fn test_arrow_markers_are_defined() {
 
     // Verify arrow markers are defined in defs section
     assert!(svg.contains("<defs>"), "SVG should have defs section");
-    assert!(svg.contains("<marker"), "SVG should define markers for arrows");
+    assert!(
+        svg.contains("<marker"),
+        "SVG should define markers for arrows"
+    );
 }
 
 #[test]
@@ -352,7 +400,10 @@ fn test_edges_use_path_elements() {
     let svg = render(&diagram).expect("Failed to render flowchart");
 
     // Verify edges are rendered as path elements
-    assert!(svg.contains("<path"), "SVG should contain path elements for edges");
+    assert!(
+        svg.contains("<path"),
+        "SVG should contain path elements for edges"
+    );
 }
 
 #[test]
@@ -481,13 +532,15 @@ fn test_state_diagram_both_start_and_end_states() {
     // Check for start state (filled circle)
     assert!(
         svg.contains("state-start"),
-        "State diagram should have a start state with class 'state-start'. SVG:\n{}", svg
+        "State diagram should have a start state with class 'state-start'. SVG:\n{}",
+        svg
     );
 
     // Check for end state (bullseye with outer and inner circles)
     assert!(
         svg.contains("state-end-outer") && svg.contains("state-end-inner"),
-        "State diagram should have an end state with bullseye (outer and inner circles). SVG:\n{}", svg
+        "State diagram should have an end state with bullseye (outer and inner circles). SVG:\n{}",
+        svg
     );
 
     // Should have at least 3 circles total: 1 for start, 2 for end (bullseye)
@@ -513,7 +566,8 @@ fn test_pie_chart_has_legend() {
     // Should have a legend with colored rectangles
     assert!(
         svg.contains("pie-legend") || svg.contains("legend"),
-        "Pie chart should have a legend. SVG:\n{}", svg
+        "Pie chart should have a legend. SVG:\n{}",
+        svg
     );
 }
 
@@ -558,14 +612,16 @@ fn test_flowchart_edge_stroke_width() {
     // (Note: markers like cross may still use stroke-width: 2 for their internal paths)
     assert!(
         svg.contains("stroke-width: 1px") || svg.contains("stroke-width=\"1\""),
-        "Edge stroke-width should be 1px. SVG:\n{}", svg
+        "Edge stroke-width should be 1px. SVG:\n{}",
+        svg
     );
 
     // The edge path element specifically should have stroke-width 1
     assert!(
-        svg.contains(r#"class="edge-path""#) &&
-        (svg.contains("stroke-width=\"1\"") || svg.contains("stroke-width: 1px")),
-        "Edge path should have stroke-width 1. SVG:\n{}", svg
+        svg.contains(r#"class="edge-path""#)
+            && (svg.contains("stroke-width=\"1\"") || svg.contains("stroke-width: 1px")),
+        "Edge path should have stroke-width 1. SVG:\n{}",
+        svg
     );
 }
 
@@ -581,7 +637,8 @@ fn test_flowchart_arrow_marker_size() {
     // Arrow point markers should be 8x8, not 12x12
     assert!(
         svg.contains("markerWidth=\"8\"") || svg.contains("markerWidth: 8"),
-        "Arrow markers should be 8x8. SVG:\n{}", svg
+        "Arrow markers should be 8x8. SVG:\n{}",
+        svg
     );
 }
 
@@ -598,7 +655,8 @@ fn test_flowchart_subroutine_uses_polygon() {
     // Should use polygon element (not separate rect + lines)
     assert!(
         svg.contains("<polygon"),
-        "Subroutine should use polygon element. SVG:\n{}", svg
+        "Subroutine should use polygon element. SVG:\n{}",
+        svg
     );
 
     // The polygon should have points for both inner and outer rectangles
@@ -610,10 +668,14 @@ fn test_flowchart_subroutine_uses_polygon() {
         assert!(
             point_count >= 8,
             "Subroutine polygon should have at least 8 points (got {}). Points: {}",
-            point_count, points
+            point_count,
+            points
         );
     } else {
-        panic!("Subroutine should have polygon with points attribute. SVG:\n{}", svg);
+        panic!(
+            "Subroutine should have polygon with points attribute. SVG:\n{}",
+            svg
+        );
     }
 }
 
@@ -638,7 +700,8 @@ fn test_flowchart_has_circle_markers() {
     // Verify marker definitions exist
     assert!(
         svg.contains("marker") && svg.contains("circle"),
-        "Flowchart should have circle markers defined. SVG:\n{}", svg
+        "Flowchart should have circle markers defined. SVG:\n{}",
+        svg
     );
 }
 
@@ -654,20 +717,23 @@ fn test_er_diagram_has_crow_foot_notation() {
     // Should have cardinality symbols rendered
     assert!(
         svg.contains("cardinality"),
-        "ER diagram should have cardinality symbols. SVG:\n{}", svg
+        "ER diagram should have cardinality symbols. SVG:\n{}",
+        svg
     );
 
     // The ZeroOrMore cardinality (o{) should have both a circle and crow's foot paths
     // Circle for the "zero" part
     assert!(
         svg.contains("<circle"),
-        "ER diagram ZeroOrMore cardinality should include a circle. SVG:\n{}", svg
+        "ER diagram ZeroOrMore cardinality should include a circle. SVG:\n{}",
+        svg
     );
 
     // Crow's foot path for the "many" part
     assert!(
         svg.contains("<path") && svg.contains("cardinality"),
-        "ER diagram should have crow's foot paths in cardinality group. SVG:\n{}", svg
+        "ER diagram should have crow's foot paths in cardinality group. SVG:\n{}",
+        svg
     );
 }
 
@@ -691,7 +757,9 @@ fn test_gantt_task_labels_inside_bars() {
 
     // Task label should have class that indicates it's inside the bar (mermaid.js uses taskText)
     assert!(
-        svg.contains("taskText") || svg.contains("task-label-inside") || svg.contains(r#"class="task-label""#),
+        svg.contains("taskText")
+            || svg.contains("task-label-inside")
+            || svg.contains(r#"class="task-label""#),
         "Gantt chart should have task labels"
     );
 
@@ -717,9 +785,11 @@ fn test_gantt_task_bar_uses_mermaid_colors() {
 
     // Task bar should use mermaid.js default purple color
     assert!(
-        svg.contains("fill=\"#8a90dd\"") || svg.contains("fill: #8a90dd") ||
-        svg.contains("fill=\"#8A90DD\""),
-        "Gantt task bars should use mermaid.js purple (#8a90dd), not light blue. SVG:\n{}", svg
+        svg.contains("fill=\"#8a90dd\"")
+            || svg.contains("fill: #8a90dd")
+            || svg.contains("fill=\"#8A90DD\""),
+        "Gantt task bars should use mermaid.js purple (#8a90dd), not light blue. SVG:\n{}",
+        svg
     );
 }
 
@@ -739,7 +809,8 @@ fn test_gantt_has_vertical_grid_lines() {
     // mermaid.js renders these with class="grid" containing tick marks
     assert!(
         svg.contains("grid") || svg.contains("tick"),
-        "Gantt chart should have vertical grid lines. SVG:\n{}", svg
+        "Gantt chart should have vertical grid lines. SVG:\n{}",
+        svg
     );
 }
 
@@ -756,9 +827,11 @@ fn test_pie_chart_has_outer_circle() {
     // mermaid.js renders a pieOuterCircle around the pie
     // This is a circle with no fill, just a stroke around the pie
     assert!(
-        svg.contains("pieOuterCircle") || svg.contains("pie-outer") ||
-        (svg.contains("<circle") && svg.contains("fill=\"none\"")),
-        "Pie chart should have an outer circle. SVG:\n{}", svg
+        svg.contains("pieOuterCircle")
+            || svg.contains("pie-outer")
+            || (svg.contains("<circle") && svg.contains("fill=\"none\"")),
+        "Pie chart should have an outer circle. SVG:\n{}",
+        svg
     );
 }
 
@@ -789,7 +862,10 @@ fn test_diamond_edges_exit_from_sides_not_corners() {
 
     // The test will be more specific once we fix the implementation
     // For now, verify the diamond is rendered correctly
-    assert!(svg.contains("<polygon"), "Diamond should be rendered as polygon");
+    assert!(
+        svg.contains("<polygon"),
+        "Diamond should be rendered as polygon"
+    );
 }
 
 #[test]
@@ -801,7 +877,11 @@ fn test_parallelogram_renders_as_polygon() {
     let svg = render(&diagram).expect("Failed to render flowchart");
 
     // Parallelogram (LeanRight) should render as a polygon, not a rect
-    assert!(svg.contains("<polygon"), "Parallelogram should render as polygon, got:\n{}", svg);
+    assert!(
+        svg.contains("<polygon"),
+        "Parallelogram should render as polygon, got:\n{}",
+        svg
+    );
 }
 
 #[test]
@@ -817,11 +897,17 @@ fn test_class_inheritance_arrow_is_hollow_triangle() {
 
     // Inheritance relation should use a marker
     let has_inheritance_marker = svg.contains("url(#inheritance)");
-    assert!(has_inheritance_marker, "Inheritance relation should use url(#inheritance) marker");
+    assert!(
+        has_inheritance_marker,
+        "Inheritance relation should use url(#inheritance) marker"
+    );
 
     // The inheritance marker should exist and be hollow (fill="none")
     let has_inheritance_def = svg.contains(r#"id="inheritance""#);
-    assert!(has_inheritance_def, "SVG should contain inheritance marker definition");
+    assert!(
+        has_inheritance_def,
+        "SVG should contain inheritance marker definition"
+    );
 
     // The marker path should have fill="none" for hollow triangle (not filled)
     // Extract the marker section and check it has fill="none"
@@ -897,12 +983,16 @@ fn test_flowchart_tb_layout_vertical_ordering() {
     assert!(
         y_a < y_b,
         "In TB layout, A should be above B (A.y={} should be < B.y={}). SVG:\n{}",
-        y_a, y_b, svg
+        y_a,
+        y_b,
+        svg
     );
     assert!(
         y_b < y_c,
         "In TB layout, B should be above C (B.y={} should be < C.y={}). SVG:\n{}",
-        y_b, y_c, svg
+        y_b,
+        y_c,
+        svg
     );
 }
 
@@ -1039,7 +1129,8 @@ fn test_flowchart_tb_layout_with_diamond_ordering() {
     assert!(
         (y_d - y_e).abs() < 20.0,
         "D and E should be on same level: D.y={}, E.y={}",
-        y_d, y_e
+        y_d,
+        y_e
     );
 
     // F should be below D and E
@@ -1140,7 +1231,8 @@ fn test_flowchart_tb_subgraph_internal_layout() {
         y_a < y_c,
         "Within subgraph, A should be above C (Diamond): A.y={} should be < C.y={}. \
         This is mermaid-rs-agi: nodes in subgraph not respecting TB direction.",
-        y_a, y_c
+        y_a,
+        y_c
     );
 
     assert!(y_a < y_b, "A should be above B: A.y={} < B.y={}", y_a, y_b);
@@ -1255,7 +1347,8 @@ fn test_flowchart_full_tb_layout() {
         "BUG mermaid-rs-agi: In flowchart_full, A (Rectangle) should be ABOVE C (Diamond). \
         Instead, C is at y={} and A is at y={}. The Diamond Decision is being placed \
         above the Rectangle when it should be below it.",
-        y_c, y_a
+        y_c,
+        y_a
     );
 }
 
@@ -1315,7 +1408,8 @@ fn test_state_diagram_vertical_layout() {
     assert!(
         y_idle < y_running,
         "In vertical layout, Idle should be above Running. Idle.y={} vs Running.y={}",
-        y_idle, y_running
+        y_idle,
+        y_running
     );
 
     // Also verify the diagram is taller than it is wide (vertical orientation)
@@ -1335,7 +1429,8 @@ fn test_state_diagram_vertical_layout() {
         assert!(
             height > width * 0.8, // Allow some tolerance, but should be roughly taller
             "State diagram should be roughly vertical. Got {}x{} (width x height)",
-            width, height
+            width,
+            height
         );
     }
 }
@@ -1353,11 +1448,13 @@ fn test_class_diagram_cardinality_labels() {
     // Should contain both cardinality labels
     assert!(
         svg.contains("1"),
-        "Class diagram should contain cardinality '1'. SVG:\n{}", svg
+        "Class diagram should contain cardinality '1'. SVG:\n{}",
+        svg
     );
     assert!(
         svg.contains("many"),
-        "Class diagram should contain cardinality 'many'. SVG:\n{}", svg
+        "Class diagram should contain cardinality 'many'. SVG:\n{}",
+        svg
     );
 }
 
@@ -1430,14 +1527,16 @@ fn test_er_diagram_vertical_layout() {
     assert!(
         y_customer < y_order,
         "CUSTOMER should be above ORDER. CUSTOMER.y={} vs ORDER.y={}",
-        y_customer, y_order
+        y_customer,
+        y_order
     );
 
     // LINE-ITEM should be below ORDER (because ORDER ||--|{ LINE-ITEM)
     assert!(
         y_order < y_line_item,
         "ORDER should be above LINE-ITEM. ORDER.y={} vs LINE-ITEM.y={}",
-        y_order, y_line_item
+        y_order,
+        y_line_item
     );
 
     // Verify the diagram is taller than a simple grid would produce
@@ -1480,33 +1579,42 @@ fn test_class_diagram_parent_centered_over_children() {
     // Children span from ~92 to ~488, so parent should be near middle (~290)
 
     // Parse Animal's x position
-    let animal_x = svg.find(r#"id="class-Animal""#).and_then(|start| {
-        let remaining = &svg[start..];
-        remaining.find(r#"<rect x=""#).and_then(|rect_start| {
-            let after_x = &remaining[rect_start + 9..];
-            let end = after_x.find('"')?;
-            after_x[..end].parse::<f64>().ok()
+    let animal_x = svg
+        .find(r#"id="class-Animal""#)
+        .and_then(|start| {
+            let remaining = &svg[start..];
+            remaining.find(r#"<rect x=""#).and_then(|rect_start| {
+                let after_x = &remaining[rect_start + 9..];
+                let end = after_x.find('"')?;
+                after_x[..end].parse::<f64>().ok()
+            })
         })
-    }).expect("Could not find Animal class x position");
+        .expect("Could not find Animal class x position");
 
     // Parse children's x positions
-    let duck_x = svg.find(r#"id="class-Duck""#).and_then(|start| {
-        let remaining = &svg[start..];
-        remaining.find(r#"<rect x=""#).and_then(|rect_start| {
-            let after_x = &remaining[rect_start + 9..];
-            let end = after_x.find('"')?;
-            after_x[..end].parse::<f64>().ok()
+    let duck_x = svg
+        .find(r#"id="class-Duck""#)
+        .and_then(|start| {
+            let remaining = &svg[start..];
+            remaining.find(r#"<rect x=""#).and_then(|rect_start| {
+                let after_x = &remaining[rect_start + 9..];
+                let end = after_x.find('"')?;
+                after_x[..end].parse::<f64>().ok()
+            })
         })
-    }).expect("Could not find Duck class x position");
+        .expect("Could not find Duck class x position");
 
-    let zebra_x = svg.find(r#"id="class-Zebra""#).and_then(|start| {
-        let remaining = &svg[start..];
-        remaining.find(r#"<rect x=""#).and_then(|rect_start| {
-            let after_x = &remaining[rect_start + 9..];
-            let end = after_x.find('"')?;
-            after_x[..end].parse::<f64>().ok()
+    let zebra_x = svg
+        .find(r#"id="class-Zebra""#)
+        .and_then(|start| {
+            let remaining = &svg[start..];
+            remaining.find(r#"<rect x=""#).and_then(|rect_start| {
+                let after_x = &remaining[rect_start + 9..];
+                let end = after_x.find('"')?;
+                after_x[..end].parse::<f64>().ok()
+            })
         })
-    }).expect("Could not find Zebra class x position");
+        .expect("Could not find Zebra class x position");
 
     // Class width is 180, so we need to account for that when calculating centers
     let class_width = 180.0;
@@ -1520,7 +1628,11 @@ fn test_class_diagram_parent_centered_over_children() {
         "Animal (parent) should be horizontally centered over children. \
          Animal center={}, children center={}, diff={}. \
          Animal x={}, Duck x={}, Zebra x={}",
-        animal_center, children_center, (animal_center - children_center).abs(),
-        animal_x, duck_x, zebra_x
+        animal_center,
+        children_center,
+        (animal_center - children_center).abs(),
+        animal_x,
+        duck_x,
+        zebra_x
     );
 }

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -3,6 +3,197 @@
 use mermaid::{parse, render, render_with_config};
 use mermaid::render::{RenderConfig, Theme};
 
+// ============================================================================
+// Output Format Tests (PNG/PDF)
+// ============================================================================
+
+#[cfg(feature = "png")]
+mod png_output_tests {
+    use super::*;
+
+    /// Test that SVG can be converted to valid PNG
+    #[test]
+    fn test_svg_to_png_produces_valid_png() {
+        let input = r#"flowchart LR
+            A[Start] --> B[End]"#;
+
+        let diagram = parse(input).expect("Failed to parse");
+        let svg = render(&diagram).expect("Failed to render");
+
+        // Convert to PNG using resvg
+        use resvg::usvg;
+        use resvg::tiny_skia;
+
+        let mut opt = usvg::Options::default();
+        opt.fontdb_mut().load_system_fonts();
+
+        let tree = usvg::Tree::from_str(&svg, &opt)
+            .expect("Failed to parse SVG");
+
+        let size = tree.size();
+        let mut pixmap = tiny_skia::Pixmap::new(
+            size.width() as u32,
+            size.height() as u32,
+        ).expect("Failed to create pixmap");
+
+        resvg::render(&tree, tiny_skia::Transform::default(), &mut pixmap.as_mut());
+
+        let png_data = pixmap.encode_png().expect("Failed to encode PNG");
+
+        // Verify PNG header (magic bytes)
+        assert!(png_data.starts_with(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+            "Output should be valid PNG (check magic bytes)");
+
+        // Should have reasonable size
+        assert!(png_data.len() > 100, "PNG should have content");
+    }
+
+    /// Test that PNG output respects scaling
+    #[test]
+    fn test_png_scaling() {
+        let input = r#"flowchart LR
+            A --> B --> C"#;
+
+        let diagram = parse(input).expect("Failed to parse");
+        let svg = render(&diagram).expect("Failed to render");
+
+        use resvg::usvg;
+        use resvg::tiny_skia;
+
+        let mut opt = usvg::Options::default();
+        opt.fontdb_mut().load_system_fonts();
+
+        let tree = usvg::Tree::from_str(&svg, &opt).expect("Failed to parse SVG");
+
+        // Render at 2x scale
+        let size = tree.size();
+        let scale = 2.0;
+        let width = (size.width() * scale) as u32;
+        let height = (size.height() * scale) as u32;
+
+        let mut pixmap = tiny_skia::Pixmap::new(width, height)
+            .expect("Failed to create pixmap");
+
+        let transform = tiny_skia::Transform::from_scale(scale, scale);
+        resvg::render(&tree, transform, &mut pixmap.as_mut());
+
+        assert_eq!(pixmap.width(), width);
+        assert_eq!(pixmap.height(), height);
+    }
+
+    /// Test PNG output with dark theme
+    #[test]
+    fn test_png_with_dark_theme() {
+        let input = r#"flowchart TB
+            A[Start] --> B{Decision}
+            B -->|Yes| C[End]"#;
+
+        let diagram = parse(input).expect("Failed to parse");
+        let config = RenderConfig {
+            theme: Theme::dark(),
+            ..Default::default()
+        };
+        let svg = render_with_config(&diagram, &config).expect("Failed to render");
+
+        use resvg::usvg;
+        use resvg::tiny_skia;
+
+        let mut opt = usvg::Options::default();
+        opt.fontdb_mut().load_system_fonts();
+
+        let tree = usvg::Tree::from_str(&svg, &opt).expect("Failed to parse SVG");
+
+        let size = tree.size();
+        let mut pixmap = tiny_skia::Pixmap::new(
+            size.width() as u32,
+            size.height() as u32,
+        ).expect("Failed to create pixmap");
+
+        resvg::render(&tree, tiny_skia::Transform::default(), &mut pixmap.as_mut());
+
+        let png_data = pixmap.encode_png().expect("Failed to encode PNG");
+        assert!(png_data.starts_with(&[0x89, 0x50, 0x4E, 0x47]),
+            "Dark theme should produce valid PNG");
+    }
+}
+
+#[cfg(feature = "pdf")]
+mod pdf_output_tests {
+    use super::*;
+
+    /// Test that SVG can be converted to valid PDF
+    #[test]
+    fn test_svg_to_pdf_produces_valid_pdf() {
+        let input = r#"flowchart LR
+            A[Start] --> B[End]"#;
+
+        let diagram = parse(input).expect("Failed to parse");
+        let svg = render(&diagram).expect("Failed to render");
+
+        use resvg::usvg;
+
+        let mut opt = usvg::Options::default();
+        opt.fontdb_mut().load_system_fonts();
+
+        let tree = usvg::Tree::from_str(&svg, &opt)
+            .expect("Failed to parse SVG");
+
+        let pdf_data = svg2pdf::to_pdf(
+            &tree,
+            svg2pdf::ConversionOptions::default(),
+            svg2pdf::PageOptions::default(),
+        ).expect("Failed to convert to PDF");
+
+        // Verify PDF header
+        assert!(pdf_data.starts_with(b"%PDF-"),
+            "Output should be valid PDF (check header)");
+
+        // Should have reasonable size
+        assert!(pdf_data.len() > 100, "PDF should have content");
+    }
+
+    /// Test PDF output with various diagram types
+    #[test]
+    fn test_pdf_with_different_diagrams() {
+        let diagrams = [
+            ("flowchart", r#"flowchart TB
+                A --> B --> C"#),
+            ("pie", r#"pie title Test
+                "A" : 50
+                "B" : 50"#),
+            ("state", r#"stateDiagram-v2
+                [*] --> Active
+                Active --> [*]"#),
+        ];
+
+        for (name, input) in diagrams {
+            let diagram = parse(input).expect(&format!("Failed to parse {}", name));
+            let svg = render(&diagram).expect(&format!("Failed to render {}", name));
+
+            use resvg::usvg;
+
+            let mut opt = usvg::Options::default();
+            opt.fontdb_mut().load_system_fonts();
+
+            let tree = usvg::Tree::from_str(&svg, &opt)
+                .expect(&format!("Failed to parse {} SVG", name));
+
+            let pdf_data = svg2pdf::to_pdf(
+                &tree,
+                svg2pdf::ConversionOptions::default(),
+                svg2pdf::PageOptions::default(),
+            ).expect(&format!("Failed to convert {} to PDF", name));
+
+            assert!(pdf_data.starts_with(b"%PDF-"),
+                "{} should produce valid PDF", name);
+        }
+    }
+}
+
+// ============================================================================
+// Original Integration Tests
+// ============================================================================
+
 #[test]
 fn test_simple_flowchart_renders_to_svg() {
     let input = r#"flowchart LR

--- a/tools/gallery/analyze_diff.rs
+++ b/tools/gallery/analyze_diff.rs
@@ -42,7 +42,6 @@ struct Difference {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[allow(dead_code)]
 enum Severity {
     Critical,
     Major,
@@ -85,7 +84,10 @@ fn parse_dimension(value: &str) -> f64 {
         return 0.0;
     }
     // Extract numeric part
-    let numeric: String = value.chars().take_while(|c| c.is_ascii_digit() || *c == '.').collect();
+    let numeric: String = value
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
     numeric.parse().unwrap_or(0.0)
 }
 
@@ -156,7 +158,8 @@ fn extract_metrics(svg_content: &str) -> SvgMetrics {
                     }
                 } else {
                     // Otherwise collect from tspans only
-                    let text: String = node.children()
+                    let text: String = node
+                        .children()
                         .filter(|n| n.is_element() && n.tag_name().name() == "tspan")
                         .filter_map(|n| n.text())
                         .map(|s| s.trim())
@@ -174,19 +177,11 @@ fn extract_metrics(svg_content: &str) -> SvgMetrics {
             "foreignObject" => {
                 // mermaid-js uses foreignObject for HTML text
                 metrics.text_count += 1;
-                // Only extract text from leaf elements (no element children)
-                // to avoid double-counting from nested elements
                 for descendant in node.descendants() {
-                    if descendant.is_element() {
-                        let has_element_children = descendant.children().any(|c| c.is_element());
-                        if !has_element_children {
-                            // This is a leaf element - extract its text
-                            if let Some(text) = descendant.text() {
-                                let text = text.trim().to_string();
-                                if !text.is_empty() {
-                                    metrics.text_contents.push(text);
-                                }
-                            }
+                    if let Some(text) = descendant.text() {
+                        let text = text.trim().to_string();
+                        if !text.is_empty() {
+                            metrics.text_contents.push(text);
                         }
                     }
                 }
@@ -218,7 +213,7 @@ fn extract_metrics(svg_content: &str) -> SvgMetrics {
     metrics
 }
 
-fn compare_metrics(_name: &str, rs: &SvgMetrics, ref_metrics: &SvgMetrics) -> Vec<Difference> {
+fn compare_metrics(name: &str, rs: &SvgMetrics, ref_metrics: &SvgMetrics) -> Vec<Difference> {
     let mut diffs = Vec::new();
 
     // Dimension differences
@@ -354,58 +349,34 @@ fn compare_metrics(_name: &str, rs: &SvgMetrics, ref_metrics: &SvgMetrics) -> Ve
 fn calculate_similarity(rs: &SvgMetrics, ref_metrics: &SvgMetrics) -> f64 {
     let mut score = 1.0;
 
-    // Text content penalty (max 70%) - PRIMARY VISUAL METRIC
-    // This is the most important check: do all the labels appear in both versions?
-    // Text content is what users actually see and care about.
+    // Dimension penalty (max 20%)
+    let dim_diff = ((rs.width - ref_metrics.width).abs() + (rs.height - ref_metrics.height).abs())
+        / (ref_metrics.width + ref_metrics.height + 1.0);
+    score -= (dim_diff * 0.2).min(0.2);
+
+    // Element count penalty (max 40%)
+    let total_ref_elems = ref_metrics.rect_count
+        + ref_metrics.circle_count
+        + ref_metrics.path_count
+        + ref_metrics.text_count
+        + ref_metrics.line_count;
+    let total_rs_elems =
+        rs.rect_count + rs.circle_count + rs.path_count + rs.text_count + rs.line_count;
+
+    if total_ref_elems > 0 {
+        let elem_diff =
+            (total_rs_elems as f64 - total_ref_elems as f64).abs() / total_ref_elems as f64;
+        score -= (elem_diff * 0.4).min(0.4);
+    }
+
+    // Text content penalty (max 30%)
     let rs_texts: HashSet<_> = rs.text_contents.iter().collect();
     let ref_texts: HashSet<_> = ref_metrics.text_contents.iter().collect();
     let common = rs_texts.intersection(&ref_texts).count();
     let total = rs_texts.len().max(ref_texts.len());
     if total > 0 {
         let text_similarity = common as f64 / total as f64;
-        score -= (1.0 - text_similarity) * 0.70;
-    }
-
-    // Dimension penalty (max 15%)
-    // Compares overall diagram size - some difference expected due to text measurement methods
-    // Using character-based estimation vs DOM measurement causes systematic differences
-    let dim_diff = ((rs.width - ref_metrics.width).abs() + (rs.height - ref_metrics.height).abs())
-        / (ref_metrics.width + ref_metrics.height + 1.0);
-    score -= (dim_diff * 0.15).min(0.15);
-
-    // Color palette penalty (max 5%)
-    // Only checking inline fill attributes - CSS colors need separate analysis
-    // Most diagrams use CSS for fills, so this is a minor check
-    let rs_fills: HashSet<_> = rs.fills.keys().collect();
-    let ref_fills: HashSet<_> = ref_metrics.fills.keys().collect();
-    let common_fills = rs_fills.intersection(&ref_fills).count();
-    let total_fills = rs_fills.len().max(ref_fills.len());
-    if total_fills > 0 {
-        let fill_similarity = common_fills as f64 / total_fills as f64;
-        score -= (1.0 - fill_similarity) * 0.05;
-    }
-
-    // Visual shape penalty (max 10%)
-    // Only compare key visual shapes - many element differences are structural (invisible placeholders)
-    // Use a lenient ratio comparison: within 2x is acceptable for structural differences
-    let ref_core_shapes = (ref_metrics.rect_count
-        + ref_metrics.circle_count
-        + ref_metrics.polygon_count
-        + ref_metrics.ellipse_count) as f64;
-    let rs_core_shapes = (rs.rect_count
-        + rs.circle_count
-        + rs.polygon_count
-        + rs.ellipse_count) as f64;
-
-    if ref_core_shapes > 0.0 {
-        let shape_ratio = rs_core_shapes / ref_core_shapes;
-        // Only penalize if significantly different (outside 0.5-2.0 range)
-        let shape_diff = if shape_ratio >= 0.5 && shape_ratio <= 2.0 {
-            0.0
-        } else {
-            (shape_ratio - 1.0).abs().min(1.0)
-        };
-        score -= shape_diff * 0.10;
+        score -= (1.0 - text_similarity) * 0.3;
     }
 
     score.max(0.0)
@@ -548,7 +519,11 @@ fn generate_html_report(results: &[ComparisonResult], output_path: &Path) -> std
     let high_similarity = results.iter().filter(|r| r.similarity_score >= 0.9).count();
     let has_critical = results
         .iter()
-        .filter(|r| r.differences.iter().any(|d| matches!(d.severity, Severity::Critical)))
+        .filter(|r| {
+            r.differences
+                .iter()
+                .any(|d| matches!(d.severity, Severity::Critical))
+        })
         .count();
     let avg_similarity: f64 =
         results.iter().map(|r| r.similarity_score).sum::<f64>() / total.max(1) as f64;
@@ -678,7 +653,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{}", separator);
     println!();
 
-    let diagrams = ["flowchart", "pie", "sequence", "class", "state", "er", "gantt"];
+    let diagrams = [
+        "flowchart",
+        "pie",
+        "sequence",
+        "class",
+        "state",
+        "er",
+        "gantt",
+    ];
 
     let mut results = Vec::new();
 
@@ -711,7 +694,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("  No significant differences detected");
         } else {
             for diff in &differences {
-                println!("  [{}] {}: {}", diff.severity.label(), diff.category, diff.description);
+                println!(
+                    "  [{}] {}: {}",
+                    diff.severity.label(),
+                    diff.category,
+                    diff.description
+                );
             }
         }
 
@@ -720,7 +708,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             ref_metrics.width, ref_metrics.height, rs_metrics.width, rs_metrics.height
         );
         println!("  Similarity: {:.0}%", similarity * 100.0);
-
 
         results.push(ComparisonResult {
             name: name.to_string(),
@@ -738,7 +725,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let total = results.len();
     let with_diffs = results.iter().filter(|r| !r.differences.is_empty()).count();
-    let avg_sim: f64 = results.iter().map(|r| r.similarity_score).sum::<f64>() / total.max(1) as f64;
+    let avg_sim: f64 =
+        results.iter().map(|r| r.similarity_score).sum::<f64>() / total.max(1) as f64;
 
     println!("\nDiagrams with differences: {}/{}", with_diffs, total);
     println!("Average similarity: {:.0}%", avg_sim * 100.0);

--- a/tools/gallery/generate.rs
+++ b/tools/gallery/generate.rs
@@ -9,7 +9,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Sample diagrams - complex examples to exercise more features
     let diagrams = vec![
-        ("flowchart", r#"flowchart LR
+        (
+            "flowchart",
+            r#"flowchart LR
     A[Start] --> B{Decision}
     B -->|Yes| C[Action 1]
     B -->|No| D[Action 2]
@@ -18,8 +20,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     E --> F([Round])
     F --> G[[Subroutine]]
     G --> H[(Database)]
-    H o--o I((Circle))"#),
-        ("flowchart_full", r#"flowchart TB
+    H o--o I((Circle))"#,
+        ),
+        (
+            "flowchart_full",
+            r#"flowchart TB
     subgraph main [Main Flow]
         A[Rectangle] --> B(Rounded)
         B --> C{Diamond Decision}
@@ -48,13 +53,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         O o--o W
     end
     F --> G
-    N --> O"#),
-        ("pie", r#"pie title Project Distribution
+    N --> O"#,
+        ),
+        (
+            "pie",
+            r#"pie title Project Distribution
     "Development" : 40
     "Testing" : 25
     "Documentation" : 15
-    "Design" : 20"#),
-        ("sequence", r#"sequenceDiagram
+    "Design" : 20"#,
+        ),
+        (
+            "sequence",
+            r#"sequenceDiagram
     participant A as Alice
     participant B as Bob
     participant C as Server
@@ -65,8 +76,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     C-->>-A: Token
     A->>B: How are you?
     B-->>A: I'm good, thanks!
-    Note right of B: Bob thinks"#),
-        ("class", r#"classDiagram
+    Note right of B: Bob thinks"#,
+        ),
+        (
+            "class",
+            r#"classDiagram
     Animal <|-- Duck
     Animal <|-- Fish
     Animal <|-- Zebra
@@ -87,15 +101,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         +bool is_wild
         +run()
     }
-    Duck "1" *-- "many" Egg : has"#),
-        ("state", r#"stateDiagram-v2
+    Duck "1" *-- "many" Egg : has"#,
+        ),
+        (
+            "state",
+            r#"stateDiagram-v2
     [*] --> Idle
     Idle --> Running : start
     Running --> Idle : stop
     Running --> Error : error
     Error --> Idle : reset
-    Error --> [*]"#),
-        ("er", r#"erDiagram
+    Error --> [*]"#,
+        ),
+        (
+            "er",
+            r#"erDiagram
     CUSTOMER ||--o{ ORDER : places
     ORDER ||--|{ LINE-ITEM : contains
     PRODUCT ||--o{ LINE-ITEM : includes
@@ -113,8 +133,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         int id PK
         string name
         float price
-    }"#),
-        ("gantt", r#"gantt
+    }"#,
+        ),
+        (
+            "gantt",
+            r#"gantt
     title Project Timeline
     dateFormat YYYY-MM-DD
     section Planning
@@ -126,19 +149,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     API Integration :b3, after b1, 3d
     section Testing
     Unit Tests  :c1, after b2, 3d
-    QA          :c2, after b3, 5d"#),
+    QA          :c2, after b3, 5d"#,
+        ),
         // ========================================
         // Examples from mermaid.js documentation
         // https://mermaid.ai/open-source/syntax/examples.html
         // ========================================
-        ("example_pie_netflix", r#"pie title NETFLIX
+        (
+            "example_pie_netflix",
+            r#"pie title NETFLIX
          "Time spent looking for movie" : 90
-         "Time spent watching it" : 10"#),
-        ("example_pie_voldemort", r#"pie title What Voldemort doesn't have?
+         "Time spent watching it" : 10"#,
+        ),
+        (
+            "example_pie_voldemort",
+            r#"pie title What Voldemort doesn't have?
          "FRIENDS" : 2
          "FAMILY" : 3
-         "NOSE" : 45"#),
-        ("example_sequence_basic", r#"sequenceDiagram
+         "NOSE" : 45"#,
+        ),
+        (
+            "example_sequence_basic",
+            r#"sequenceDiagram
     Alice ->> Bob: Hello Bob, how are you?
     Bob-->>John: How about you John?
     Bob--x Alice: I am good thanks!
@@ -146,13 +178,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Note right of John: Bob thinks a long<br/>long time, so long<br/>that the text does<br/>not fit on a row.
 
     Bob-->Alice: Checking with John...
-    Alice->John: Yes... John, how are you?"#),
-        ("example_flowchart_basic", r#"graph LR
+    Alice->John: Yes... John, how are you?"#,
+        ),
+        (
+            "example_flowchart_basic",
+            r#"graph LR
     A[Square Rect] -- Link text --> B((Circle))
     A --> C(Round Rect)
     B --> D{Rhombus}
-    C --> D"#),
-        ("example_flowchart_styled", r#"graph TB
+    C --> D"#,
+        ),
+        (
+            "example_flowchart_styled",
+            r#"graph TB
     sq[Square shape] --> ci((Circle shape))
 
     subgraph A
@@ -170,8 +208,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
      classDef green fill:#9f6,stroke:#333,stroke-width:2px
      classDef orange fill:#f96,stroke:#333,stroke-width:4px
      class sq,e green
-     class di orange"#),
-        ("example_sequence_loops", r#"sequenceDiagram
+     class di orange"#,
+        ),
+        (
+            "example_sequence_loops",
+            r#"sequenceDiagram
     loop Daily query
         Alice->>Bob: Hello Bob, how are you?
         alt is sick
@@ -183,8 +224,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         opt Extra response
             Bob->>Alice: Thanks for asking
         end
-    end"#),
-        ("example_sequence_self_loop", r#"sequenceDiagram
+    end"#,
+        ),
+        (
+            "example_sequence_self_loop",
+            r#"sequenceDiagram
     participant Alice
     participant Bob
     Alice->>John: Hello John, how are you?
@@ -194,8 +238,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Note right of John: Rational thoughts<br/>prevail...
     John-->>Alice: Great!
     John->>Bob: How about you?
-    Bob-->>John: Jolly good!"#),
-        ("example_sequence_blogging", r#"sequenceDiagram
+    Bob-->>John: Jolly good!"#,
+        ),
+        (
+            "example_sequence_blogging",
+            r#"sequenceDiagram
     participant web as Web Browser
     participant blog as Blog Service
     participant account as Account Service
@@ -222,7 +269,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         and Response
             blog-->>-web: Successfully posted
         end
-    end"#),
+    end"#,
+        ),
     ];
 
     println!("Generating {} diagram SVGs...", diagrams.len());


### PR DESCRIPTION
## Summary

- Add **PNG output** using `resvg` (pure Rust SVG rasterization)
- Add **PDF output** using `svg2pdf` (vector-preserving PDF conversion)
- Add **kitty terminal graphics** support for inline diagram display
- Auto-detect terminal background color for theme selection

## Features

### Output Formats
```bash
selkie -i diagram.mmd -o output.svg   # SVG (default)
selkie -i diagram.mmd -o output.png   # PNG rasterization
selkie -i diagram.mmd -o output.pdf   # PDF vector output
```

### Terminal Display (kitty/ghostty)
```bash
selkie -i diagram.mmd --display       # Display inline in terminal
selkie -i diagram.mmd -t auto -d      # Auto-detect theme + display
```

### Feature Flags
- `png` - PNG output support
- `pdf` - PDF output support  
- `kitty` - Terminal display support
- `all-formats` - All of the above

## Test plan
- [x] PNG produces valid files (magic bytes check)
- [x] PNG scaling works correctly
- [x] PDF produces valid files (header check)
- [x] PDF works with multiple diagram types
- [x] Kitty module unit tests (luminance, color parsing, error handling)
- [x] All 38 existing integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)