### PR TITLE
Speed up test-playground with GitHub caches

### DIFF
--- a/.github/workflows/test-playground.yml
+++ b/.github/workflows/test-playground.yml
@@ -70,12 +70,6 @@ jobs:
           cd playground-tests
           npm ci
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('playground-tests/package-lock.json') }}
-
       - name: Install Playwright browsers
         run: |
           cd playground-tests

--- a/.github/workflows/test-playground.yml
+++ b/.github/workflows/test-playground.yml
@@ -30,8 +30,28 @@ jobs:
         with:
           target: wasm32-unknown-unknown
 
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Cache wasm-pack
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-0.12.1
+
       - name: Install wasm-pack
-        run: cargo install wasm-pack@0.12.1
+        run: |
+          if ! command -v wasm-pack &> /dev/null; then
+            cargo install wasm-pack@0.12.1
+          fi
 
       - name: Build WASM package
         run: |
@@ -49,6 +69,12 @@ jobs:
         run: |
           cd playground-tests
           npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('playground-tests/package-lock.json') }}
 
       - name: Install Playwright browsers
         run: |


### PR DESCRIPTION
Implement three caching layers to reduce CI/CD execution time:

- Cache Cargo registry and build artifacts to avoid recompiling Rust dependencies
- Cache wasm-pack binary to skip reinstallation on subsequent runs
- Cache Playwright browsers to avoid re-downloading Chromium (~100-200MB)

Expected improvements: 50-70% faster build times on cache hits.