### PR TITLE
Refactor shared diagram direction handling

### DIFF
--- a/src/diagrams/direction.rs
+++ b/src/diagrams/direction.rs
@@ -1,0 +1,59 @@
+use crate::layout::LayoutDirection;
+
+/// Shared diagram direction handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Direction {
+    #[default]
+    TopToBottom,
+    BottomToTop,
+    LeftToRight,
+    RightToLeft,
+}
+
+impl Direction {
+    /// Parse direction from mermaid syntax (supports flowchart arrow hints).
+    pub fn parse(s: &str) -> Self {
+        let s = s.trim();
+        if s.contains('<') {
+            Self::RightToLeft
+        } else if s.contains('^') {
+            Self::BottomToTop
+        } else if s.contains('>') {
+            Self::LeftToRight
+        } else if s.contains('v') || s == "TD" || s == "TB" {
+            Self::TopToBottom
+        } else {
+            Self::from_str(s)
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Self {
+        match s.to_uppercase().as_str() {
+            "BT" => Self::BottomToTop,
+            "LR" => Self::LeftToRight,
+            "RL" => Self::RightToLeft,
+            _ => Self::TopToBottom,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::TopToBottom => "TB",
+            Self::BottomToTop => "BT",
+            Self::LeftToRight => "LR",
+            Self::RightToLeft => "RL",
+        }
+    }
+}
+
+impl From<Direction> for LayoutDirection {
+    fn from(direction: Direction) -> Self {
+        match direction {
+            Direction::TopToBottom => LayoutDirection::TopToBottom,
+            Direction::BottomToTop => LayoutDirection::BottomToTop,
+            Direction::LeftToRight => LayoutDirection::LeftToRight,
+            Direction::RightToLeft => LayoutDirection::RightToLeft,
+        }
+    }
+}

--- a/src/diagrams/er/types.rs
+++ b/src/diagrams/er/types.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashMap;
 
+pub use crate::diagrams::direction::Direction;
+
 /// Cardinality types for ER relationships
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Cardinality {
@@ -196,37 +198,6 @@ impl EntityClass {
             id,
             styles: Vec::new(),
             text_styles: Vec::new(),
-        }
-    }
-}
-
-/// Direction of the ER diagram
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum Direction {
-    #[default]
-    TopToBottom,
-    BottomToTop,
-    LeftToRight,
-    RightToLeft,
-}
-
-impl Direction {
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: &str) -> Self {
-        match s.to_uppercase().as_str() {
-            "BT" => Self::BottomToTop,
-            "LR" => Self::LeftToRight,
-            "RL" => Self::RightToLeft,
-            _ => Self::TopToBottom,
-        }
-    }
-
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::TopToBottom => "TB",
-            Self::BottomToTop => "BT",
-            Self::LeftToRight => "LR",
-            Self::RightToLeft => "RL",
         }
     }
 }

--- a/src/diagrams/flowchart/types.rs
+++ b/src/diagrams/flowchart/types.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use crate::common::CommonDb;
+pub use crate::diagrams::direction::Direction;
 
 /// Valid vertex types in flowcharts
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -224,49 +225,6 @@ pub struct FlowData {
     pub edges: Vec<FlowEdge>,
     pub classes: HashMap<String, FlowClass>,
     pub subgraphs: Vec<FlowSubGraph>,
-}
-
-/// Flowchart direction
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum Direction {
-    #[default]
-    TopToBottom,
-    BottomToTop,
-    LeftToRight,
-    RightToLeft,
-}
-
-impl Direction {
-    /// Parse direction from mermaid syntax
-    pub fn parse(s: &str) -> Self {
-        let s = s.trim();
-        if s.contains('<') {
-            Self::RightToLeft
-        } else if s.contains('^') {
-            Self::BottomToTop
-        } else if s.contains('>') {
-            Self::LeftToRight
-        } else if s.contains('v') || s == "TD" || s == "TB" {
-            Self::TopToBottom
-        } else {
-            match s {
-                "RL" => Self::RightToLeft,
-                "BT" => Self::BottomToTop,
-                "LR" => Self::LeftToRight,
-                _ => Self::TopToBottom,
-            }
-        }
-    }
-
-    /// Convert to short string format (TB, BT, LR, RL)
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::TopToBottom => "TB",
-            Self::BottomToTop => "BT",
-            Self::LeftToRight => "LR",
-            Self::RightToLeft => "RL",
-        }
-    }
 }
 
 /// The flowchart database

--- a/src/diagrams/mod.rs
+++ b/src/diagrams/mod.rs
@@ -4,6 +4,7 @@ pub mod architecture;
 pub mod block;
 pub mod c4;
 pub mod class;
+pub(crate) mod direction;
 pub mod er;
 pub mod flowchart;
 pub mod gantt;

--- a/src/diagrams/state/parser.rs
+++ b/src/diagrams/state/parser.rs
@@ -57,13 +57,7 @@ fn process_statement(
         Rule::direction_stmt => {
             for inner in pair.into_inner() {
                 if inner.as_rule() == Rule::direction {
-                    let dir = match inner.as_str() {
-                        "TB" => Direction::TopToBottom,
-                        "BT" => Direction::BottomToTop,
-                        "LR" => Direction::LeftToRight,
-                        "RL" => Direction::RightToLeft,
-                        _ => Direction::TopToBottom,
-                    };
+                    let dir = Direction::from_str(inner.as_str());
                     db.set_direction(dir);
                 }
             }

--- a/src/diagrams/state/types.rs
+++ b/src/diagrams/state/types.rs
@@ -3,6 +3,7 @@
 use std::collections::HashMap;
 
 use crate::common::remove_script;
+pub use crate::diagrams::direction::Direction;
 
 /// State types
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -150,37 +151,6 @@ impl StyleClass {
             id,
             styles: Vec::new(),
             text_styles: Vec::new(),
-        }
-    }
-}
-
-/// Direction of the state diagram
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum Direction {
-    #[default]
-    TopToBottom,
-    BottomToTop,
-    LeftToRight,
-    RightToLeft,
-}
-
-impl Direction {
-    #[allow(clippy::should_implement_trait)]
-    pub fn from_str(s: &str) -> Self {
-        match s.to_uppercase().as_str() {
-            "BT" => Self::BottomToTop,
-            "LR" => Self::LeftToRight,
-            "RL" => Self::RightToLeft,
-            _ => Self::TopToBottom,
-        }
-    }
-
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::TopToBottom => "TB",
-            Self::BottomToTop => "BT",
-            Self::LeftToRight => "LR",
-            Self::RightToLeft => "RL",
         }
     }
 }

--- a/src/render/class.rs
+++ b/src/render/class.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use crate::diagrams::class::{ClassDb, ClassNode, LineType};
+use crate::diagrams::direction::Direction;
 use crate::error::Result;
 use crate::layout::{
     self, CharacterSizeEstimator, LayoutDirection, LayoutEdge, LayoutGraph, LayoutNode,
@@ -134,12 +135,7 @@ impl ToLayoutGraph for ClassDb {
     }
 
     fn preferred_direction(&self) -> LayoutDirection {
-        match self.direction.to_uppercase().as_str() {
-            "LR" => LayoutDirection::LeftToRight,
-            "RL" => LayoutDirection::RightToLeft,
-            "BT" => LayoutDirection::BottomToTop,
-            _ => LayoutDirection::TopToBottom,
-        }
+        Direction::from_str(&self.direction).into()
     }
 }
 

--- a/src/render/er.rs
+++ b/src/render/er.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use crate::diagrams::er::{Cardinality, Direction, Entity, ErDb, Identification};
+use crate::diagrams::er::{Cardinality, Entity, ErDb, Identification};
 use crate::error::Result;
 use crate::layout::{
     layout, CharacterSizeEstimator, LayoutDirection, LayoutEdge, LayoutGraph, LayoutNode,
@@ -465,12 +465,7 @@ impl ToLayoutGraph for ErDb {
     }
 
     fn preferred_direction(&self) -> LayoutDirection {
-        match self.get_direction() {
-            Direction::TopToBottom => LayoutDirection::TopToBottom,
-            Direction::BottomToTop => LayoutDirection::BottomToTop,
-            Direction::LeftToRight => LayoutDirection::LeftToRight,
-            Direction::RightToLeft => LayoutDirection::RightToLeft,
-        }
+        self.get_direction().into()
     }
 }
 

--- a/src/render/flowchart.rs
+++ b/src/render/flowchart.rs
@@ -128,12 +128,7 @@ impl ToLayoutGraph for FlowchartDb {
     }
 
     fn preferred_direction(&self) -> LayoutDirection {
-        match Direction::parse(self.get_direction()) {
-            Direction::TopToBottom => LayoutDirection::TopToBottom,
-            Direction::BottomToTop => LayoutDirection::BottomToTop,
-            Direction::LeftToRight => LayoutDirection::LeftToRight,
-            Direction::RightToLeft => LayoutDirection::RightToLeft,
-        }
+        Direction::parse(self.get_direction()).into()
     }
 }
 

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use crate::diagrams::state::{Direction, NotePosition, State, StateDb, StateType};
+use crate::diagrams::state::{NotePosition, State, StateDb, StateType};
 use crate::error::Result;
 use crate::layout::Point;
 use crate::layout::{
@@ -461,12 +461,7 @@ impl ToLayoutGraph for StateDb {
     }
 
     fn preferred_direction(&self) -> LayoutDirection {
-        match self.get_direction() {
-            Direction::TopToBottom => LayoutDirection::TopToBottom,
-            Direction::BottomToTop => LayoutDirection::BottomToTop,
-            Direction::LeftToRight => LayoutDirection::LeftToRight,
-            Direction::RightToLeft => LayoutDirection::RightToLeft,
-        }
+        self.get_direction().into()
     }
 }
 


### PR DESCRIPTION
### Motivation
- Remove duplicated direction parsing/formatting logic across diagram types and centralize conversion to `LayoutDirection` to DRY up code and make direction behavior consistent.

### Description
- Add `src/diagrams/direction.rs` providing a shared `Direction` enum with `parse`, `from_str`, `as_str`, and `From<Direction> for LayoutDirection` conversion.
- Replace per-diagram `Direction` definitions by re-exporting and using the shared `Direction` in `flowchart`, `state`, and `er` types and update the state parser to use the shared parsing helper.
- Simplify renderer implementations (`flowchart`, `state`, `er`, `class`) to obtain their `LayoutDirection` via the shared type (`.into()` conversion) and clean up related imports.
- Update `src/diagrams/mod.rs` to expose the new module as `pub(crate) mod direction` and adjust affected files accordingly.

### Testing
- Ran `cargo test`; the project compiled successfully but the test run was interrupted / hung during execution and was stopped manually (no full test-suite result available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696beefbf1088324a624ff414e92ed6b)