### PR TITLE
Fix wasm-pack build by pinning to version 0.12.1

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -27,7 +27,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        run: cargo install wasm-pack@0.12.1
 
       - name: Build WASM package
         run: wasm-pack build --target web --features wasm --out-dir playground/pkg


### PR DESCRIPTION
Newer wasm-pack versions use Cargo's --out-dir flag which has been
renamed to --artifact-dir and is only available on nightly Rust.
Pin to 0.12.1 to avoid this issue on stable Rust.