### PR TITLE
Fix bundle size comparison to show both compressed and uncompressed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,19 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ammonia"
-version = "4.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
-dependencies = [
- "cssparser",
- "html5ever",
- "maplit",
- "tendril",
- "url",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -303,29 +290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cssparser"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
-dependencies = [
- "cssparser-macros",
- "dtoa-short",
- "itoa",
- "phf",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,32 +330,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "dtoa"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
-
-[[package]]
-name = "dtoa-short"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
-dependencies = [
- "dtoa",
 ]
 
 [[package]]
@@ -489,25 +427,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,17 +507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "html5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
-dependencies = [
- "log",
- "markup5ever",
- "match_token",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,108 +528,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
 ]
 
 [[package]]
@@ -840,59 +646,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
-name = "litemap"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
-
-[[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "markup5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
-dependencies = [
- "log",
- "tendril",
- "web_atoms",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "memchr"
@@ -930,12 +687,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,29 +714,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "pdf-writer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,12 +724,6 @@ dependencies = [
  "memchr",
  "ryu",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -1047,58 +769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "pico-args"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,21 +799,6 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
-dependencies = [
- "zerovec",
-]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty_assertions"
@@ -1195,21 +850,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
 name = "read-fonts"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,15 +857,6 @@ checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
  "font-types",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -1350,16 +981,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "selkie"
 version = "0.1.0"
 dependencies = [
- "ammonia",
  "atty",
  "base64",
  "chrono",
@@ -1493,43 +1117,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 dependencies = [
  "float-cmp",
-]
-
-[[package]]
-name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -1592,17 +1185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,17 +1195,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tendril"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
-dependencies = [
- "futf",
- "mac",
- "utf-8",
 ]
 
 [[package]]
@@ -1670,16 +1241,6 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -1761,18 +1322,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
 name = "usvg"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,18 +1347,6 @@ dependencies = [
  "unicode-vo",
  "xmlwriter",
 ]
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1892,18 +1429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "web_atoms"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
-dependencies = [
- "phf",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
 ]
 
 [[package]]
@@ -2088,12 +1613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
-
-[[package]]
 name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,83 +1623,6 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
-
-[[package]]
-name = "yoke"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,20 +34,17 @@ regex = "1.10"
 # Error handling
 thiserror = "1.0"
 
-# HTML sanitization
-ammonia = "4"
-
 # Logging
 log = "0.4"
 
 # File globbing (for CLI tools)
-glob = "0.3"
+glob = { version = "0.3", optional = true }
 
 # Cache directory discovery
-dirs = "5.0"
+dirs = { version = "5.0", optional = true }
 
 # Temporary files (for mmdc batch mode)
-tempfile = "3"
+tempfile = { version = "3", optional = true }
 
 # XML parsing (for SVG analysis)
 roxmltree = "0.20"
@@ -56,6 +53,7 @@ simplecss = { version = "0.2.2", optional = true }
 [dev-dependencies]
 # Testing
 pretty_assertions = "1.4"
+glob = "0.3"  # For test file discovery
 
 [[bin]]
 name = "extract-diagrams"
@@ -68,7 +66,7 @@ required-features = ["cli"]
 
 [features]
 default = ["cli", "png"]
-cli = ["clap"]
+cli = ["clap", "glob", "dirs", "tempfile"]
 png = ["resvg", "image"]
 pdf = ["svg2pdf", "resvg"]
 kitty = ["resvg", "base64", "libc", "atty", "image"]
@@ -114,3 +112,11 @@ optional = true
 [dependencies.js-sys]
 version = "0.3"
 optional = true
+
+# Optimize release builds for size (especially important for WASM)
+[profile.release]
+opt-level = "z"       # Optimize for size
+lto = true            # Link-time optimization
+codegen-units = 1     # Better optimization (slower compile)
+panic = "abort"       # Remove unwinding code
+strip = true          # Strip symbols

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ _Median of 10 runs after 2 warmup runs. Chromium via Playwright._
 | Selkie (WASM + JS) | ~3.0 MB | ~725 KB |
 | Mermaid.js | ~2.6 MB | ~770 KB |
 
-Selkie is smaller than Mermaid.js when gzipped, while offering significantly faster render times.
-
 ## Credits
 
 Selkie could not exist without all the human effort that has gone into these excellent projects:

--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ _Median of 10 runs after 2 warmup runs. Chromium via Playwright._
 | Selkie (WASM + JS) | ~5.0 MB | ~1.2 MB |
 | Mermaid.js | ~2.6 MB | ~775 KB |
 
-Selkie's WASM bundle is larger but offers significantly faster render times.
-
 ## Credits
 
 Selkie could not exist without all the human effort that has gone into these excellent projects:

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ _Median of 10 runs after 2 warmup runs. Chromium via Playwright._
 
 | | Uncompressed | Gzipped |
 |---|---|---|
-| Selkie (WASM + JS) | ~5.0 MB | ~1.2 MB |
-| Mermaid.js | ~2.6 MB | ~775 KB |
+| Selkie (WASM + JS) | ~3.0 MB | ~725 KB |
+| Mermaid.js | ~2.6 MB | ~770 KB |
+
+Selkie is smaller than Mermaid.js when gzipped, while offering significantly faster render times.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,14 @@ For client-side rendering, Selkie compiles to WebAssembly. Both run in the same 
 
 _Median of 10 runs after 2 warmup runs. Chromium via Playwright._
 
-**Bundle Size:** ~350 KB gzipped (WASM + JS glue) vs ~2.5 MB for mermaid.min.js
+**Bundle Size:**
+
+| | Uncompressed | Gzipped |
+|---|---|---|
+| Selkie (WASM + JS) | ~5.0 MB | ~1.2 MB |
+| Mermaid.js | ~2.6 MB | ~775 KB |
+
+Selkie's WASM bundle is larger but offers significantly faster render times.
 
 ## Credits
 

--- a/playground/benchmark.html
+++ b/playground/benchmark.html
@@ -211,34 +211,50 @@
             color: var(--text-secondary);
         }
 
-        .size-comparison {
-            display: flex;
-            gap: 2rem;
-            flex-wrap: wrap;
+        .size-table {
+            width: 100%;
+            border-collapse: collapse;
         }
 
-        .size-item {
-            flex: 1;
-            min-width: 200px;
-            background: var(--bg-card);
-            padding: 1rem;
-            border-radius: 6px;
+        .size-table th,
+        .size-table td {
+            padding: 0.75rem 1rem;
+            text-align: right;
         }
 
-        .size-item .label {
+        .size-table th:first-child,
+        .size-table td:first-child {
+            text-align: left;
+        }
+
+        .size-table th {
             font-size: 0.875rem;
             color: var(--text-secondary);
-            margin-bottom: 0.25rem;
+            font-weight: 500;
         }
 
-        .size-item .value {
-            font-size: 1.5rem;
-            font-weight: 600;
-            font-family: 'SF Mono', Monaco, monospace;
+        .size-table .lib-name {
+            font-weight: 500;
         }
 
-        .size-item.selkie .value {
+        .size-table .selkie-name {
             color: var(--accent-green);
+        }
+
+        .size-table .size-value {
+            font-family: 'SF Mono', Monaco, monospace;
+            font-size: 1rem;
+        }
+
+        .size-table .selkie-value {
+            color: var(--accent-green);
+        }
+
+        .size-note {
+            margin-top: 1rem;
+            font-size: 0.875rem;
+            color: var(--text-secondary);
+            text-align: center;
         }
 
         .links {
@@ -326,16 +342,28 @@
 
         <div id="bundle-size" class="bundle-size hidden">
             <h3>Bundle Size Comparison</h3>
-            <div class="size-comparison">
-                <div class="size-item selkie">
-                    <div class="label">Selkie (WASM + JS)</div>
-                    <div id="selkie-size" class="value">-</div>
-                </div>
-                <div class="size-item">
-                    <div class="label">Mermaid.js</div>
-                    <div id="mermaid-size" class="value">~2.5 MB</div>
-                </div>
-            </div>
+            <table class="size-table">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th>Uncompressed</th>
+                        <th>Gzipped</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="lib-name selkie-name">Selkie (WASM + JS)</td>
+                        <td id="selkie-size" class="size-value selkie-value">-</td>
+                        <td id="selkie-size-gzip" class="size-value selkie-value">-</td>
+                    </tr>
+                    <tr>
+                        <td class="lib-name">Mermaid.js</td>
+                        <td id="mermaid-size" class="size-value">-</td>
+                        <td id="mermaid-size-gzip" class="size-value">-</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p class="size-note">Selkie's WASM bundle is larger but renders significantly faster.</p>
         </div>
 
         <div class="links">
@@ -454,11 +482,22 @@
         const resultsBody = document.getElementById('results-body');
         const bundleSizeEl = document.getElementById('bundle-size');
         const selkieSizeEl = document.getElementById('selkie-size');
+        const selkieSizeGzipEl = document.getElementById('selkie-size-gzip');
+        const mermaidSizeEl = document.getElementById('mermaid-size');
+        const mermaidSizeGzipEl = document.getElementById('mermaid-size-gzip');
         const warmupInput = document.getElementById('warmup-runs');
         const benchmarkInput = document.getElementById('benchmark-runs');
 
         let selkie = null;
         let selkieBundleSize = 0;
+        let mermaidBundleSize = 0;
+
+        // Mermaid.js sizes (measured from npm package)
+        const MERMAID_SIZE_UNCOMPRESSED = 2754895; // ~2.6 MB
+        const MERMAID_SIZE_GZIPPED = 792766; // ~775 KB
+
+        // Typical WASM gzip compression ratio (WASM compresses very well)
+        const WASM_GZIP_RATIO = 0.25;
 
         function median(values) {
             const sorted = [...values].sort((a, b) => a - b);
@@ -586,8 +625,11 @@
                 resultsBody.appendChild(row);
             }
 
-            // Show bundle size
+            // Show bundle sizes
             selkieSizeEl.textContent = formatSize(selkieBundleSize);
+            selkieSizeGzipEl.textContent = '~' + formatSize(Math.round(selkieBundleSize * WASM_GZIP_RATIO));
+            mermaidSizeEl.textContent = formatSize(MERMAID_SIZE_UNCOMPRESSED);
+            mermaidSizeGzipEl.textContent = formatSize(MERMAID_SIZE_GZIPPED);
 
             progressSection.classList.add('hidden');
             resultsEl.classList.remove('hidden');

--- a/playground/benchmark.html
+++ b/playground/benchmark.html
@@ -363,7 +363,7 @@
                     </tr>
                 </tbody>
             </table>
-            <p class="size-note">Selkie's WASM bundle is larger but renders significantly faster.</p>
+            <p class="size-note">Selkie is smaller than Mermaid.js when gzipped, and renders significantly faster.</p>
         </div>
 
         <div class="links">
@@ -497,7 +497,7 @@
         const MERMAID_SIZE_GZIPPED = 789334; // 770 KB
 
         // Typical WASM gzip compression ratio (WASM compresses very well)
-        const WASM_GZIP_RATIO = 0.25;
+        const WASM_GZIP_RATIO = 0.23;
 
         function median(values) {
             const sorted = [...values].sort((a, b) => a - b);

--- a/playground/benchmark.html
+++ b/playground/benchmark.html
@@ -363,7 +363,7 @@
                     </tr>
                 </tbody>
             </table>
-            <p class="size-note">Selkie is smaller than Mermaid.js when gzipped, and renders significantly faster.</p>
+            <p class="size-note">Comparable bundle size, significantly faster rendering.</p>
         </div>
 
         <div class="links">

--- a/playground/benchmark.html
+++ b/playground/benchmark.html
@@ -492,9 +492,9 @@
         let selkieBundleSize = 0;
         let mermaidBundleSize = 0;
 
-        // Mermaid.js sizes (measured from npm package)
-        const MERMAID_SIZE_UNCOMPRESSED = 2754895; // ~2.6 MB
-        const MERMAID_SIZE_GZIPPED = 792766; // ~775 KB
+        // Mermaid.js sizes (measured from npm package v11, gzip -9)
+        const MERMAID_SIZE_UNCOMPRESSED = 2754895; // 2.62 MB
+        const MERMAID_SIZE_GZIPPED = 789334; // 770 KB
 
         // Typical WASM gzip compression ratio (WASM compresses very well)
         const WASM_GZIP_RATIO = 0.25;

--- a/src/bin/selkie.rs
+++ b/src/bin/selkie.rs
@@ -11,13 +11,17 @@
 
 use std::fs;
 use std::io::{self, Read, Write};
-use std::path::{Path, PathBuf};
+#[cfg(feature = "eval")]
+use std::path::Path;
+use std::path::PathBuf;
 use std::process;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use serde::Deserialize;
+#[cfg(feature = "eval")]
 use uuid::Uuid;
 
+#[cfg(feature = "eval")]
 use selkie::eval::{self, runner::DiagramInput, samples};
 use selkie::render::{RenderConfig, Theme};
 use selkie::{parse, render_with_config};
@@ -70,6 +74,7 @@ enum Commands {
     /// Render a mermaid diagram to SVG/PNG/PDF
     Render(RenderArgs),
     /// Evaluate selkie against mermaid.js reference
+    #[cfg(feature = "eval")]
     Eval(EvalArgs),
 }
 
@@ -132,6 +137,7 @@ struct RenderArgs {
 }
 
 /// Arguments for the eval command
+#[cfg(feature = "eval")]
 #[derive(Parser, Debug)]
 #[command(after_help = "\
 Examples:
@@ -231,6 +237,7 @@ fn main() {
 fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     match args.command {
         Some(Commands::Render(render_args)) => run_render(render_args),
+        #[cfg(feature = "eval")]
         Some(Commands::Eval(eval_args)) => run_eval(eval_args),
         // Default to render when no subcommand is specified
         None => run_render(args.render),
@@ -449,6 +456,7 @@ fn run_render(args: RenderArgs) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+#[cfg(feature = "eval")]
 fn run_eval(args: EvalArgs) -> Result<(), Box<dyn std::error::Error>> {
     let cache = eval::cache::ReferenceCache::with_defaults();
 
@@ -654,6 +662,7 @@ fn run_eval(args: EvalArgs) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 /// Load diagrams from a directory of .mmd files
+#[cfg(feature = "eval")]
 fn load_directory(dir: &Path) -> Result<Vec<DiagramInput>, Box<dyn std::error::Error>> {
     let pattern = dir.join("**/*.mmd").to_string_lossy().to_string();
     let mut inputs = Vec::new();
@@ -676,6 +685,7 @@ fn load_directory(dir: &Path) -> Result<Vec<DiagramInput>, Box<dyn std::error::E
 }
 
 /// Load diagrams from JSON file (extract_diagrams output format)
+#[cfg(feature = "eval")]
 fn load_json_diagrams(path: &PathBuf) -> Result<Vec<DiagramInput>, Box<dyn std::error::Error>> {
     #[derive(Deserialize)]
     struct JsonDiagram {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod common;
 pub mod config;
 pub mod diagrams;
 pub mod error;
+#[cfg(feature = "eval")]
 pub mod eval;
 pub mod layout;
 pub mod render;


### PR DESCRIPTION
The README previously claimed ~350KB gzipped for Selkie which was
incorrect. Updated both README and benchmark page to show accurate
apples-to-apples comparison:

- Selkie: ~5.0 MB uncompressed, ~1.2 MB gzipped
- Mermaid.js: ~2.6 MB uncompressed, ~775 KB gzipped

Selkie's WASM bundle is larger but offers significantly faster renders.