### PR TITLE
Add theme support and Playwright tests to playground

### DIFF
--- a/.github/workflows/test-playground.yml
+++ b/.github/workflows/test-playground.yml
@@ -1,0 +1,69 @@
+name: Test Playground
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'playground/**'
+      - 'playground-tests/**'
+      - 'src/**'
+      - 'Cargo.toml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'playground/**'
+      - 'playground-tests/**'
+      - 'src/**'
+      - 'Cargo.toml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack@0.12.1
+
+      - name: Build WASM package
+        run: |
+          wasm-pack build --target web --features wasm
+          mv pkg playground/pkg
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: playground-tests/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          cd playground-tests
+          npm ci
+
+      - name: Install Playwright browsers
+        run: |
+          cd playground-tests
+          npx playwright install chromium --with-deps
+
+      - name: Run Playwright tests
+        run: |
+          cd playground-tests
+          npm test
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playground-tests/playwright-report/
+          retention-days: 7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["diagram", "chart", "flowchart", "sequence", "mermaid"]
 categories = ["visualization", "parsing"]
 
 [lib]
-name = "mermaid"
+name = "selkie"
 path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Selkie aims to provide a fast, native alternative to Mermaid.js for parsing and 
 
 This project has been built entirely with coding agents, mostly [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Development is guided by an evaluation system that compares Selkie's output against the reference Mermaid.js implementation, toward visual and structural parity.
 
+## Live Playground
+
+Try Selkie in your browser: **[btucker.github.io/selkie](https://btucker.github.io/selkie/)**
+
+The playground runs entirely client-side using WebAssembly, featuring:
+- Real-time diagram rendering as you type
+- Multiple theme support (default, dark, forest, neutral, base)
+- Example diagrams for all supported types
+- URL sharing for diagrams
+- SVG download
+
 ## Performance
 
 Selkie provides significant performance improvements over mermaid-js in both CLI and browser environments.

--- a/playground-tests/.gitignore
+++ b/playground-tests/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+test-results/
+playwright-report/
+.playwright-mcp/

--- a/playground-tests/package-lock.json
+++ b/playground-tests/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "playground-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "playground-tests",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@playwright/test": "^1.57.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/playground-tests/package.json
+++ b/playground-tests/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "playground-tests",
+  "version": "1.0.0",
+  "description": "Playwright tests for Selkie playground",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "test:ui": "playwright test --ui"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "module",
+  "devDependencies": {
+    "@playwright/test": "^1.57.0"
+  }
+}

--- a/playground-tests/playwright.config.js
+++ b/playground-tests/playwright.config.js
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:8080',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'python3 -m http.server 8080 -d ../playground',
+    url: 'http://localhost:8080',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/playground-tests/tests/playground.spec.js
+++ b/playground-tests/tests/playground.spec.js
@@ -1,0 +1,240 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Selkie Playground', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    // Wait for WASM to load
+    await expect(page.getByText(/Rendered in/)).toBeVisible({ timeout: 30000 });
+  });
+
+  test.describe('Initial Load', () => {
+    test('should display the page title', async ({ page }) => {
+      await expect(page).toHaveTitle('Selkie Playground - Mermaid Diagram Editor');
+    });
+
+    test('should show the header with logo and title', async ({ page }) => {
+      await expect(page.getByRole('heading', { name: 'Selkie Playground' })).toBeVisible();
+      await expect(page.getByText('Fast Mermaid diagram rendering in Rust/WASM')).toBeVisible();
+    });
+
+    test('should load default example diagram', async ({ page }) => {
+      const editor = page.locator('#editor');
+      const value = await editor.inputValue();
+      expect(value).toContain('flowchart TD');
+    });
+
+    test('should render default diagram as SVG', async ({ page }) => {
+      const preview = page.locator('#preview');
+      await expect(preview.locator('svg')).toBeVisible();
+    });
+
+    test('should display render time', async ({ page }) => {
+      await expect(page.getByText(/Rendered in \d+\.\d+ms/)).toBeVisible();
+    });
+  });
+
+  test.describe('Theme Selection', () => {
+    test('should have theme selector with all themes', async ({ page }) => {
+      const themeSelect = page.getByLabel('Select theme');
+      await expect(themeSelect).toBeVisible();
+
+      const options = themeSelect.locator('option');
+      await expect(options).toHaveCount(5);
+      await expect(options.nth(0)).toHaveText('Default');
+      await expect(options.nth(1)).toHaveText('Dark');
+      await expect(options.nth(2)).toHaveText('Forest');
+      await expect(options.nth(3)).toHaveText('Neutral');
+      await expect(options.nth(4)).toHaveText('Base');
+    });
+
+    test('should switch to dark theme and update background', async ({ page }) => {
+      const themeSelect = page.getByLabel('Select theme');
+      await themeSelect.selectOption('Dark');
+
+      // Check URL includes theme
+      await expect(page).toHaveURL(/#dark:/);
+
+      // Check preview background changed (dark theme background is #1f2020)
+      const previewContainer = page.locator('#preview-container');
+      await expect(previewContainer).toHaveCSS('background-color', 'rgb(31, 32, 32)');
+    });
+
+    test('should switch to forest theme', async ({ page }) => {
+      const themeSelect = page.getByLabel('Select theme');
+      await themeSelect.selectOption('Forest');
+
+      await expect(page).toHaveURL(/#forest:/);
+      // Forest theme has white background
+      const previewContainer = page.locator('#preview-container');
+      await expect(previewContainer).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+    });
+
+    test('should persist theme in URL', async ({ page }) => {
+      // Switch to dark theme
+      await page.getByLabel('Select theme').selectOption('Dark');
+
+      // Get current URL
+      const url = page.url();
+      expect(url).toContain('#dark:');
+
+      // Reload page
+      await page.reload();
+      await expect(page.getByText(/Rendered in/)).toBeVisible({ timeout: 30000 });
+
+      // Verify theme is restored
+      await expect(page.getByLabel('Select theme')).toHaveValue('dark');
+    });
+  });
+
+  test.describe('Example Selection', () => {
+    test('should have example selector', async ({ page }) => {
+      const exampleSelect = page.getByLabel('Select example diagram');
+      await expect(exampleSelect).toBeVisible();
+    });
+
+    test('should load flowchart example', async ({ page }) => {
+      await page.getByLabel('Select example diagram').selectOption('flowchart-simple');
+      await page.waitForTimeout(200); // Wait for example to load
+
+      const editor = page.locator('#editor');
+      const value = await editor.inputValue();
+      expect(value).toContain('flowchart TD');
+    });
+
+    test('should load sequence diagram example', async ({ page }) => {
+      await page.getByLabel('Select example diagram').selectOption('sequence-simple');
+      await page.waitForTimeout(200); // Wait for example to load
+
+      const editor = page.locator('#editor');
+      const value = await editor.inputValue();
+      expect(value).toContain('sequenceDiagram');
+      await expect(page.getByText(/Rendered in/)).toBeVisible();
+    });
+
+    test('should load pie chart example', async ({ page }) => {
+      await page.getByLabel('Select example diagram').selectOption('pie-simple');
+      await page.waitForTimeout(200); // Wait for example to load
+
+      const editor = page.locator('#editor');
+      const value = await editor.inputValue();
+      expect(value).toContain('pie');
+    });
+  });
+
+  test.describe('Editor Functionality', () => {
+    test('should update diagram on typing', async ({ page }) => {
+      const editor = page.getByRole('textbox', { name: /Enter Mermaid diagram/ });
+
+      // Clear and type new diagram
+      await editor.fill('flowchart LR\n  A --> B');
+
+      // Wait for render
+      await expect(page.getByText(/Rendered in/)).toBeVisible();
+
+      // Check SVG contains expected text
+      const preview = page.locator('#preview svg');
+      await expect(preview).toBeVisible();
+    });
+
+    test('should show error for invalid syntax', async ({ page }) => {
+      const editor = page.getByRole('textbox', { name: /Enter Mermaid diagram/ });
+
+      // Type invalid diagram
+      await editor.fill('invalid diagram syntax !!!');
+
+      // Wait a bit for render attempt
+      await page.waitForTimeout(500);
+
+      // Check error display
+      const errorDisplay = page.locator('#error-display');
+      await expect(errorDisplay).toBeVisible();
+    });
+
+    test('should clear error when valid syntax entered', async ({ page }) => {
+      const editor = page.getByRole('textbox', { name: /Enter Mermaid diagram/ });
+
+      // Type invalid, then valid
+      await editor.fill('invalid!!!');
+      await page.waitForTimeout(300);
+
+      await editor.fill('flowchart TD\n  A --> B');
+      await expect(page.getByText(/Rendered in/)).toBeVisible();
+
+      const errorDisplay = page.locator('#error-display');
+      await expect(errorDisplay).toBeHidden();
+    });
+  });
+
+  test.describe('Zoom Controls', () => {
+    test('should zoom in', async ({ page }) => {
+      const zoomIn = page.getByRole('button', { name: '+' });
+      const zoomReset = page.getByRole('button', { name: /\d+%/ });
+
+      await zoomIn.click();
+      await expect(zoomReset).toHaveText('125%');
+    });
+
+    test('should zoom out', async ({ page }) => {
+      const zoomOut = page.getByRole('button', { name: '-' });
+      const zoomReset = page.getByRole('button', { name: /\d+%/ });
+
+      await zoomOut.click();
+      await expect(zoomReset).toHaveText('75%');
+    });
+
+    test('should reset zoom', async ({ page }) => {
+      const zoomIn = page.getByRole('button', { name: '+' });
+      const zoomReset = page.getByRole('button', { name: /\d+%/ });
+
+      // Zoom in first
+      await zoomIn.click();
+      await zoomIn.click();
+      await expect(zoomReset).toHaveText('150%');
+
+      // Reset
+      await zoomReset.click();
+      await expect(zoomReset).toHaveText('100%');
+    });
+  });
+
+  test.describe('Download SVG', () => {
+    test('should have download button', async ({ page }) => {
+      const downloadBtn = page.getByRole('button', { name: 'Download SVG' });
+      await expect(downloadBtn).toBeVisible();
+    });
+
+    test('should trigger download on click', async ({ page }) => {
+      const downloadPromise = page.waitForEvent('download');
+
+      await page.getByRole('button', { name: 'Download SVG' }).click();
+
+      const download = await downloadPromise;
+      expect(download.suggestedFilename()).toBe('diagram.svg');
+    });
+  });
+
+  test.describe('URL State', () => {
+    test('should update URL when diagram changes', async ({ page }) => {
+      const editor = page.getByRole('textbox', { name: /Enter Mermaid diagram/ });
+
+      await editor.fill('flowchart LR\n  X --> Y');
+
+      // URL should be updated
+      await expect(page).toHaveURL(/#/);
+    });
+  });
+});
+
+// Separate test without beforeEach to test URL hash loading
+test('should load diagram from URL hash', async ({ page }) => {
+  // Navigate with a specific hash (base64 encoded "flowchart LR\n  Custom")
+  const diagram = 'flowchart LR\n  Custom';
+  const encoded = btoa(encodeURIComponent(diagram));
+
+  await page.goto(`/#${encoded}`);
+  await expect(page.getByText(/Rendered in/)).toBeVisible({ timeout: 30000 });
+
+  const editor = page.locator('#editor');
+  const value = await editor.inputValue();
+  expect(value).toContain('Custom');
+});

--- a/playground/app.js
+++ b/playground/app.js
@@ -411,14 +411,25 @@ const examples = {
 // State
 let selkie = null;
 let currentZoom = 1;
+let currentTheme = 'default';
 let renderTimeout = null;
 let lastSvg = '';
+
+// Theme backgrounds (must match Rust theme definitions)
+const themeBackgrounds = {
+    'default': '#ffffff',
+    'dark': '#1f2020',
+    'forest': '#ffffff',
+    'neutral': '#ffffff',
+    'base': '#f4f4f4',
+};
 
 // DOM Elements
 const editor = document.getElementById('editor');
 const preview = document.getElementById('preview');
 const errorDisplay = document.getElementById('error-display');
 const renderTimeDisplay = document.getElementById('render-time');
+const themeSelect = document.getElementById('theme-select');
 const exampleSelect = document.getElementById('example-select');
 const loadingOverlay = document.getElementById('loading-overlay');
 const divider = document.getElementById('divider');
@@ -479,6 +490,14 @@ function setupEventListeners() {
         }
     });
 
+    // Theme selector
+    themeSelect.addEventListener('change', (e) => {
+        currentTheme = e.target.value;
+        updatePreviewBackground();
+        renderDiagram();
+        updateUrl();
+    });
+
     // Zoom controls
     document.getElementById('zoom-in').addEventListener('click', () => {
         currentZoom = Math.min(currentZoom + 0.25, 3);
@@ -513,9 +532,19 @@ function renderDiagram() {
         return;
     }
 
+    // Prepend theme directive if not using default theme
+    let diagramInput = input;
+    if (currentTheme !== 'default') {
+        // Check if the diagram already has a theme directive
+        const hasThemeDirective = /%%\{.*"theme"\s*:/i.test(input);
+        if (!hasThemeDirective) {
+            diagramInput = `%%{init: {"theme": "${currentTheme}"}}%%\n${input}`;
+        }
+    }
+
     try {
         const startTime = performance.now();
-        const result = selkie.render('diagram', input);
+        const result = selkie.render('diagram', diagramInput);
         const endTime = performance.now();
 
         lastSvg = result.svg;
@@ -537,6 +566,12 @@ function renderDiagram() {
 function applyZoom() {
     preview.style.transform = `scale(${currentZoom})`;
     document.getElementById('zoom-reset').textContent = `${Math.round(currentZoom * 100)}%`;
+}
+
+// Update preview background to match theme
+function updatePreviewBackground() {
+    const bgColor = themeBackgrounds[currentTheme] || themeBackgrounds['default'];
+    previewContainer.style.backgroundColor = bgColor;
 }
 
 // Download SVG file
@@ -594,7 +629,9 @@ function updateUrl() {
     const code = editor.value;
     if (code) {
         const encoded = btoa(encodeURIComponent(code));
-        history.replaceState(null, '', `#${encoded}`);
+        // Include theme in URL if not default
+        const themePrefix = currentTheme !== 'default' ? `${currentTheme}:` : '';
+        history.replaceState(null, '', `#${themePrefix}${encoded}`);
     } else {
         history.replaceState(null, '', window.location.pathname);
     }
@@ -604,8 +641,25 @@ function loadFromUrl() {
     const hash = window.location.hash.slice(1);
     if (hash) {
         try {
-            const decoded = decodeURIComponent(atob(hash));
+            // Check for theme prefix (format: "theme:base64code" or just "base64code")
+            let theme = 'default';
+            let codeHash = hash;
+
+            const colonIndex = hash.indexOf(':');
+            if (colonIndex > 0 && colonIndex < 10) {
+                // Potential theme prefix (themes are short names)
+                const potentialTheme = hash.substring(0, colonIndex);
+                if (themeBackgrounds[potentialTheme]) {
+                    theme = potentialTheme;
+                    codeHash = hash.substring(colonIndex + 1);
+                }
+            }
+
+            const decoded = decodeURIComponent(atob(codeHash));
             editor.value = decoded;
+            currentTheme = theme;
+            themeSelect.value = theme;
+            updatePreviewBackground();
             renderDiagram();
             return;
         } catch (e) {
@@ -615,6 +669,7 @@ function loadFromUrl() {
 
     // Load default example
     editor.value = examples['flowchart-simple'];
+    updatePreviewBackground();
     renderDiagram();
 }
 

--- a/playground/index.html
+++ b/playground/index.html
@@ -16,6 +16,13 @@
             </div>
         </div>
         <div class="header-right">
+            <select id="theme-select" aria-label="Select theme">
+                <option value="default">Default</option>
+                <option value="dark">Dark</option>
+                <option value="forest">Forest</option>
+                <option value="neutral">Neutral</option>
+                <option value="base">Base</option>
+            </select>
             <select id="example-select" aria-label="Select example diagram">
                 <option value="">-- Select Example --</option>
                 <optgroup label="Basic">

--- a/src/bin/selkie.rs
+++ b/src/bin/selkie.rs
@@ -18,9 +18,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 use serde::Deserialize;
 use uuid::Uuid;
 
-use mermaid::eval::{self, runner::DiagramInput, samples};
-use mermaid::render::{RenderConfig, Theme};
-use mermaid::{parse, render_with_config};
+use selkie::eval::{self, runner::DiagramInput, samples};
+use selkie::render::{RenderConfig, Theme};
+use selkie::{parse, render_with_config};
 
 /// Configuration file format (compatible with mermaid-cli)
 #[derive(Debug, Default, Deserialize)]
@@ -287,7 +287,7 @@ fn run_render(args: RenderArgs) -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(feature = "kitty")]
         ThemeArg::Auto => {
             // Auto-detect based on terminal background
-            if mermaid::kitty::is_terminal_dark() {
+            if selkie::kitty::is_terminal_dark() {
                 if args.verbose {
                     eprintln!("Auto-detected dark terminal, using dark theme");
                 }
@@ -371,7 +371,7 @@ fn run_render(args: RenderArgs) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(feature = "kitty")]
     if args.display || args.force_display {
         // Check for kitty support
-        if !args.force_display && !mermaid::kitty::is_supported() {
+        if !args.force_display && !selkie::kitty::is_supported() {
             return Err("Terminal does not support kitty graphics protocol. Use --force-display to override.".into());
         }
 
@@ -381,7 +381,7 @@ fn run_render(args: RenderArgs) -> Result<(), Box<dyn std::error::Error>> {
 
         // Convert to PNG for display
         let png_data = svg_to_png(&svg, args.width, args.height)?;
-        mermaid::kitty::display_png(&png_data)
+        selkie::kitty::display_png(&png_data)
             .map_err(|e| format!("Failed to display image: {}", e))?;
 
         // Also write to file if output was specified

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -34,7 +34,7 @@ pub fn render(diagram: &Diagram) -> Result<String> {
 /// # Example
 ///
 /// ```
-/// use mermaid::render::render_text;
+/// use selkie::render::render_text;
 ///
 /// let svg = render_text(r#"%%{init: {"theme": "dark"}}%%
 /// flowchart TD

--- a/src/render/svg/mod.rs
+++ b/src/render/svg/mod.rs
@@ -36,7 +36,7 @@ pub struct RenderConfig {
     /// # Example
     ///
     /// ```
-    /// use mermaid::render::RenderConfig;
+    /// use selkie::render::RenderConfig;
     ///
     /// let config = RenderConfig {
     ///     theme_css: Some(".node rect { rx: 10; }".to_string()),

--- a/src/render/svg/theme.rs
+++ b/src/render/svg/theme.rs
@@ -656,7 +656,7 @@ marker path {{
     /// # Example
     /// ```
     /// use std::collections::HashMap;
-    /// use mermaid::render::svg::Theme;
+    /// use selkie::render::svg::Theme;
     ///
     /// let mut overrides = HashMap::new();
     /// overrides.insert("primaryColor".to_string(), "#ff0000".to_string());
@@ -927,8 +927,8 @@ marker path {{
     /// # Example
     ///
     /// ```
-    /// use mermaid::diagrams::DiagramConfig;
-    /// use mermaid::render::svg::Theme;
+    /// use selkie::diagrams::DiagramConfig;
+    /// use selkie::render::svg::Theme;
     /// use std::collections::HashMap;
     ///
     /// let mut config = DiagramConfig::default();

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the rendering engine
 
-use mermaid::render::{RenderConfig, Theme};
-use mermaid::{parse, render, render_text, render_with_config};
+use selkie::render::{RenderConfig, Theme};
+use selkie::{parse, render, render_text, render_with_config};
 
 // ============================================================================
 // Output Format Tests (PNG/PDF)

--- a/tests/wasm_api.rs
+++ b/tests/wasm_api.rs
@@ -3,7 +3,7 @@
 use js_sys::{Function, Reflect};
 use wasm_bindgen::JsValue;
 
-use mermaid::wasm::{initialize, parse, render, render_text};
+use selkie::wasm::{initialize, parse, render, render_text};
 
 #[test]
 fn render_text_returns_svg() {


### PR DESCRIPTION
## Summary
- Fix WASM module naming (mermaid → selkie) to fix deployment
- Add theme selector with 5 themes (default, dark, forest, neutral, base)
- Preview background matches selected theme
- Theme persists in URL
- Add comprehensive Playwright test suite (23 tests)
- Add GitHub Action to run tests on PR/push
- Update README to mention the playground

## Test plan
- [x] Verified locally that playground loads and renders diagrams
- [x] Tested theme switching updates preview background
- [x] All 23 Playwright tests pass locally
- [x] URL state persistence works for both diagrams and themes

🤖 Generated with [Claude Code](https://claude.ai/code)