### PR TITLE
Fix all clippy warnings and enforce linting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          rustflags: ""  # Don't fail on warnings (98 pre-existing)
       - run: cargo test --features all-formats
 
   lint:
@@ -28,6 +26,5 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy, rustfmt
-          rustflags: ""
       - run: cargo fmt --check
-      - run: cargo clippy --features all-formats
+      - run: cargo clippy --features all-formats -- -D warnings

--- a/src/bin/extract_diagrams.rs
+++ b/src/bin/extract_diagrams.rs
@@ -99,8 +99,7 @@ fn extract_diagrams_from_file(filepath: &Path) -> Vec<DiagramEntry> {
         let pos = cap.get(0).unwrap().start();
         let test_name = test_positions
             .iter()
-            .filter(|(p, _)| *p < pos)
-            .next_back()
+            .rfind(|(p, _)| *p < pos)
             .map(|(_, name)| name.clone())
             .unwrap_or_else(|| "unknown".to_string());
 

--- a/src/bin/extract_diagrams.rs
+++ b/src/bin/extract_diagrams.rs
@@ -100,7 +100,7 @@ fn extract_diagrams_from_file(filepath: &Path) -> Vec<DiagramEntry> {
         let test_name = test_positions
             .iter()
             .filter(|(p, _)| *p < pos)
-            .last()
+            .next_back()
             .map(|(_, name)| name.clone())
             .unwrap_or_else(|| "unknown".to_string());
 

--- a/src/bin/render_validate.rs
+++ b/src/bin/render_validate.rs
@@ -377,12 +377,13 @@ fn main() {
     let diagrams = if input_path.is_dir() {
         // Load all .mmd files from directory
         let mut diagrams = Vec::new();
-        for entry in glob::glob(input_path.join("**/*.mmd").to_str().unwrap()).unwrap() {
-            if let Ok(path) = entry {
-                if let Ok(content) = fs::read_to_string(&path) {
-                    let name = path.file_stem().unwrap().to_string_lossy().to_string();
-                    diagrams.push((name, content));
-                }
+        for path in glob::glob(input_path.join("**/*.mmd").to_str().unwrap())
+            .unwrap()
+            .flatten()
+        {
+            if let Ok(content) = fs::read_to_string(&path) {
+                let name = path.file_stem().unwrap().to_string_lossy().to_string();
+                diagrams.push((name, content));
             }
         }
         diagrams

--- a/src/common/sanitize.rs
+++ b/src/common/sanitize.rs
@@ -168,7 +168,7 @@ fn process_set(input: &str) -> String {
 
     // If there is an odd number of tildes, and the input starts with a tilde,
     // we need to remove it and add it back in later
-    if tilde_count % 2 != 0 && input.starts_with('~') {
+    if !tilde_count.is_multiple_of(2) && input.starts_with('~') {
         input = input[1..].to_string();
         has_starting_tilde = true;
     }

--- a/src/diagrams/block/parser.rs
+++ b/src/diagrams/block/parser.rs
@@ -334,7 +334,7 @@ fn process_class_def(db: &mut BlockDb, pair: pest::iterators::Pair<Rule>) -> Res
                 // Split by semicolon or comma
                 styles = inner
                     .as_str()
-                    .split(|c| c == ';' || c == ',')
+                    .split([';', ','])
                     .map(|s| s.trim().to_string())
                     .filter(|s| !s.is_empty())
                     .collect();
@@ -518,7 +518,7 @@ mod tests {
             assert!(result.is_ok(), "Parse error: {:?}", result.err());
             let db = result.unwrap();
             // Should have the composite and the inner block
-            assert!(db.get_blocks().len() >= 1);
+            assert!(!db.get_blocks().is_empty());
         }
 
         #[test]

--- a/src/diagrams/c4/parser.rs
+++ b/src/diagrams/c4/parser.rs
@@ -67,7 +67,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_person_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     C4ShapeType::Person,
@@ -78,7 +78,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_person_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     C4ShapeType::PersonExt,
@@ -90,7 +90,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_system_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     C4ShapeType::System,
@@ -101,7 +101,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_system_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     C4ShapeType::SystemDb,
@@ -112,7 +112,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_system_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     C4ShapeType::SystemQueue,
@@ -123,7 +123,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_system_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     C4ShapeType::SystemExt,
@@ -134,7 +134,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_system_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     C4ShapeType::SystemDbExt,
@@ -145,7 +145,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_system_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     C4ShapeType::SystemQueueExt,
@@ -157,7 +157,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_container_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -169,7 +169,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_container_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -181,7 +181,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_container_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -193,7 +193,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_container_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -205,7 +205,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_container_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -217,7 +217,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_container_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -230,7 +230,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_component_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -242,7 +242,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_component_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -254,7 +254,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_component_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -266,7 +266,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_component_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -278,7 +278,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_component_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -290,7 +290,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if !attrs.is_empty() {
                 db.add_component_with_type(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -316,7 +316,7 @@ fn process_statement(db: &mut C4Db, pair: pest::iterators::Pair<Rule>) -> Result
             let attrs = extract_all_attributes(pair);
             if attrs.len() >= 2 {
                 db.add_relationship(
-                    &attrs.get(0).cloned().unwrap_or_default(),
+                    &attrs.first().cloned().unwrap_or_default(),
                     &attrs.get(1).cloned().unwrap_or_default(),
                     &attrs.get(2).cloned().unwrap_or_default(),
                     &attrs.get(3).cloned().unwrap_or_default(),
@@ -349,7 +349,7 @@ fn process_boundary(
     }
 
     // Start the boundary
-    let alias = attrs.get(0).cloned().unwrap_or_default();
+    let alias = attrs.first().cloned().unwrap_or_default();
     let label = attrs.get(1).cloned().unwrap_or_default();
     db.start_boundary(&alias, &label, boundary_type);
 

--- a/src/diagrams/detect.rs
+++ b/src/diagrams/detect.rs
@@ -156,9 +156,9 @@ pub fn detect_type(input: &str) -> Result<DiagramType> {
 /// Remove YAML frontmatter from input
 fn remove_frontmatter(input: &str) -> String {
     let trimmed = input.trim_start();
-    if trimmed.starts_with("---") {
-        if let Some(end_pos) = trimmed[3..].find("---") {
-            return trimmed[end_pos + 6..].to_string();
+    if let Some(after_start) = trimmed.strip_prefix("---") {
+        if let Some(end_pos) = after_start.find("---") {
+            return after_start[end_pos + 3..].to_string();
         }
     }
     input.to_string()

--- a/src/diagrams/er/parser.rs
+++ b/src/diagrams/er/parser.rs
@@ -27,13 +27,10 @@ pub fn parse_into(input: &str, db: &mut ErDb) -> Result<()> {
         .map_err(|e| MermaidError::ParseError(e.to_string()))?;
 
     for pair in pairs {
-        match pair.as_rule() {
-            Rule::diagram => {
-                for inner in pair.into_inner() {
-                    process_rule(inner, db)?;
-                }
+        if pair.as_rule() == Rule::diagram {
+            for inner in pair.into_inner() {
+                process_rule(inner, db)?;
             }
-            _ => {}
         }
     }
 

--- a/src/diagrams/er/types.rs
+++ b/src/diagrams/er/types.rs
@@ -14,6 +14,7 @@ pub enum Cardinality {
 }
 
 impl Cardinality {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_uppercase().as_str() {
             "ZERO_OR_ONE" | "ZERO OR ONE" | "|o" | "o|" => Self::ZeroOrOne,
@@ -45,6 +46,7 @@ pub enum Identification {
 }
 
 impl Identification {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_uppercase().as_str() {
             "IDENTIFYING" | "--" => Self::Identifying,
@@ -69,6 +71,7 @@ pub enum AttributeKey {
 }
 
 impl AttributeKey {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_uppercase().as_str() {
             "PK" => Some(Self::PrimaryKey),
@@ -208,6 +211,7 @@ pub enum Direction {
 }
 
 impl Direction {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_uppercase().as_str() {
             "BT" => Self::BottomToTop,

--- a/src/diagrams/flowchart/parser.rs
+++ b/src/diagrams/flowchart/parser.rs
@@ -25,13 +25,10 @@ pub fn parse_into(input: &str, db: &mut FlowchartDb) -> Result<()> {
         .map_err(|e| MermaidError::ParseError(e.to_string()))?;
 
     for pair in pairs {
-        match pair.as_rule() {
-            Rule::diagram => {
-                for inner in pair.into_inner() {
-                    process_rule(inner, db)?;
-                }
+        if pair.as_rule() == Rule::diagram {
+            for inner in pair.into_inner() {
+                process_rule(inner, db)?;
             }
-            _ => {}
         }
     }
 
@@ -668,7 +665,7 @@ mod tests {
         let db = result.unwrap();
         let vertex = db.get_vertices().get("A").unwrap();
         assert!(
-            vertex.styles.len() > 0,
+            !vertex.styles.is_empty(),
             "Vertex A should have styles: {:?}",
             vertex
         );

--- a/src/diagrams/flowchart/types.rs
+++ b/src/diagrams/flowchart/types.rs
@@ -351,15 +351,15 @@ fn parse_arrow(arrow: &str) -> (String, EdgeStroke, u32) {
             // Count consecutive dashes or tildes
             let dash_count = arrow.chars().filter(|&c| c == '-' || c == '~').count();
             // Minimum length is 1, max is 3 for display purposes
-            (dash_count.saturating_sub(1).max(1).min(3)) as u32
+            (dash_count.saturating_sub(1).clamp(1, 3)) as u32
         }
         EdgeStroke::Thick => {
             let eq_count = arrow.chars().filter(|&c| c == '=').count();
-            (eq_count.saturating_sub(1).max(1).min(3)) as u32
+            (eq_count.saturating_sub(1).clamp(1, 3)) as u32
         }
         EdgeStroke::Dotted => {
             let dot_count = arrow.chars().filter(|&c| c == '.').count();
-            (dot_count.max(1).min(3)) as u32
+            (dot_count.clamp(1, 3)) as u32
         }
     };
 
@@ -412,6 +412,7 @@ impl FlowchartDb {
     }
 
     /// Add a vertex to the flowchart
+    #[allow(clippy::too_many_arguments)]
     pub fn add_vertex(
         &mut self,
         id: &str,
@@ -677,7 +678,7 @@ impl FlowchartDb {
         text: Option<&str>,
         vertex_type: Option<FlowVertexType>,
     ) {
-        let text_obj = text.map(|t| FlowText::new(t));
+        let text_obj = text.map(FlowText::new);
         self.add_vertex(
             id,
             text_obj,
@@ -710,7 +711,7 @@ impl FlowchartDb {
         let (edge_type, stroke, length) = parse_arrow(arrow);
 
         let flow_link = FlowLink {
-            text: text.map(|t| FlowText::new(t)),
+            text: text.map(FlowText::new),
             id: link_id.map(String::from),
             link_type: Some(edge_type),
             stroke,

--- a/src/diagrams/gantt/types.rs
+++ b/src/diagrams/gantt/types.rs
@@ -15,6 +15,7 @@ pub enum DurationUnit {
 
 impl DurationUnit {
     /// Parse a duration unit from a string suffix
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s {
             "ms" => Some(Self::Milliseconds),
@@ -409,8 +410,7 @@ impl GanttDb {
             ("m", "m"),
             ("s", "s"),
         ] {
-            if s.ends_with(suffix) {
-                let num_str = &s[..s.len() - suffix.len()];
+            if let Some(num_str) = s.strip_suffix(suffix) {
                 if let Ok(value) = num_str.parse::<f64>() {
                     return (value, unit);
                 }
@@ -450,7 +450,7 @@ impl GanttDb {
         }
 
         if let Ok(date) = NaiveDate::parse_from_str(s, &chrono_format) {
-            return Some(date.and_hms_opt(0, 0, 0)?);
+            return date.and_hms_opt(0, 0, 0);
         }
 
         None
@@ -512,7 +512,7 @@ impl GanttDb {
                                 .and_hms_opt(0, 0, 0);
                             latest_end = Some(match latest_end {
                                 Some(current) => today.map(|t| current.max(t)).unwrap_or(current),
-                                None => today.unwrap_or_else(|| NaiveDateTime::default()),
+                                None => today.unwrap_or_default(),
                             });
                         }
                     }
@@ -526,13 +526,11 @@ impl GanttDb {
                 }
 
                 // If no start time yet and no after deps, use previous task's end
-                if self.tasks[i].start_time.is_none() && after_ids.is_empty() {
-                    if i > 0 {
-                        // Find the previous task in the same section or overall
-                        if let Some(prev_end) = self.tasks[i - 1].end_time {
-                            self.tasks[i].start_time = Some(prev_end);
-                            changed = true;
-                        }
+                if self.tasks[i].start_time.is_none() && after_ids.is_empty() && i > 0 {
+                    // Find the previous task in the same section or overall
+                    if let Some(prev_end) = self.tasks[i - 1].end_time {
+                        self.tasks[i].start_time = Some(prev_end);
+                        changed = true;
                     }
                 }
 
@@ -642,17 +640,11 @@ impl GanttDb {
                 "milestone" => result.flags.milestone = true,
                 _ => {
                     // Check if it's an "after" reference
-                    if part.starts_with("after ") {
-                        let deps = part[6..]
-                            .split_whitespace()
-                            .map(|s| s.to_string())
-                            .collect();
+                    if let Some(stripped) = part.strip_prefix("after ") {
+                        let deps = stripped.split_whitespace().map(|s| s.to_string()).collect();
                         result.after = deps;
-                    } else if part.starts_with("until ") {
-                        let deps = part[6..]
-                            .split_whitespace()
-                            .map(|s| s.to_string())
-                            .collect();
+                    } else if let Some(stripped) = part.strip_prefix("until ") {
+                        let deps = stripped.split_whitespace().map(|s| s.to_string()).collect();
                         result.until = deps;
                     } else if self.looks_like_date(part) {
                         // It's a date
@@ -708,8 +700,7 @@ impl GanttDb {
 
         // Check for duration patterns: 1d, 2w, 3h, 4m, 5s, 6ms
         for suffix in ["ms", "w", "d", "h", "m", "s"] {
-            if s.ends_with(suffix) {
-                let num_part = &s[..s.len() - suffix.len()];
+            if let Some(num_part) = s.strip_suffix(suffix) {
                 if num_part.parse::<f64>().is_ok() {
                     return true;
                 }

--- a/src/diagrams/git/types.rs
+++ b/src/diagrams/git/types.rs
@@ -15,6 +15,7 @@ pub enum CommitType {
 
 impl CommitType {
     /// Parse a commit type from a string
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_uppercase().as_str() {
             "REVERSE" => Self::Reverse,
@@ -41,6 +42,7 @@ pub enum DiagramOrientation {
 }
 
 impl DiagramOrientation {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_uppercase().as_str() {
             "TB" | "TD" => Self::TopToBottom,

--- a/src/diagrams/kanban/types.rs
+++ b/src/diagrams/kanban/types.rs
@@ -15,6 +15,7 @@ pub enum Priority {
 
 impl Priority {
     /// Parse a priority from a string
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "very high" | "veryhigh" => Some(Self::VeryHigh),

--- a/src/diagrams/radar/types.rs
+++ b/src/diagrams/radar/types.rs
@@ -14,6 +14,7 @@ pub enum Graticule {
 }
 
 impl Graticule {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "polygon" => Graticule::Polygon,

--- a/src/diagrams/sequence/parser.rs
+++ b/src/diagrams/sequence/parser.rs
@@ -530,12 +530,10 @@ fn parse_arrow_type(arrow: &str) -> (LineType, bool, bool) {
         } else {
             LineType::SolidOpen
         }
+    } else if is_dotted {
+        LineType::DottedOpen
     } else {
-        if is_dotted {
-            LineType::DottedOpen
-        } else {
-            LineType::SolidOpen
-        }
+        LineType::SolidOpen
     };
 
     (line_type, activate, deactivate)

--- a/src/diagrams/sequence/types.rs
+++ b/src/diagrams/sequence/types.rs
@@ -83,6 +83,7 @@ pub enum Placement {
 }
 
 impl Placement {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "rightof" | "right of" => Self::RightOf,
@@ -107,6 +108,7 @@ pub enum ParticipantType {
 }
 
 impl ParticipantType {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "actor" => Self::Actor,

--- a/src/diagrams/state/types.rs
+++ b/src/diagrams/state/types.rs
@@ -18,6 +18,7 @@ pub enum StateType {
 }
 
 impl StateType {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "start" => Self::Start,
@@ -52,6 +53,7 @@ pub enum NotePosition {
 }
 
 impl NotePosition {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "left of" | "leftof" => Self::LeftOf,
@@ -163,6 +165,7 @@ pub enum Direction {
 }
 
 impl Direction {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s.to_uppercase().as_str() {
             "BT" => Self::BottomToTop,

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -11,9 +11,9 @@
 //! # References
 //! - <https://sw.kovidgoyal.net/kitty/graphics-protocol/>
 
-use std::io::{self, Write};
 #[cfg(unix)]
 use std::io::Read;
+use std::io::{self, Write};
 use std::sync::OnceLock;
 
 use base64::Engine;

--- a/src/kitty.rs
+++ b/src/kitty.rs
@@ -11,7 +11,9 @@
 //! # References
 //! - <https://sw.kovidgoyal.net/kitty/graphics-protocol/>
 
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
+#[cfg(unix)]
+use std::io::Read;
 use std::sync::OnceLock;
 
 use base64::Engine;
@@ -229,6 +231,7 @@ fn query_terminal_color(osc_code: u8) -> Option<BackgroundColor> {
 }
 
 /// Parse RGB color from terminal response.
+#[cfg(unix)]
 fn parse_rgb_response(response: &str) -> Option<BackgroundColor> {
     // Look for rgb:RRRR/GGGG/BBBB pattern
     let rgb_start = response.find("rgb:")?;
@@ -254,6 +257,7 @@ fn parse_rgb_response(response: &str) -> Option<BackgroundColor> {
 }
 
 /// Try to read background color from Ghostty config file.
+#[cfg(unix)]
 fn get_ghostty_background() -> Option<BackgroundColor> {
     let home = std::env::var("HOME").ok()?;
     let config_path = format!("{}/.config/ghostty/config", home);
@@ -514,6 +518,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_parse_rgb_response_standard() {
         // Standard 16-bit response format
         let response = "\x1b]11;rgb:1e1e/1e1e/1e1e\x1b\\";
@@ -524,6 +529,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_parse_rgb_response_white() {
         let response = "\x1b]11;rgb:ffff/ffff/ffff\x1b\\";
         let color = parse_rgb_response(response).unwrap();
@@ -533,6 +539,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(unix)]
     fn test_parse_rgb_response_invalid() {
         // No rgb: prefix
         assert!(parse_rgb_response("invalid response").is_none());

--- a/src/layout/dagre/normalize.rs
+++ b/src/layout/dagre/normalize.rs
@@ -137,11 +137,8 @@ pub fn undo(graph: &mut DagreGraph) {
         // Collect points from dummy nodes
         let mut points = Vec::new();
 
-        loop {
-            let node = match graph.node(&current) {
-                Some(n) => n.clone(),
-                None => break,
-            };
+        while let Some(n) = graph.node(&current) {
+            let node = n.clone();
 
             // Check if this is still a dummy node
             if node.dummy.is_none() {
@@ -202,7 +199,7 @@ pub fn intersect_node(node: &NodeLabel, p: &super::graph::Point) -> super::graph
 pub fn intersect_rect(node: &NodeLabel, p: &super::graph::Point) -> super::graph::Point {
     let (cx, cy) = match (node.x, node.y) {
         (Some(x), Some(y)) => (x, y),
-        _ => return p.clone(),
+        _ => return *p,
     };
 
     let w = node.width / 2.0;
@@ -239,7 +236,7 @@ pub fn intersect_rect(node: &NodeLabel, p: &super::graph::Point) -> super::graph
 pub fn intersect_diamond(node: &NodeLabel, p: &super::graph::Point) -> super::graph::Point {
     let (cx, cy) = match (node.x, node.y) {
         (Some(x), Some(y)) => (x, y),
-        _ => return p.clone(),
+        _ => return *p,
     };
 
     let w = node.width / 2.0;
@@ -271,7 +268,7 @@ pub fn intersect_diamond(node: &NodeLabel, p: &super::graph::Point) -> super::gr
 pub fn intersect_circle(node: &NodeLabel, p: &super::graph::Point) -> super::graph::Point {
     let (cx, cy) = match (node.x, node.y) {
         (Some(x), Some(y)) => (x, y),
-        _ => return p.clone(),
+        _ => return *p,
     };
 
     // For circles, use the smaller of width/height as diameter
@@ -296,7 +293,7 @@ pub fn intersect_circle(node: &NodeLabel, p: &super::graph::Point) -> super::gra
 pub fn intersect_ellipse(node: &NodeLabel, p: &super::graph::Point) -> super::graph::Point {
     let (cx, cy) = match (node.x, node.y) {
         (Some(x), Some(y)) => (x, y),
-        _ => return p.clone(),
+        _ => return *p,
     };
 
     let rx = node.width / 2.0;
@@ -382,8 +379,8 @@ pub fn assign_node_intersects(graph: &mut DagreGraph) {
         let end_point = intersect_node(&node_w, &p2);
 
         // Add start and end points
-        points.insert(0, start_point.clone());
-        points.push(end_point.clone());
+        points.insert(0, start_point);
+        points.push(end_point);
 
         // For edges with only 2 points (no intermediate dummy nodes),
         // add intermediate points to create smooth curved edges like mermaid.js

--- a/src/layout/dagre/rank/network_simplex.rs
+++ b/src/layout/dagre/rank/network_simplex.rs
@@ -35,6 +35,12 @@ pub struct TreeNode {
     pub parent: Option<String>,
 }
 
+impl Default for SpanningTree {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SpanningTree {
     pub fn new() -> Self {
         Self {
@@ -240,7 +246,7 @@ fn dfs_assign(tree: &mut SpanningTree, v: &str, parent: Option<&str>, counter: &
     // Visit children
     let neighbors: Vec<String> = tree.neighbors(v);
     for w in neighbors {
-        if parent.map_or(true, |p| p != w) {
+        if parent.is_none_or(|p| p != w) {
             dfs_assign(tree, &w, Some(v), counter);
         }
     }
@@ -337,7 +343,7 @@ fn is_descendant(tree: &SpanningTree, v: &str, u: &str) -> bool {
 pub fn leave_edge(tree: &SpanningTree) -> Option<(String, String)> {
     for (v, w) in tree.edges_list() {
         if let Some(edge) = tree.edge(v, w) {
-            if edge.cutvalue.map_or(false, |cv| cv < 0) {
+            if edge.cutvalue.is_some_and(|cv| cv < 0) {
                 return Some((v.to_string(), w.to_string()));
             }
         }

--- a/src/layout/graph.rs
+++ b/src/layout/graph.rs
@@ -120,14 +120,14 @@ impl LayoutGraph {
     /// Get all node IDs (recursively including children)
     pub fn all_node_ids(&self) -> Vec<&str> {
         let mut ids = Vec::new();
-        self.collect_node_ids(&self.nodes, &mut ids);
+        Self::collect_node_ids(&self.nodes, &mut ids);
         ids
     }
 
-    fn collect_node_ids<'a>(&self, nodes: &'a [LayoutNode], ids: &mut Vec<&'a str>) {
+    fn collect_node_ids<'a>(nodes: &'a [LayoutNode], ids: &mut Vec<&'a str>) {
         for node in nodes {
             ids.push(&node.id);
-            self.collect_node_ids(&node.children, ids);
+            Self::collect_node_ids(&node.children, ids);
         }
     }
 
@@ -188,16 +188,16 @@ impl LayoutGraph {
     where
         F: FnMut(&LayoutNode),
     {
-        self.traverse_nodes_recursive(&self.nodes, &mut f);
+        Self::traverse_nodes_recursive(&self.nodes, &mut f);
     }
 
-    fn traverse_nodes_recursive<F>(&self, nodes: &[LayoutNode], f: &mut F)
+    fn traverse_nodes_recursive<F>(nodes: &[LayoutNode], f: &mut F)
     where
         F: FnMut(&LayoutNode),
     {
         for node in nodes {
             f(node);
-            self.traverse_nodes_recursive(&node.children, f);
+            Self::traverse_nodes_recursive(&node.children, f);
         }
     }
 
@@ -226,7 +226,7 @@ impl LayoutGraph {
         let mut rec_stack = HashSet::new();
 
         for node_id in self.all_node_ids() {
-            if self.has_cycle_dfs(node_id, &adj, &mut visited, &mut rec_stack) {
+            if Self::has_cycle_dfs(node_id, &adj, &mut visited, &mut rec_stack) {
                 return true;
             }
         }
@@ -234,7 +234,6 @@ impl LayoutGraph {
     }
 
     fn has_cycle_dfs<'a>(
-        &self,
         node_id: &'a str,
         adj: &HashMap<&'a str, Vec<&'a str>>,
         visited: &mut HashSet<&'a str>,
@@ -252,7 +251,7 @@ impl LayoutGraph {
 
         if let Some(neighbors) = adj.get(node_id) {
             for &neighbor in neighbors {
-                if self.has_cycle_dfs(neighbor, adj, visited, rec_stack) {
+                if Self::has_cycle_dfs(neighbor, adj, visited, rec_stack) {
                     return true;
                 }
             }

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -154,7 +154,7 @@ fn apply_dagre_results(graph: &mut LayoutGraph, dg: &DagreGraph) {
                             Some(Point::new((p1.x + p2.x) / 2.0, (p1.y + p2.y) / 2.0));
                     } else {
                         // Use the middle point if odd number
-                        edge.label_position = Some(edge.bend_points[mid_idx].clone());
+                        edge.label_position = Some(edge.bend_points[mid_idx]);
                     }
                 }
             }

--- a/src/render/class.rs
+++ b/src/render/class.rs
@@ -157,8 +157,7 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
     if is_horizontal {
         // Horizontal layout: levels go left-to-right
         let mut current_x = margin;
-        for level in 0..=max_level {
-            let level_classes = &levels[level];
+        for level_classes in levels.iter().take(max_level + 1) {
             if level_classes.is_empty() {
                 continue;
             }
@@ -185,10 +184,7 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
         // Process levels from bottom to top
         for level in (0..=max_level).rev() {
             for class_id in &levels[level] {
-                let children: Vec<_> = children_of
-                    .get(class_id)
-                    .map(|c| c.clone())
-                    .unwrap_or_default();
+                let children: Vec<_> = children_of.get(class_id).cloned().unwrap_or_default();
 
                 if children.is_empty() {
                     // Leaf node: width is just the class width
@@ -209,8 +205,7 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
 
         // First pass: calculate y positions for each level
         let mut level_y: Vec<f64> = Vec::new();
-        for level in 0..=max_level {
-            let level_classes = &levels[level];
+        for level_classes in levels.iter().take(max_level + 1) {
             if level_classes.is_empty() {
                 level_y.push(current_y);
                 continue;
@@ -229,6 +224,7 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
 
         // Second pass: calculate x positions using tree centering
         // Start with root nodes, position them, then recursively position children
+        #[allow(clippy::too_many_arguments)]
         fn position_subtree(
             node_id: &str,
             start_x: f64,
@@ -289,8 +285,8 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
         }
 
         // Position any orphan nodes (not in any tree) - place them at the end
-        for level in 0..=max_level {
-            for class_id in &levels[level] {
+        for (level, level_classes) in levels.iter().enumerate().take(max_level + 1) {
+            for class_id in level_classes {
                 if !class_positions.contains_key(class_id) {
                     let y = level_y.get(level).copied().unwrap_or(0.0);
                     class_positions.insert(class_id.clone(), (root_x, y));
@@ -384,6 +380,7 @@ pub fn render_class(db: &ClassDb, config: &RenderConfig) -> Result<String> {
 }
 
 /// Render a class box with name, attributes, and methods
+#[allow(clippy::too_many_arguments)]
 fn render_class_box(
     class: &ClassNode,
     x: f64,
@@ -548,6 +545,7 @@ fn render_class_box(
 }
 
 /// Render a relation between two classes
+#[allow(clippy::too_many_arguments)]
 fn render_relation(
     x1: f64,
     y1: f64,
@@ -743,12 +741,10 @@ fn calculate_connection_points(
         } else {
             (x2 + width, center2_y) // Right edge
         }
+    } else if dy > 0.0 {
+        (center2_x, y2) // Top edge
     } else {
-        if dy > 0.0 {
-            (center2_x, y2) // Top edge
-        } else {
-            (center2_x, y2 + h2) // Bottom edge
-        }
+        (center2_x, y2 + h2) // Bottom edge
     };
 
     (start_x, start_y, end_x, end_y)

--- a/src/render/er.rs
+++ b/src/render/er.rs
@@ -254,6 +254,7 @@ pub fn render_er(db: &ErDb, config: &RenderConfig) -> Result<String> {
 }
 
 /// Render an entity box with attributes
+#[allow(clippy::too_many_arguments)]
 fn render_entity(
     entity: &Entity,
     x: f64,
@@ -351,6 +352,7 @@ fn render_entity(
 }
 
 /// Render a relationship line between two entities
+#[allow(clippy::too_many_arguments)]
 fn render_relationship(
     x1: f64,
     y1: f64,

--- a/src/render/gantt.rs
+++ b/src/render/gantt.rs
@@ -284,6 +284,7 @@ pub fn render_gantt(db: &mut GanttDb, config: &RenderConfig) -> Result<String> {
 }
 
 /// Render the timeline axis and vertical grid lines
+#[allow(clippy::too_many_arguments)]
 fn render_timeline_axis(
     x: f64,
     y: f64,

--- a/src/render/pie.rs
+++ b/src/render/pie.rs
@@ -54,7 +54,7 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
     // sorted by value descending. Legend stays in original order.
 
     // Step 1: Create color mapping based on original order
-    let sections_vec: Vec<_> = sections.iter().cloned().collect();
+    let sections_vec: Vec<_> = sections.to_vec();
     let label_to_color_index: std::collections::HashMap<_, _> = sections_vec
         .iter()
         .enumerate()

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -260,6 +260,7 @@ pub fn render_state(db: &StateDb, config: &RenderConfig) -> Result<String> {
 }
 
 /// Render a state node based on its type
+#[allow(clippy::too_many_arguments)]
 fn render_state_node(
     state: &State,
     x: f64,
@@ -417,6 +418,7 @@ fn render_state_node(
 }
 
 /// Render a transition between two states
+#[allow(clippy::too_many_arguments)]
 fn render_transition(
     x1: f64,
     y1: f64,
@@ -494,6 +496,7 @@ fn render_transition(
 }
 
 /// Calculate exit point from a state
+#[allow(clippy::too_many_arguments)]
 fn calculate_exit_point(
     x: f64,
     y: f64,
@@ -543,6 +546,7 @@ fn calculate_exit_point(
 }
 
 /// Calculate entry point into a state
+#[allow(clippy::too_many_arguments)]
 fn calculate_entry_point(
     x: f64,
     y: f64,
@@ -693,7 +697,7 @@ fn determine_start_end_states(db: &StateDb) -> HashMap<&str, StartEndInfo> {
     let relations = db.get_relations();
 
     // Classify states in the states map
-    for (id, _state) in db.get_states() {
+    for id in db.get_states().keys() {
         if id.starts_with("[*]_start") {
             result.insert(id.as_str(), StartEndInfo { is_start: true });
         } else if id.starts_with("[*]_end") {

--- a/src/render/svg/document.rs
+++ b/src/render/svg/document.rs
@@ -1,6 +1,7 @@
 //! SVG document builder
 
 use super::elements::{Attrs, SvgElement};
+use std::fmt;
 
 /// SVG document builder
 #[derive(Debug, Clone)]
@@ -92,13 +93,18 @@ impl SvgDocument {
     pub fn add_node(&mut self, element: SvgElement) {
         self.nodes.push(element);
     }
+}
 
-    /// Convert to SVG string
-    pub fn to_string(&self) -> String {
-        let mut result = String::new();
+impl Default for SvgDocument {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
+impl fmt::Display for SvgDocument {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // XML declaration
-        result.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        writeln!(f, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>")?;
 
         // SVG opening tag
         let view_box_str = self
@@ -106,63 +112,51 @@ impl SvgDocument {
             .map(|(x, y, w, h)| format!(" viewBox=\"{} {} {} {}\"", x, y, w, h))
             .unwrap_or_default();
 
-        result.push_str(&format!(
-            "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{}\" height=\"{}\"{} class=\"mermaid\">\n",
+        writeln!(
+            f,
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{}\" height=\"{}\"{} class=\"mermaid\">",
             self.width, self.height, view_box_str
-        ));
+        )?;
 
         // Styles
         if !self.styles.is_empty() {
-            result.push_str("  <style>\n");
+            writeln!(f, "  <style>")?;
             for style in &self.styles {
-                result.push_str(style);
-                result.push('\n');
+                writeln!(f, "{}", style)?;
             }
-            result.push_str("  </style>\n");
+            writeln!(f, "  </style>")?;
         }
 
         // Defs
         if !self.defs.is_empty() {
-            result.push_str("  <defs>\n");
+            writeln!(f, "  <defs>")?;
             for def in &self.defs {
-                result.push_str(&def.to_svg(2));
-                result.push('\n');
+                writeln!(f, "{}", def.to_svg(2))?;
             }
-            result.push_str("  </defs>\n");
+            writeln!(f, "  </defs>")?;
         }
 
         // Content group (root)
-        result.push_str("  <g class=\"root\">\n");
+        writeln!(f, "  <g class=\"root\">")?;
 
-        // Container groups in mermaid.js order: clusters, edgePaths, edgeLabels, nodes
-        // This ensures proper layering (clusters behind, nodes on top)
-        self.render_container_group(&mut result, "clusters", &self.clusters);
-        self.render_container_group(&mut result, "edgePaths", &self.edge_paths);
-        self.render_container_group(&mut result, "edgeLabels", &self.edge_labels);
-        self.render_container_group(&mut result, "nodes", &self.nodes);
-
-        // Legacy elements (for backwards compatibility)
-        for element in &self.elements {
-            result.push_str(&element.to_svg(2));
-            result.push('\n');
+        // Container groups in mermaid.js order
+        for (class, elements) in [
+            ("clusters", &self.clusters),
+            ("edgePaths", &self.edge_paths),
+            ("edgeLabels", &self.edge_labels),
+            ("nodes", &self.nodes),
+        ] {
+            let group =
+                SvgElement::group(elements.to_vec()).with_attrs(Attrs::new().with_class(class));
+            writeln!(f, "{}", group.to_svg(2))?;
         }
 
-        result.push_str("  </g>\n");
-        result.push_str("</svg>\n");
+        // Legacy elements
+        for element in &self.elements {
+            writeln!(f, "{}", element.to_svg(2))?;
+        }
 
-        result
-    }
-
-    /// Render a container group with elements
-    fn render_container_group(&self, result: &mut String, class: &str, elements: &[SvgElement]) {
-        let group = SvgElement::group(elements.to_vec()).with_attrs(Attrs::new().with_class(class));
-        result.push_str(&group.to_svg(2));
-        result.push('\n');
-    }
-}
-
-impl Default for SvgDocument {
-    fn default() -> Self {
-        Self::new()
+        writeln!(f, "  </g>")?;
+        writeln!(f, "</svg>")
     }
 }

--- a/src/render/svg/elements.rs
+++ b/src/render/svg/elements.rs
@@ -61,6 +61,7 @@ impl Attrs {
     }
 
     /// Convert to SVG attribute string
+    #[allow(clippy::inherent_to_string)]
     pub fn to_string(&self) -> String {
         let mut result = String::new();
 

--- a/src/render/svg/structure.rs
+++ b/src/render/svg/structure.rs
@@ -340,7 +340,7 @@ fn count_nodes_and_edges(doc: &roxmltree::Document) -> (usize, usize) {
             // mermaid-rs uses "edge" class on <g> elements
             // mermaid.js uses "flowchart-link" on <path> elements with data-edge
             // We only count "edge" here since data-edge is handled above
-            if node.tag_name().name() == "g" && classes.iter().any(|c| *c == "edge") {
+            if node.tag_name().name() == "g" && classes.contains(&"edge") {
                 edge_count += 1;
             }
         }

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -176,23 +176,23 @@ mod pdf_output_tests {
         ];
 
         for (name, input) in diagrams {
-            let diagram = parse(input).expect(&format!("Failed to parse {}", name));
-            let svg = render(&diagram).expect(&format!("Failed to render {}", name));
+            let diagram = parse(input).unwrap_or_else(|_| panic!("Failed to parse {}", name));
+            let svg = render(&diagram).unwrap_or_else(|_| panic!("Failed to render {}", name));
 
             use resvg::usvg;
 
             let mut opt = usvg::Options::default();
             opt.fontdb_mut().load_system_fonts();
 
-            let tree =
-                usvg::Tree::from_str(&svg, &opt).expect(&format!("Failed to parse {} SVG", name));
+            let tree = usvg::Tree::from_str(&svg, &opt)
+                .unwrap_or_else(|_| panic!("Failed to parse {} SVG", name));
 
             let pdf_data = svg2pdf::to_pdf(
                 &tree,
                 svg2pdf::ConversionOptions::default(),
                 svg2pdf::PageOptions::default(),
             )
-            .expect(&format!("Failed to convert {} to PDF", name));
+            .unwrap_or_else(|_| panic!("Failed to convert {} to PDF", name));
 
             assert!(
                 pdf_data.starts_with(b"%PDF-"),
@@ -342,12 +342,10 @@ fn test_flowchart_all_directions() {
 
     for dir in &directions {
         let input = format!("flowchart {}\n    A --> B", dir);
-        let diagram =
-            parse(&input).expect(&format!("Failed to parse flowchart with direction {}", dir));
-        let svg = render(&diagram).expect(&format!(
-            "Failed to render flowchart with direction {}",
-            dir
-        ));
+        let diagram = parse(&input)
+            .unwrap_or_else(|_| panic!("Failed to parse flowchart with direction {}", dir));
+        let svg = render(&diagram)
+            .unwrap_or_else(|_| panic!("Failed to render flowchart with direction {}", dir));
 
         assert!(
             svg.contains("<svg"),

--- a/tools/gallery/analyze_diff.rs
+++ b/tools/gallery/analyze_diff.rs
@@ -42,6 +42,7 @@ struct Difference {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
 enum Severity {
     Critical,
     Major,
@@ -213,7 +214,7 @@ fn extract_metrics(svg_content: &str) -> SvgMetrics {
     metrics
 }
 
-fn compare_metrics(name: &str, rs: &SvgMetrics, ref_metrics: &SvgMetrics) -> Vec<Difference> {
+fn compare_metrics(_name: &str, rs: &SvgMetrics, ref_metrics: &SvgMetrics) -> Vec<Difference> {
     let mut diffs = Vec::new();
 
     // Dimension differences


### PR DESCRIPTION
## Summary
- Fixed all 90+ clippy warnings across the codebase
- Updated CI to enforce lint checks with `cargo clippy -- -D warnings`
- All tests passing

## Changes
- **Idiomatic Rust patterns**: Replaced manual implementations with `.clamp()`, `while let`, `strip_prefix/strip_suffix`, `.first()`
- **Recursive functions**: Made static methods where `&self` was only used for recursion
- **Allow attributes**: Added for intentional patterns (`from_str` methods, functions with many rendering arguments)
- **Display trait**: Implemented for `SvgDocument` to fix `inherent_to_string` warning
- **Iterator loops**: Replaced index-based loops with iterators where appropriate

## Test plan
- [x] `cargo clippy --features all-formats -- -D warnings` passes
- [x] `cargo test --features all-formats` passes
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)