### PR TITLE
Fix SVG rendering in eval report GitHub action

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -34,7 +34,10 @@ jobs:
           wasm-pack build --target web --features wasm
           mv pkg playground/pkg
 
-      - name: Install mermaid-cli for eval
+      - name: Install Chromium dependencies
+        run: npx playwright install-deps chromium
+
+      - name: Install mermaid-cli
         run: npm install -g @mermaid-js/mermaid-cli
 
       - name: Generate eval report


### PR DESCRIPTION
The mermaid-cli (mmdc) uses Puppeteer which requires browser system dependencies. Use `npx playwright install-deps chromium` to install these dependencies before running mmdc, similar to the approach in test-playground.yml.