### PR TITLE
Implement xychart rendering with cypress test parity

### DIFF
--- a/docs/images/xychart.svg
+++ b/docs/images/xychart.svg
@@ -136,46 +136,46 @@ marker path {
 
     </g>
     <rect x="0" y="0" width="700" height="500" class="xychart-background" fill="#ffffff"/>
-    <text x="350" y="50" class="xychart-title" fill="#333333" text-anchor="middle" dominant-baseline="hanging" font-weight="bold" font-size="16">Sales Revenue</text>
-    <path d="M 90 90 L 90 410" class="xychart-axis" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="15" y="250" class="xychart-axis-title" transform="rotate(-90 15 250)" font-size="12" dominant-baseline="middle" text-anchor="middle" fill="#333333">Revenue (in $)</text>
-    <path d="M 90 410 L 85 410" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="80" y="410" class="xychart-axis-label" font-size="10" dominant-baseline="middle" fill="#333333" text-anchor="end">4000</text>
-    <path d="M 90 346 L 85 346" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
-    <text x="80" y="346" class="xychart-axis-label" fill="#333333" text-anchor="end" dominant-baseline="middle" font-size="10">5400</text>
-    <path d="M 90 282 L 85 282" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
-    <text x="80" y="282" class="xychart-axis-label" dominant-baseline="middle" font-size="10" fill="#333333" text-anchor="end">6800</text>
-    <path d="M 90 218 L 85 218" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="80" y="218" class="xychart-axis-label" fill="#333333" dominant-baseline="middle" text-anchor="end" font-size="10">8200</text>
-    <path d="M 90 154 L 85 154" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
-    <text x="80" y="154" class="xychart-axis-label" text-anchor="end" dominant-baseline="middle" fill="#333333" font-size="10">9600</text>
+    <text x="350" y="50" class="xychart-title" text-anchor="middle" fill="#333333" dominant-baseline="hanging" font-size="16" font-weight="bold">Sales Revenue</text>
+    <path d="M 90 90 L 90 410" class="xychart-axis" fill="none" stroke-width="1" stroke="#333333"/>
+    <text x="15" y="250" class="xychart-axis-title" dominant-baseline="middle" font-size="12" transform="rotate(-90 15 250)" fill="#333333" text-anchor="middle">Revenue (in $)</text>
+    <path d="M 90 410 L 85 410" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="80" y="410" class="xychart-axis-label" fill="#333333" text-anchor="end" font-size="10" dominant-baseline="middle">4000</text>
+    <path d="M 90 346 L 85 346" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="80" y="346" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" fill="#333333" font-size="10">5400</text>
+    <path d="M 90 282 L 85 282" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="80" y="282" class="xychart-axis-label" fill="#333333" font-size="10" dominant-baseline="middle" text-anchor="end">6800</text>
+    <path d="M 90 218 L 85 218" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
+    <text x="80" y="218" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" fill="#333333" font-size="10">8200</text>
+    <path d="M 90 154 L 85 154" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="80" y="154" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" font-size="10" fill="#333333">9600</text>
     <path d="M 90 90 L 85 90" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
-    <text x="80" y="90" class="xychart-axis-label" fill="#333333" font-size="10" dominant-baseline="middle" text-anchor="end">11000</text>
-    <path d="M 90 410 L 650 410" class="xychart-axis" stroke-width="1" fill="none" stroke="#333333"/>
-    <path d="M 113.33333333333333 410 L 113.33333333333333 415" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="113.33333333333333" y="425" class="xychart-axis-label" dominant-baseline="hanging" fill="#333333" text-anchor="middle" font-size="10">jan</text>
-    <path d="M 160 410 L 160 415" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
-    <text x="160" y="425" class="xychart-axis-label" text-anchor="middle" font-size="10" dominant-baseline="hanging" fill="#333333">feb</text>
+    <text x="80" y="90" class="xychart-axis-label" dominant-baseline="middle" fill="#333333" text-anchor="end" font-size="10">11000</text>
+    <path d="M 90 410 L 650 410" class="xychart-axis" fill="none" stroke="#333333" stroke-width="1"/>
+    <path d="M 113.33333333333333 410 L 113.33333333333333 415" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
+    <text x="113.33333333333333" y="425" class="xychart-axis-label" text-anchor="middle" dominant-baseline="hanging" font-size="10" fill="#333333">jan</text>
+    <path d="M 160 410 L 160 415" class="xychart-tick" stroke="#333333" fill="none" stroke-width="1"/>
+    <text x="160" y="425" class="xychart-axis-label" fill="#333333" font-size="10" text-anchor="middle" dominant-baseline="hanging">feb</text>
     <path d="M 206.66666666666666 410 L 206.66666666666666 415" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="206.66666666666666" y="425" class="xychart-axis-label" dominant-baseline="hanging" fill="#333333" font-size="10" text-anchor="middle">mar</text>
+    <text x="206.66666666666666" y="425" class="xychart-axis-label" dominant-baseline="hanging" text-anchor="middle" fill="#333333" font-size="10">mar</text>
     <path d="M 253.33333333333331 410 L 253.33333333333331 415" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
-    <text x="253.33333333333331" y="425" class="xychart-axis-label" font-size="10" dominant-baseline="hanging" fill="#333333" text-anchor="middle">apr</text>
-    <path d="M 300 410 L 300 415" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="300" y="425" class="xychart-axis-label" dominant-baseline="hanging" font-size="10" fill="#333333" text-anchor="middle">may</text>
-    <path d="M 346.66666666666663 410 L 346.66666666666663 415" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="346.66666666666663" y="425" class="xychart-axis-label" dominant-baseline="hanging" text-anchor="middle" font-size="10" fill="#333333">jun</text>
-    <path d="M 393.3333333333333 410 L 393.3333333333333 415" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
-    <text x="393.3333333333333" y="425" class="xychart-axis-label" font-size="10" text-anchor="middle" fill="#333333" dominant-baseline="hanging">jul</text>
+    <text x="253.33333333333331" y="425" class="xychart-axis-label" dominant-baseline="hanging" font-size="10" text-anchor="middle" fill="#333333">apr</text>
+    <path d="M 300 410 L 300 415" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="300" y="425" class="xychart-axis-label" text-anchor="middle" dominant-baseline="hanging" font-size="10" fill="#333333">may</text>
+    <path d="M 346.66666666666663 410 L 346.66666666666663 415" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
+    <text x="346.66666666666663" y="425" class="xychart-axis-label" font-size="10" fill="#333333" dominant-baseline="hanging" text-anchor="middle">jun</text>
+    <path d="M 393.3333333333333 410 L 393.3333333333333 415" class="xychart-tick" stroke="#333333" fill="none" stroke-width="1"/>
+    <text x="393.3333333333333" y="425" class="xychart-axis-label" dominant-baseline="hanging" font-size="10" fill="#333333" text-anchor="middle">jul</text>
     <path d="M 440 410 L 440 415" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
-    <text x="440" y="425" class="xychart-axis-label" dominant-baseline="hanging" font-size="10" text-anchor="middle" fill="#333333">aug</text>
-    <path d="M 486.66666666666663 410 L 486.66666666666663 415" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
-    <text x="486.66666666666663" y="425" class="xychart-axis-label" font-size="10" text-anchor="middle" fill="#333333" dominant-baseline="hanging">sep</text>
-    <path d="M 533.3333333333333 410 L 533.3333333333333 415" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
-    <text x="533.3333333333333" y="425" class="xychart-axis-label" font-size="10" text-anchor="middle" fill="#333333" dominant-baseline="hanging">oct</text>
-    <path d="M 580 410 L 580 415" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
-    <text x="580" y="425" class="xychart-axis-label" dominant-baseline="hanging" fill="#333333" text-anchor="middle" font-size="10">nov</text>
-    <path d="M 626.6666666666666 410 L 626.6666666666666 415" class="xychart-tick" stroke="#333333" fill="none" stroke-width="1"/>
-    <text x="626.6666666666666" y="425" class="xychart-axis-label" font-size="10" dominant-baseline="hanging" fill="#333333" text-anchor="middle">dec</text>
+    <text x="440" y="425" class="xychart-axis-label" dominant-baseline="hanging" fill="#333333" font-size="10" text-anchor="middle">aug</text>
+    <path d="M 486.66666666666663 410 L 486.66666666666663 415" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="486.66666666666663" y="425" class="xychart-axis-label" fill="#333333" font-size="10" text-anchor="middle" dominant-baseline="hanging">sep</text>
+    <path d="M 533.3333333333333 410 L 533.3333333333333 415" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
+    <text x="533.3333333333333" y="425" class="xychart-axis-label" text-anchor="middle" dominant-baseline="hanging" font-size="10" fill="#333333">oct</text>
+    <path d="M 580 410 L 580 415" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="580" y="425" class="xychart-axis-label" text-anchor="middle" fill="#333333" font-size="10" dominant-baseline="hanging">nov</text>
+    <path d="M 626.6666666666666 410 L 626.6666666666666 415" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
+    <text x="626.6666666666666" y="425" class="xychart-axis-label" font-size="10" dominant-baseline="hanging" text-anchor="middle" fill="#333333">dec</text>
     <rect x="94.66666666666666" y="364.2857142857143" width="37.333333333333336" height="45.71428571428571" class="xychart-bar" fill="#4C78A8"/>
     <rect x="141.33333333333334" y="318.57142857142856" width="37.333333333333336" height="91.42857142857142" class="xychart-bar" fill="#4C78A8"/>
     <rect x="188" y="250" width="37.333333333333336" height="160" class="xychart-bar" fill="#4C78A8"/>
@@ -188,18 +188,18 @@ marker path {
     <rect x="514.6666666666666" y="204.28571428571428" width="37.333333333333336" height="205.71428571428572" class="xychart-bar" fill="#4C78A8"/>
     <rect x="561.3333333333334" y="272.8571428571429" width="37.333333333333336" height="137.14285714285714" class="xychart-bar" fill="#4C78A8"/>
     <rect x="608" y="318.57142857142856" width="37.333333333333336" height="91.42857142857142" class="xychart-bar" fill="#4C78A8"/>
-    <path d="M 90 364.2857142857143 L 140.9090909090909 318.57142857142856 L 191.8181818181818 250 L 242.72727272727272 218 L 293.6363636363636 158.57142857142858 L 344.5454545454545 112.85714285714283 L 395.45454545454544 90 L 446.3636363636364 126.57142857142856 L 497.27272727272725 172.28571428571428 L 548.1818181818181 204.28571428571428 L 599.090909090909 272.8571428571429 L 650 318.57142857142856" class="xychart-line" fill="none" stroke-width="2" stroke="#F58518"/>
+    <path d="M 90 364.2857142857143 L 140.9090909090909 318.57142857142856 L 191.8181818181818 250 L 242.72727272727272 218 L 293.6363636363636 158.57142857142858 L 344.5454545454545 112.85714285714283 L 395.45454545454544 90 L 446.3636363636364 126.57142857142856 L 497.27272727272725 172.28571428571428 L 548.1818181818181 204.28571428571428 L 599.090909090909 272.8571428571429 L 650 318.57142857142856" class="xychart-line" fill="none" stroke="#F58518" stroke-width="2"/>
     <circle cx="90" cy="364.2857142857143" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
-    <circle cx="140.9090909090909" cy="318.57142857142856" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
-    <circle cx="191.8181818181818" cy="250" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
-    <circle cx="242.72727272727272" cy="218" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="140.9090909090909" cy="318.57142857142856" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="191.8181818181818" cy="250" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="242.72727272727272" cy="218" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
     <circle cx="293.6363636363636" cy="158.57142857142858" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
     <circle cx="344.5454545454545" cy="112.85714285714283" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
     <circle cx="395.45454545454544" cy="90" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
     <circle cx="446.3636363636364" cy="126.57142857142856" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
-    <circle cx="497.27272727272725" cy="172.28571428571428" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
-    <circle cx="548.1818181818181" cy="204.28571428571428" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
-    <circle cx="599.090909090909" cy="272.8571428571429" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
-    <circle cx="650" cy="318.57142857142856" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="497.27272727272725" cy="172.28571428571428" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="548.1818181818181" cy="204.28571428571428" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="599.090909090909" cy="272.8571428571429" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="650" cy="318.57142857142856" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
   </g>
 </svg>

--- a/docs/images/xychart.svg
+++ b/docs/images/xychart.svg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="500" viewBox="0 0 700 500" class="mermaid">
+  <style>
+
+.mermaid {
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+  font-size: 16px;
+}
+
+.node rect,
+.node polygon,
+.node circle,
+.node ellipse,
+.node path {
+  fill: #ECECFF;
+  stroke: #9370DB;
+  stroke-width: 1px;
+}
+
+.node line {
+  stroke: #9370DB;
+  stroke-width: 1px;
+}
+
+.node .label {
+  fill: #333333;
+}
+
+.node text {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+  font-size: 16px;
+}
+
+.edge-path {
+  fill: none;
+  stroke: #333333;
+  stroke-width: 1px;
+}
+
+.edge-label {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+}
+
+.edge-label-bg {
+  fill: rgba(232, 232, 232, 0.8);
+}
+
+.subgraph {
+  fill: #ffffde;
+  stroke: #aaaa33;
+  stroke-width: 1px;
+}
+
+.subgraph-title {
+  fill: #333333;
+  font-weight: bold;
+}
+
+.cluster rect {
+  fill: #ffffde;
+  stroke: #aaaa33;
+  stroke-width: 1px;
+  rx: 5px;
+  ry: 5px;
+}
+
+.cluster-label {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+marker path {
+  fill: #333333;
+  stroke: #333333;
+}
+
+
+.xychart-background {
+  fill: #ffffff;
+}
+
+.xychart-title {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+}
+
+.xychart-axis {
+  stroke: #333333;
+  stroke-width: 1px;
+}
+
+.xychart-axis-title {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+}
+
+.xychart-axis-label {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+}
+
+.xychart-tick {
+  stroke: #333333;
+  stroke-width: 1px;
+}
+
+.xychart-bar {
+  stroke-width: 0;
+}
+
+.xychart-line {
+  fill: none;
+  stroke-width: 2px;
+}
+
+.xychart-point {
+  stroke-width: 1px;
+}
+
+  </style>
+  <g class="root">
+    <g class="clusters">
+
+    </g>
+    <g class="edgePaths">
+
+    </g>
+    <g class="edgeLabels">
+
+    </g>
+    <g class="nodes">
+
+    </g>
+    <rect x="0" y="0" width="700" height="500" class="xychart-background" fill="#ffffff"/>
+    <text x="350" y="50" class="xychart-title" fill="#333333" text-anchor="middle" dominant-baseline="hanging" font-weight="bold" font-size="16">Sales Revenue</text>
+    <path d="M 90 90 L 90 410" class="xychart-axis" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="15" y="250" class="xychart-axis-title" transform="rotate(-90 15 250)" font-size="12" dominant-baseline="middle" text-anchor="middle" fill="#333333">Revenue (in $)</text>
+    <path d="M 90 410 L 85 410" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="80" y="410" class="xychart-axis-label" font-size="10" dominant-baseline="middle" fill="#333333" text-anchor="end">4000</text>
+    <path d="M 90 346 L 85 346" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
+    <text x="80" y="346" class="xychart-axis-label" fill="#333333" text-anchor="end" dominant-baseline="middle" font-size="10">5400</text>
+    <path d="M 90 282 L 85 282" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
+    <text x="80" y="282" class="xychart-axis-label" dominant-baseline="middle" font-size="10" fill="#333333" text-anchor="end">6800</text>
+    <path d="M 90 218 L 85 218" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="80" y="218" class="xychart-axis-label" fill="#333333" dominant-baseline="middle" text-anchor="end" font-size="10">8200</text>
+    <path d="M 90 154 L 85 154" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
+    <text x="80" y="154" class="xychart-axis-label" text-anchor="end" dominant-baseline="middle" fill="#333333" font-size="10">9600</text>
+    <path d="M 90 90 L 85 90" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
+    <text x="80" y="90" class="xychart-axis-label" fill="#333333" font-size="10" dominant-baseline="middle" text-anchor="end">11000</text>
+    <path d="M 90 410 L 650 410" class="xychart-axis" stroke-width="1" fill="none" stroke="#333333"/>
+    <path d="M 113.33333333333333 410 L 113.33333333333333 415" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="113.33333333333333" y="425" class="xychart-axis-label" dominant-baseline="hanging" fill="#333333" text-anchor="middle" font-size="10">jan</text>
+    <path d="M 160 410 L 160 415" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="160" y="425" class="xychart-axis-label" text-anchor="middle" font-size="10" dominant-baseline="hanging" fill="#333333">feb</text>
+    <path d="M 206.66666666666666 410 L 206.66666666666666 415" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="206.66666666666666" y="425" class="xychart-axis-label" dominant-baseline="hanging" fill="#333333" font-size="10" text-anchor="middle">mar</text>
+    <path d="M 253.33333333333331 410 L 253.33333333333331 415" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
+    <text x="253.33333333333331" y="425" class="xychart-axis-label" font-size="10" dominant-baseline="hanging" fill="#333333" text-anchor="middle">apr</text>
+    <path d="M 300 410 L 300 415" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="300" y="425" class="xychart-axis-label" dominant-baseline="hanging" font-size="10" fill="#333333" text-anchor="middle">may</text>
+    <path d="M 346.66666666666663 410 L 346.66666666666663 415" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="346.66666666666663" y="425" class="xychart-axis-label" dominant-baseline="hanging" text-anchor="middle" font-size="10" fill="#333333">jun</text>
+    <path d="M 393.3333333333333 410 L 393.3333333333333 415" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
+    <text x="393.3333333333333" y="425" class="xychart-axis-label" font-size="10" text-anchor="middle" fill="#333333" dominant-baseline="hanging">jul</text>
+    <path d="M 440 410 L 440 415" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
+    <text x="440" y="425" class="xychart-axis-label" dominant-baseline="hanging" font-size="10" text-anchor="middle" fill="#333333">aug</text>
+    <path d="M 486.66666666666663 410 L 486.66666666666663 415" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
+    <text x="486.66666666666663" y="425" class="xychart-axis-label" font-size="10" text-anchor="middle" fill="#333333" dominant-baseline="hanging">sep</text>
+    <path d="M 533.3333333333333 410 L 533.3333333333333 415" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
+    <text x="533.3333333333333" y="425" class="xychart-axis-label" font-size="10" text-anchor="middle" fill="#333333" dominant-baseline="hanging">oct</text>
+    <path d="M 580 410 L 580 415" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
+    <text x="580" y="425" class="xychart-axis-label" dominant-baseline="hanging" fill="#333333" text-anchor="middle" font-size="10">nov</text>
+    <path d="M 626.6666666666666 410 L 626.6666666666666 415" class="xychart-tick" stroke="#333333" fill="none" stroke-width="1"/>
+    <text x="626.6666666666666" y="425" class="xychart-axis-label" font-size="10" dominant-baseline="hanging" fill="#333333" text-anchor="middle">dec</text>
+    <rect x="94.66666666666666" y="364.2857142857143" width="37.333333333333336" height="45.71428571428571" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="141.33333333333334" y="318.57142857142856" width="37.333333333333336" height="91.42857142857142" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="188" y="250" width="37.333333333333336" height="160" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="234.66666666666666" y="218" width="37.333333333333336" height="192" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="281.3333333333333" y="158.57142857142858" width="37.333333333333336" height="251.42857142857142" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="327.99999999999994" y="112.85714285714283" width="37.333333333333336" height="297.14285714285717" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="374.66666666666663" y="90" width="37.333333333333336" height="320" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="421.3333333333333" y="126.57142857142856" width="37.333333333333336" height="283.42857142857144" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="467.99999999999994" y="172.28571428571428" width="37.333333333333336" height="237.71428571428572" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="514.6666666666666" y="204.28571428571428" width="37.333333333333336" height="205.71428571428572" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="561.3333333333334" y="272.8571428571429" width="37.333333333333336" height="137.14285714285714" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="608" y="318.57142857142856" width="37.333333333333336" height="91.42857142857142" class="xychart-bar" fill="#4C78A8"/>
+    <path d="M 90 364.2857142857143 L 140.9090909090909 318.57142857142856 L 191.8181818181818 250 L 242.72727272727272 218 L 293.6363636363636 158.57142857142858 L 344.5454545454545 112.85714285714283 L 395.45454545454544 90 L 446.3636363636364 126.57142857142856 L 497.27272727272725 172.28571428571428 L 548.1818181818181 204.28571428571428 L 599.090909090909 272.8571428571429 L 650 318.57142857142856" class="xychart-line" fill="none" stroke-width="2" stroke="#F58518"/>
+    <circle cx="90" cy="364.2857142857143" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="140.9090909090909" cy="318.57142857142856" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="191.8181818181818" cy="250" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="242.72727272727272" cy="218" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="293.6363636363636" cy="158.57142857142858" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="344.5454545454545" cy="112.85714285714283" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="395.45454545454544" cy="90" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="446.3636363636364" cy="126.57142857142856" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="497.27272727272725" cy="172.28571428571428" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="548.1818181818181" cy="204.28571428571428" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="599.090909090909" cy="272.8571428571429" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="650" cy="318.57142857142856" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+  </g>
+</svg>

--- a/docs/images/xychart_complex.svg
+++ b/docs/images/xychart_complex.svg
@@ -136,54 +136,37 @@ marker path {
 
     </g>
     <rect x="0" y="0" width="700" height="500" class="xychart-background" fill="#ffffff"/>
-    <text x="350" y="50" class="xychart-title" dominant-baseline="hanging" font-size="16" text-anchor="middle" fill="#333333" font-weight="bold">Quarterly Sales by Region</text>
-    <path d="M 90 90 L 650 90" class="xychart-axis" stroke-width="1" fill="none" stroke="#333333"/>
-    <text x="370" y="65" class="xychart-axis-title" transform="rotate(0 370 65)" dominant-baseline="middle" text-anchor="middle" fill="#333333" font-size="12">Sales (millions)</text>
-    <path d="M 90 90 L 90 85" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
-    <text x="90" y="80" class="xychart-axis-label" fill="#333333" dominant-baseline="auto" font-size="10" text-anchor="middle">0</text>
-    <path d="M 202 90 L 202 85" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="202" y="80" class="xychart-axis-label" fill="#333333" font-size="10" text-anchor="middle" dominant-baseline="auto">10</text>
-    <path d="M 314 90 L 314 85" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
-    <text x="314" y="80" class="xychart-axis-label" dominant-baseline="auto" text-anchor="middle" fill="#333333" font-size="10">20</text>
-    <path d="M 426 90 L 426 85" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
-    <text x="426" y="80" class="xychart-axis-label" fill="#333333" text-anchor="middle" font-size="10" dominant-baseline="auto">30</text>
+    <text x="350" y="50" class="xychart-title" dominant-baseline="hanging" fill="#333333" font-size="16" text-anchor="middle" font-weight="bold">Complex Chart</text>
+    <path d="M 90 90 L 650 90" class="xychart-axis" fill="none" stroke="#333333" stroke-width="1"/>
+    <path d="M 90 90 L 90 85" class="xychart-tick" stroke="#333333" fill="none" stroke-width="1"/>
+    <text x="90" y="80" class="xychart-axis-label" font-size="10" text-anchor="middle" dominant-baseline="auto" fill="#333333">0</text>
+    <path d="M 202 90 L 202 85" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="202" y="80" class="xychart-axis-label" dominant-baseline="auto" font-size="10" text-anchor="middle" fill="#333333">40</text>
+    <path d="M 314 90 L 314 85" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="314" y="80" class="xychart-axis-label" text-anchor="middle" fill="#333333" font-size="10" dominant-baseline="auto">80</text>
+    <path d="M 426 90 L 426 85" class="xychart-tick" fill="none" stroke-width="1" stroke="#333333"/>
+    <text x="426" y="80" class="xychart-axis-label" font-size="10" fill="#333333" dominant-baseline="auto" text-anchor="middle">120</text>
     <path d="M 538 90 L 538 85" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="538" y="80" class="xychart-axis-label" dominant-baseline="auto" font-size="10" text-anchor="middle" fill="#333333">40</text>
+    <text x="538" y="80" class="xychart-axis-label" fill="#333333" dominant-baseline="auto" font-size="10" text-anchor="middle">160</text>
     <path d="M 650 90 L 650 85" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
-    <text x="650" y="80" class="xychart-axis-label" text-anchor="middle" dominant-baseline="auto" fill="#333333" font-size="10">50</text>
-    <path d="M 90 90 L 90 410" class="xychart-axis" stroke-width="1" fill="none" stroke="#333333"/>
-    <text x="65" y="250" class="xychart-axis-title" transform="rotate(-90 65 250)" font-size="12" text-anchor="middle" fill="#333333" dominant-baseline="middle">Region</text>
-    <path d="M 90 122 L 85 122" class="xychart-tick" stroke="#333333" fill="none" stroke-width="1"/>
-    <text x="80" y="122" class="xychart-axis-label" text-anchor="end" font-size="10" dominant-baseline="middle" fill="#333333">North</text>
-    <path d="M 90 186 L 85 186" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="80" y="186" class="xychart-axis-label" fill="#333333" dominant-baseline="middle" font-size="10" text-anchor="end">South</text>
-    <path d="M 90 250 L 85 250" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
-    <text x="80" y="250" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" font-size="10" fill="#333333">East</text>
-    <path d="M 90 314 L 85 314" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
-    <text x="80" y="314" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" fill="#333333" font-size="10">West</text>
-    <path d="M 90 378 L 85 378" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="80" y="378" class="xychart-axis-label" font-size="10" dominant-baseline="middle" fill="#333333" text-anchor="end">Central</text>
-    <rect x="90" y="96.4" width="280" height="51.2" class="xychart-bar" fill="#4C78A8"/>
-    <rect x="90" y="160.4" width="336" height="51.2" class="xychart-bar" fill="#4C78A8"/>
-    <rect x="90" y="224.4" width="224" height="51.2" class="xychart-bar" fill="#4C78A8"/>
-    <rect x="90" y="288.4" width="392" height="51.2" class="xychart-bar" fill="#4C78A8"/>
-    <rect x="90" y="352.4" width="168" height="51.2" class="xychart-bar" fill="#4C78A8"/>
-    <path d="M 370 122 L 426 186 L 314 250 L 482 314 L 258 378" class="xychart-line" stroke-width="2" fill="none" stroke="#F58518"/>
-    <circle cx="370" cy="122" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
-    <circle cx="426" cy="186" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
-    <circle cx="314" cy="250" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
-    <circle cx="482" cy="314" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
-    <circle cx="258" cy="378" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
-    <rect x="90" y="96.4" width="313.6" height="51.2" class="xychart-bar" fill="#E45756"/>
-    <rect x="90" y="160.4" width="280" height="51.2" class="xychart-bar" fill="#E45756"/>
-    <rect x="90" y="224.4" width="246.4" height="51.2" class="xychart-bar" fill="#E45756"/>
-    <rect x="90" y="288.4" width="448" height="51.2" class="xychart-bar" fill="#E45756"/>
-    <rect x="90" y="352.4" width="201.6" height="51.2" class="xychart-bar" fill="#E45756"/>
-    <path d="M 403.6 122 L 370 186 L 336.4 250 L 538 314 L 291.6 378" class="xychart-line" stroke="#72B7B2" stroke-width="2" fill="none"/>
-    <circle cx="403.6" cy="122" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
-    <circle cx="370" cy="186" r="4" class="xychart-point" stroke="#72B7B2" fill="#72B7B2"/>
-    <circle cx="336.4" cy="250" r="4" class="xychart-point" stroke="#72B7B2" fill="#72B7B2"/>
-    <circle cx="538" cy="314" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
-    <circle cx="291.6" cy="378" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
+    <text x="650" y="80" class="xychart-axis-label" fill="#333333" text-anchor="middle" font-size="10" dominant-baseline="auto">200</text>
+    <path d="M 90 90 L 90 410" class="xychart-axis" fill="none" stroke-width="1" stroke="#333333"/>
+    <path d="M 90 130 L 85 130" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="80" y="130" class="xychart-axis-label" fill="#333333" font-size="10" dominant-baseline="middle" text-anchor="end">Category A</text>
+    <path d="M 90 210 L 85 210" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="80" y="210" class="xychart-axis-label" text-anchor="end" dominant-baseline="middle" font-size="10" fill="#333333">Category B</text>
+    <path d="M 90 290 L 85 290" class="xychart-tick" fill="none" stroke-width="1" stroke="#333333"/>
+    <text x="80" y="290" class="xychart-axis-label" font-size="10" fill="#333333" text-anchor="end" dominant-baseline="middle">Category C</text>
+    <path d="M 90 370 L 85 370" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="80" y="370" class="xychart-axis-label" dominant-baseline="middle" fill="#333333" font-size="10" text-anchor="end">Category D</text>
+    <rect x="90" y="98" width="280" height="64" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="90" y="178" width="420" height="64" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="90" y="258" width="224" height="64" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="90" y="338" width="504" height="64" class="xychart-bar" fill="#4C78A8"/>
+    <path d="M 426 90 L 482 196.66666666666669 L 342 303.33333333333337 L 538 410" class="xychart-line" fill="none" stroke="#F58518" stroke-width="2"/>
+    <circle cx="426" cy="90" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="482" cy="196.66666666666669" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="342" cy="303.33333333333337" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="538" cy="410" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
   </g>
 </svg>

--- a/docs/images/xychart_complex.svg
+++ b/docs/images/xychart_complex.svg
@@ -1,0 +1,189 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="700" height="500" viewBox="0 0 700 500" class="mermaid">
+  <style>
+
+.mermaid {
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+  font-size: 16px;
+}
+
+.node rect,
+.node polygon,
+.node circle,
+.node ellipse,
+.node path {
+  fill: #ECECFF;
+  stroke: #9370DB;
+  stroke-width: 1px;
+}
+
+.node line {
+  stroke: #9370DB;
+  stroke-width: 1px;
+}
+
+.node .label {
+  fill: #333333;
+}
+
+.node text {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+  font-size: 16px;
+}
+
+.edge-path {
+  fill: none;
+  stroke: #333333;
+  stroke-width: 1px;
+}
+
+.edge-label {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+}
+
+.edge-label-bg {
+  fill: rgba(232, 232, 232, 0.8);
+}
+
+.subgraph {
+  fill: #ffffde;
+  stroke: #aaaa33;
+  stroke-width: 1px;
+}
+
+.subgraph-title {
+  fill: #333333;
+  font-weight: bold;
+}
+
+.cluster rect {
+  fill: #ffffde;
+  stroke: #aaaa33;
+  stroke-width: 1px;
+  rx: 5px;
+  ry: 5px;
+}
+
+.cluster-label {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+  font-size: 16px;
+  font-weight: bold;
+}
+
+marker path {
+  fill: #333333;
+  stroke: #333333;
+}
+
+
+.xychart-background {
+  fill: #ffffff;
+}
+
+.xychart-title {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+}
+
+.xychart-axis {
+  stroke: #333333;
+  stroke-width: 1px;
+}
+
+.xychart-axis-title {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+}
+
+.xychart-axis-label {
+  fill: #333333;
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+}
+
+.xychart-tick {
+  stroke: #333333;
+  stroke-width: 1px;
+}
+
+.xychart-bar {
+  stroke-width: 0;
+}
+
+.xychart-line {
+  fill: none;
+  stroke-width: 2px;
+}
+
+.xychart-point {
+  stroke-width: 1px;
+}
+
+  </style>
+  <g class="root">
+    <g class="clusters">
+
+    </g>
+    <g class="edgePaths">
+
+    </g>
+    <g class="edgeLabels">
+
+    </g>
+    <g class="nodes">
+
+    </g>
+    <rect x="0" y="0" width="700" height="500" class="xychart-background" fill="#ffffff"/>
+    <text x="350" y="50" class="xychart-title" fill="#333333" dominant-baseline="hanging" font-weight="bold" font-size="16" text-anchor="middle">Quarterly Sales by Region</text>
+    <path d="M 90 90 L 650 90" class="xychart-axis" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="370" y="65" class="xychart-axis-title" fill="#333333" font-size="12" text-anchor="middle" transform="rotate(0 370 65)" dominant-baseline="middle">Sales (millions)</text>
+    <path d="M 90 90 L 90 85" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
+    <text x="90" y="80" class="xychart-axis-label" text-anchor="middle" font-size="10" dominant-baseline="auto" fill="#333333">0</text>
+    <path d="M 202 90 L 202 85" class="xychart-tick" stroke="#333333" fill="none" stroke-width="1"/>
+    <text x="202" y="80" class="xychart-axis-label" text-anchor="middle" font-size="10" dominant-baseline="auto" fill="#333333">10</text>
+    <path d="M 314 90 L 314 85" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="314" y="80" class="xychart-axis-label" dominant-baseline="auto" text-anchor="middle" font-size="10" fill="#333333">20</text>
+    <path d="M 426 90 L 426 85" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="426" y="80" class="xychart-axis-label" text-anchor="middle" dominant-baseline="auto" fill="#333333" font-size="10">30</text>
+    <path d="M 538 90 L 538 85" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="538" y="80" class="xychart-axis-label" fill="#333333" dominant-baseline="auto" text-anchor="middle" font-size="10">40</text>
+    <path d="M 650 90 L 650 85" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="650" y="80" class="xychart-axis-label" text-anchor="middle" fill="#333333" font-size="10" dominant-baseline="auto">50</text>
+    <path d="M 90 90 L 90 410" class="xychart-axis" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="65" y="250" class="xychart-axis-title" text-anchor="middle" dominant-baseline="middle" font-size="12" fill="#333333" transform="rotate(-90 65 250)">Region</text>
+    <path d="M 90 122 L 85 122" class="xychart-tick" fill="none" stroke-width="1" stroke="#333333"/>
+    <text x="80" y="122" class="xychart-axis-label" text-anchor="end" dominant-baseline="middle" font-size="10" fill="#333333">North</text>
+    <path d="M 90 186 L 85 186" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
+    <text x="80" y="186" class="xychart-axis-label" font-size="10" text-anchor="end" dominant-baseline="middle" fill="#333333">South</text>
+    <path d="M 90 250 L 85 250" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
+    <text x="80" y="250" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" font-size="10" fill="#333333">East</text>
+    <path d="M 90 314 L 85 314" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="80" y="314" class="xychart-axis-label" fill="#333333" dominant-baseline="middle" font-size="10" text-anchor="end">West</text>
+    <path d="M 90 378 L 85 378" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
+    <text x="80" y="378" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" font-size="10" fill="#333333">Central</text>
+    <rect x="90" y="96.4" width="280" height="51.2" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="90" y="160.4" width="336" height="51.2" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="90" y="224.4" width="224" height="51.2" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="90" y="288.4" width="392" height="51.2" class="xychart-bar" fill="#4C78A8"/>
+    <rect x="90" y="352.4" width="168" height="51.2" class="xychart-bar" fill="#4C78A8"/>
+    <path d="M 370 90 L 426 170 L 314 250 L 482 330 L 258 410" class="xychart-line" fill="none" stroke="#F58518" stroke-width="2"/>
+    <circle cx="370" cy="90" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="426" cy="170" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="314" cy="250" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="482" cy="330" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="258" cy="410" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <rect x="90" y="96.4" width="313.6" height="51.2" class="xychart-bar" fill="#E45756"/>
+    <rect x="90" y="160.4" width="280" height="51.2" class="xychart-bar" fill="#E45756"/>
+    <rect x="90" y="224.4" width="246.4" height="51.2" class="xychart-bar" fill="#E45756"/>
+    <rect x="90" y="288.4" width="448" height="51.2" class="xychart-bar" fill="#E45756"/>
+    <rect x="90" y="352.4" width="201.6" height="51.2" class="xychart-bar" fill="#E45756"/>
+    <path d="M 403.6 90 L 370 170 L 336.4 250 L 538 330 L 291.6 410" class="xychart-line" stroke-width="2" stroke="#72B7B2" fill="none"/>
+    <circle cx="403.6" cy="90" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
+    <circle cx="370" cy="170" r="4" class="xychart-point" stroke="#72B7B2" fill="#72B7B2"/>
+    <circle cx="336.4" cy="250" r="4" class="xychart-point" stroke="#72B7B2" fill="#72B7B2"/>
+    <circle cx="538" cy="330" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
+    <circle cx="291.6" cy="410" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
+  </g>
+</svg>

--- a/docs/images/xychart_complex.svg
+++ b/docs/images/xychart_complex.svg
@@ -136,54 +136,54 @@ marker path {
 
     </g>
     <rect x="0" y="0" width="700" height="500" class="xychart-background" fill="#ffffff"/>
-    <text x="350" y="50" class="xychart-title" fill="#333333" dominant-baseline="hanging" font-weight="bold" font-size="16" text-anchor="middle">Quarterly Sales by Region</text>
+    <text x="350" y="50" class="xychart-title" dominant-baseline="hanging" font-size="16" text-anchor="middle" fill="#333333" font-weight="bold">Quarterly Sales by Region</text>
     <path d="M 90 90 L 650 90" class="xychart-axis" stroke-width="1" fill="none" stroke="#333333"/>
-    <text x="370" y="65" class="xychart-axis-title" fill="#333333" font-size="12" text-anchor="middle" transform="rotate(0 370 65)" dominant-baseline="middle">Sales (millions)</text>
+    <text x="370" y="65" class="xychart-axis-title" transform="rotate(0 370 65)" dominant-baseline="middle" text-anchor="middle" fill="#333333" font-size="12">Sales (millions)</text>
     <path d="M 90 90 L 90 85" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
-    <text x="90" y="80" class="xychart-axis-label" text-anchor="middle" font-size="10" dominant-baseline="auto" fill="#333333">0</text>
-    <path d="M 202 90 L 202 85" class="xychart-tick" stroke="#333333" fill="none" stroke-width="1"/>
-    <text x="202" y="80" class="xychart-axis-label" text-anchor="middle" font-size="10" dominant-baseline="auto" fill="#333333">10</text>
-    <path d="M 314 90 L 314 85" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
-    <text x="314" y="80" class="xychart-axis-label" dominant-baseline="auto" text-anchor="middle" font-size="10" fill="#333333">20</text>
+    <text x="90" y="80" class="xychart-axis-label" fill="#333333" dominant-baseline="auto" font-size="10" text-anchor="middle">0</text>
+    <path d="M 202 90 L 202 85" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="202" y="80" class="xychart-axis-label" fill="#333333" font-size="10" text-anchor="middle" dominant-baseline="auto">10</text>
+    <path d="M 314 90 L 314 85" class="xychart-tick" stroke-width="1" stroke="#333333" fill="none"/>
+    <text x="314" y="80" class="xychart-axis-label" dominant-baseline="auto" text-anchor="middle" fill="#333333" font-size="10">20</text>
     <path d="M 426 90 L 426 85" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
-    <text x="426" y="80" class="xychart-axis-label" text-anchor="middle" dominant-baseline="auto" fill="#333333" font-size="10">30</text>
+    <text x="426" y="80" class="xychart-axis-label" fill="#333333" text-anchor="middle" font-size="10" dominant-baseline="auto">30</text>
     <path d="M 538 90 L 538 85" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="538" y="80" class="xychart-axis-label" fill="#333333" dominant-baseline="auto" text-anchor="middle" font-size="10">40</text>
+    <text x="538" y="80" class="xychart-axis-label" dominant-baseline="auto" font-size="10" text-anchor="middle" fill="#333333">40</text>
     <path d="M 650 90 L 650 85" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
-    <text x="650" y="80" class="xychart-axis-label" text-anchor="middle" fill="#333333" font-size="10" dominant-baseline="auto">50</text>
+    <text x="650" y="80" class="xychart-axis-label" text-anchor="middle" dominant-baseline="auto" fill="#333333" font-size="10">50</text>
     <path d="M 90 90 L 90 410" class="xychart-axis" stroke-width="1" fill="none" stroke="#333333"/>
-    <text x="65" y="250" class="xychart-axis-title" text-anchor="middle" dominant-baseline="middle" font-size="12" fill="#333333" transform="rotate(-90 65 250)">Region</text>
-    <path d="M 90 122 L 85 122" class="xychart-tick" fill="none" stroke-width="1" stroke="#333333"/>
-    <text x="80" y="122" class="xychart-axis-label" text-anchor="end" dominant-baseline="middle" font-size="10" fill="#333333">North</text>
-    <path d="M 90 186 L 85 186" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
-    <text x="80" y="186" class="xychart-axis-label" font-size="10" text-anchor="end" dominant-baseline="middle" fill="#333333">South</text>
+    <text x="65" y="250" class="xychart-axis-title" transform="rotate(-90 65 250)" font-size="12" text-anchor="middle" fill="#333333" dominant-baseline="middle">Region</text>
+    <path d="M 90 122 L 85 122" class="xychart-tick" stroke="#333333" fill="none" stroke-width="1"/>
+    <text x="80" y="122" class="xychart-axis-label" text-anchor="end" font-size="10" dominant-baseline="middle" fill="#333333">North</text>
+    <path d="M 90 186 L 85 186" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="80" y="186" class="xychart-axis-label" fill="#333333" dominant-baseline="middle" font-size="10" text-anchor="end">South</text>
     <path d="M 90 250 L 85 250" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
     <text x="80" y="250" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" font-size="10" fill="#333333">East</text>
-    <path d="M 90 314 L 85 314" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
-    <text x="80" y="314" class="xychart-axis-label" fill="#333333" dominant-baseline="middle" font-size="10" text-anchor="end">West</text>
-    <path d="M 90 378 L 85 378" class="xychart-tick" stroke-width="1" fill="none" stroke="#333333"/>
-    <text x="80" y="378" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" font-size="10" fill="#333333">Central</text>
+    <path d="M 90 314 L 85 314" class="xychart-tick" fill="none" stroke="#333333" stroke-width="1"/>
+    <text x="80" y="314" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" fill="#333333" font-size="10">West</text>
+    <path d="M 90 378 L 85 378" class="xychart-tick" stroke="#333333" stroke-width="1" fill="none"/>
+    <text x="80" y="378" class="xychart-axis-label" font-size="10" dominant-baseline="middle" fill="#333333" text-anchor="end">Central</text>
     <rect x="90" y="96.4" width="280" height="51.2" class="xychart-bar" fill="#4C78A8"/>
     <rect x="90" y="160.4" width="336" height="51.2" class="xychart-bar" fill="#4C78A8"/>
     <rect x="90" y="224.4" width="224" height="51.2" class="xychart-bar" fill="#4C78A8"/>
     <rect x="90" y="288.4" width="392" height="51.2" class="xychart-bar" fill="#4C78A8"/>
     <rect x="90" y="352.4" width="168" height="51.2" class="xychart-bar" fill="#4C78A8"/>
-    <path d="M 370 90 L 426 170 L 314 250 L 482 330 L 258 410" class="xychart-line" fill="none" stroke="#F58518" stroke-width="2"/>
-    <circle cx="370" cy="90" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
-    <circle cx="426" cy="170" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <path d="M 370 122 L 426 186 L 314 250 L 482 314 L 258 378" class="xychart-line" stroke-width="2" fill="none" stroke="#F58518"/>
+    <circle cx="370" cy="122" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="426" cy="186" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
     <circle cx="314" cy="250" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
-    <circle cx="482" cy="330" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
-    <circle cx="258" cy="410" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
+    <circle cx="482" cy="314" r="4" class="xychart-point" fill="#F58518" stroke="#F58518"/>
+    <circle cx="258" cy="378" r="4" class="xychart-point" stroke="#F58518" fill="#F58518"/>
     <rect x="90" y="96.4" width="313.6" height="51.2" class="xychart-bar" fill="#E45756"/>
     <rect x="90" y="160.4" width="280" height="51.2" class="xychart-bar" fill="#E45756"/>
     <rect x="90" y="224.4" width="246.4" height="51.2" class="xychart-bar" fill="#E45756"/>
     <rect x="90" y="288.4" width="448" height="51.2" class="xychart-bar" fill="#E45756"/>
     <rect x="90" y="352.4" width="201.6" height="51.2" class="xychart-bar" fill="#E45756"/>
-    <path d="M 403.6 90 L 370 170 L 336.4 250 L 538 330 L 291.6 410" class="xychart-line" stroke-width="2" stroke="#72B7B2" fill="none"/>
-    <circle cx="403.6" cy="90" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
-    <circle cx="370" cy="170" r="4" class="xychart-point" stroke="#72B7B2" fill="#72B7B2"/>
+    <path d="M 403.6 122 L 370 186 L 336.4 250 L 538 314 L 291.6 378" class="xychart-line" stroke="#72B7B2" stroke-width="2" fill="none"/>
+    <circle cx="403.6" cy="122" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
+    <circle cx="370" cy="186" r="4" class="xychart-point" stroke="#72B7B2" fill="#72B7B2"/>
     <circle cx="336.4" cy="250" r="4" class="xychart-point" stroke="#72B7B2" fill="#72B7B2"/>
-    <circle cx="538" cy="330" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
-    <circle cx="291.6" cy="410" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
+    <circle cx="538" cy="314" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
+    <circle cx="291.6" cy="378" r="4" class="xychart-point" fill="#72B7B2" stroke="#72B7B2"/>
   </g>
 </svg>

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -12,6 +12,7 @@ mod pie;
 mod sequence;
 mod state;
 pub mod svg;
+mod xychart;
 
 use crate::diagrams::{detect_init, detect_type, parse, remove_directives, Diagram};
 use crate::error::{MermaidError, Result};
@@ -85,6 +86,7 @@ pub fn render_with_config(diagram: &Diagram, config: &RenderConfig) -> Result<St
             let mut db_clone = db.clone();
             gantt::render_gantt(&mut db_clone, config)
         }
+        Diagram::XyChart(db) => xychart::render_xychart(db, config),
         _ => Err(MermaidError::RenderError(format!(
             "Diagram type {:?} not yet supported for rendering",
             diagram_type_name(diagram)

--- a/src/render/xychart.rs
+++ b/src/render/xychart.rs
@@ -1,0 +1,938 @@
+//! XY Chart renderer
+//!
+//! Renders XY charts with line and bar plots, supporting both vertical and horizontal orientations.
+
+use crate::diagrams::xychart::{
+    ChartOrientation, Plot, PlotType, XAxisData, XYChartDb, YAxisData,
+};
+use crate::error::Result;
+use crate::render::svg::{Attrs, RenderConfig, SvgDocument, SvgElement};
+
+/// Default chart dimensions (matching mermaid.js defaults)
+const DEFAULT_WIDTH: f64 = 700.0;
+const DEFAULT_HEIGHT: f64 = 500.0;
+const PADDING: f64 = 50.0;
+const TITLE_HEIGHT: f64 = 30.0;
+const AXIS_LABEL_PADDING: f64 = 40.0;
+const TICK_LENGTH: f64 = 5.0;
+
+/// XY Chart color palette (matching mermaid.js default theme)
+const PLOT_COLORS: &[&str] = &[
+    "#4C78A8", // Blue
+    "#F58518", // Orange
+    "#E45756", // Red
+    "#72B7B2", // Teal
+    "#54A24B", // Green
+    "#EECA3B", // Yellow
+    "#B279A2", // Purple
+    "#FF9DA6", // Pink
+];
+
+/// Render an XY chart to SVG
+pub fn render_xychart(db: &XYChartDb, config: &RenderConfig) -> Result<String> {
+    let mut doc = SvgDocument::new();
+
+    let width = DEFAULT_WIDTH;
+    let height = DEFAULT_HEIGHT;
+    doc.set_size(width, height);
+
+    // Add theme styles
+    if config.embed_css {
+        doc.add_style(&config.theme.generate_css());
+        doc.add_style(&generate_xychart_css(&config.theme));
+    }
+
+    // Calculate plot area
+    let title_offset = if !db.title.is_empty() {
+        TITLE_HEIGHT + 10.0
+    } else {
+        0.0
+    };
+
+    let plot_left = PADDING + AXIS_LABEL_PADDING;
+    let plot_right = width - PADDING;
+    let plot_top = PADDING + title_offset;
+    let plot_bottom = height - PADDING - AXIS_LABEL_PADDING;
+
+    let plot_width = plot_right - plot_left;
+    let plot_height = plot_bottom - plot_top;
+
+    // Render background
+    let bg = SvgElement::Rect {
+        x: 0.0,
+        y: 0.0,
+        width,
+        height,
+        rx: None,
+        ry: None,
+        attrs: Attrs::new()
+            .with_fill(&config.theme.background)
+            .with_class("xychart-background"),
+    };
+    doc.add_element(bg);
+
+    // Render title if present
+    if !db.title.is_empty() {
+        let title_elem = SvgElement::Text {
+            x: width / 2.0,
+            y: PADDING,
+            content: db.title.clone(),
+            attrs: Attrs::new()
+                .with_attr("text-anchor", "middle")
+                .with_attr("dominant-baseline", "hanging")
+                .with_class("xychart-title")
+                .with_attr("font-size", "16")
+                .with_attr("font-weight", "bold")
+                .with_fill(&config.theme.primary_text_color),
+        };
+        doc.add_element(title_elem);
+    }
+
+    // Calculate data range
+    let (y_min, y_max) = calculate_y_range(db);
+    let num_points = calculate_num_points(db);
+
+    if num_points == 0 {
+        return Ok(doc.to_string());
+    }
+
+    // Create scaling functions
+    let is_horizontal = db.orientation == ChartOrientation::Horizontal;
+
+    // Render based on orientation
+    if is_horizontal {
+        render_horizontal_chart(
+            &mut doc,
+            db,
+            config,
+            plot_left,
+            plot_top,
+            plot_width,
+            plot_height,
+            y_min,
+            y_max,
+            num_points,
+        );
+    } else {
+        render_vertical_chart(
+            &mut doc,
+            db,
+            config,
+            plot_left,
+            plot_top,
+            plot_width,
+            plot_height,
+            y_min,
+            y_max,
+            num_points,
+        );
+    }
+
+    Ok(doc.to_string())
+}
+
+/// Render a vertical chart (x-axis at bottom, y-axis at left)
+fn render_vertical_chart(
+    doc: &mut SvgDocument,
+    db: &XYChartDb,
+    config: &RenderConfig,
+    plot_left: f64,
+    plot_top: f64,
+    plot_width: f64,
+    plot_height: f64,
+    y_min: f64,
+    y_max: f64,
+    num_points: usize,
+) {
+    let plot_bottom = plot_top + plot_height;
+    let _plot_right = plot_left + plot_width;
+
+    // Render axes
+    render_y_axis(
+        doc,
+        db,
+        config,
+        plot_left,
+        plot_top,
+        plot_height,
+        y_min,
+        y_max,
+        false,
+    );
+    render_x_axis(
+        doc,
+        db,
+        config,
+        plot_left,
+        plot_bottom,
+        plot_width,
+        num_points,
+        false,
+    );
+
+    // Render plots
+    let mut bar_index = 0;
+    let mut line_index = 0;
+
+    for (plot_idx, plot) in db.get_plots().iter().enumerate() {
+        let color = PLOT_COLORS[plot_idx % PLOT_COLORS.len()];
+
+        match plot.plot_type {
+            PlotType::Bar => {
+                render_vertical_bars(
+                    doc,
+                    plot,
+                    color,
+                    plot_left,
+                    plot_top,
+                    plot_width,
+                    plot_height,
+                    y_min,
+                    y_max,
+                    num_points,
+                    bar_index,
+                );
+                bar_index += 1;
+            }
+            PlotType::Line => {
+                render_vertical_line(
+                    doc,
+                    plot,
+                    color,
+                    plot_left,
+                    plot_top,
+                    plot_width,
+                    plot_height,
+                    y_min,
+                    y_max,
+                    num_points,
+                    line_index,
+                );
+                line_index += 1;
+            }
+        }
+    }
+}
+
+/// Render a horizontal chart (x-axis at left, y-axis at top)
+fn render_horizontal_chart(
+    doc: &mut SvgDocument,
+    db: &XYChartDb,
+    config: &RenderConfig,
+    plot_left: f64,
+    plot_top: f64,
+    plot_width: f64,
+    plot_height: f64,
+    y_min: f64,
+    y_max: f64,
+    num_points: usize,
+) {
+    // In horizontal mode, x and y are swapped visually
+    // X-axis (categories) goes on the left (vertical)
+    // Y-axis (values) goes on the top (horizontal)
+
+    render_y_axis(
+        doc,
+        db,
+        config,
+        plot_left,
+        plot_top,
+        plot_width,
+        y_min,
+        y_max,
+        true,
+    );
+    render_x_axis(
+        doc,
+        db,
+        config,
+        plot_left,
+        plot_top,
+        plot_height,
+        num_points,
+        true,
+    );
+
+    // Render plots
+    let mut bar_index = 0;
+    let mut line_index = 0;
+
+    for (plot_idx, plot) in db.get_plots().iter().enumerate() {
+        let color = PLOT_COLORS[plot_idx % PLOT_COLORS.len()];
+
+        match plot.plot_type {
+            PlotType::Bar => {
+                render_horizontal_bars(
+                    doc,
+                    plot,
+                    color,
+                    plot_left,
+                    plot_top,
+                    plot_width,
+                    plot_height,
+                    y_min,
+                    y_max,
+                    num_points,
+                    bar_index,
+                );
+                bar_index += 1;
+            }
+            PlotType::Line => {
+                render_horizontal_line(
+                    doc,
+                    plot,
+                    color,
+                    plot_left,
+                    plot_top,
+                    plot_width,
+                    plot_height,
+                    y_min,
+                    y_max,
+                    num_points,
+                    line_index,
+                );
+                line_index += 1;
+            }
+        }
+    }
+}
+
+/// Render vertical bars for a bar plot
+fn render_vertical_bars(
+    doc: &mut SvgDocument,
+    plot: &Plot,
+    color: &str,
+    plot_left: f64,
+    plot_top: f64,
+    plot_width: f64,
+    plot_height: f64,
+    y_min: f64,
+    y_max: f64,
+    num_points: usize,
+    _bar_index: usize,
+) {
+    let bar_spacing = plot_width / num_points as f64;
+    let bar_padding = 0.1; // 10% padding on each side
+    let bar_width = bar_spacing * (1.0 - 2.0 * bar_padding);
+
+    let plot_bottom = plot_top + plot_height;
+    let y_range = y_max - y_min;
+
+    for (i, data_point) in plot.data.iter().enumerate() {
+        let x = plot_left + bar_spacing * (i as f64 + 0.5) - bar_width / 2.0;
+
+        // Calculate bar height and y position
+        let value_ratio = if y_range != 0.0 {
+            (data_point.value - y_min) / y_range
+        } else {
+            0.5
+        };
+
+        let bar_height = plot_height * value_ratio;
+        let y = plot_bottom - bar_height;
+
+        // Handle negative values
+        let (actual_y, actual_height) = if data_point.value >= 0.0 {
+            (y, bar_height)
+        } else {
+            // For negative values, the bar goes down from the zero line
+            let zero_y = if y_range != 0.0 {
+                plot_bottom - plot_height * ((0.0 - y_min) / y_range)
+            } else {
+                plot_bottom
+            };
+            (zero_y, bar_height.abs())
+        };
+
+        let bar = SvgElement::Rect {
+            x,
+            y: actual_y,
+            width: bar_width.max(1.0),
+            height: actual_height.max(0.0),
+            rx: None,
+            ry: None,
+            attrs: Attrs::new()
+                .with_fill(color)
+                .with_class("xychart-bar"),
+        };
+        doc.add_element(bar);
+    }
+}
+
+/// Render horizontal bars for a bar plot
+fn render_horizontal_bars(
+    doc: &mut SvgDocument,
+    plot: &Plot,
+    color: &str,
+    plot_left: f64,
+    plot_top: f64,
+    plot_width: f64,
+    plot_height: f64,
+    y_min: f64,
+    y_max: f64,
+    num_points: usize,
+    _bar_index: usize,
+) {
+    let bar_spacing = plot_height / num_points as f64;
+    let bar_padding = 0.1;
+    let bar_height = bar_spacing * (1.0 - 2.0 * bar_padding);
+
+    let y_range = y_max - y_min;
+
+    for (i, data_point) in plot.data.iter().enumerate() {
+        let y = plot_top + bar_spacing * (i as f64 + 0.5) - bar_height / 2.0;
+
+        // Calculate bar width
+        let value_ratio = if y_range != 0.0 {
+            (data_point.value - y_min) / y_range
+        } else {
+            0.5
+        };
+
+        let bar_width_calc = plot_width * value_ratio;
+
+        let bar = SvgElement::Rect {
+            x: plot_left,
+            y,
+            width: bar_width_calc.max(0.0),
+            height: bar_height.max(1.0),
+            rx: None,
+            ry: None,
+            attrs: Attrs::new()
+                .with_fill(color)
+                .with_class("xychart-bar"),
+        };
+        doc.add_element(bar);
+    }
+}
+
+/// Render a line for a line plot (vertical orientation)
+fn render_vertical_line(
+    doc: &mut SvgDocument,
+    plot: &Plot,
+    color: &str,
+    plot_left: f64,
+    plot_top: f64,
+    plot_width: f64,
+    plot_height: f64,
+    y_min: f64,
+    y_max: f64,
+    num_points: usize,
+    _line_index: usize,
+) {
+    if plot.data.is_empty() {
+        return;
+    }
+
+    let x_spacing = if num_points > 1 {
+        plot_width / (num_points - 1) as f64
+    } else {
+        plot_width
+    };
+
+    let plot_bottom = plot_top + plot_height;
+    let y_range = y_max - y_min;
+
+    let mut path_data = String::new();
+
+    for (i, data_point) in plot.data.iter().enumerate() {
+        let x = if num_points > 1 {
+            plot_left + x_spacing * i as f64
+        } else {
+            plot_left + plot_width / 2.0
+        };
+
+        let value_ratio = if y_range != 0.0 {
+            (data_point.value - y_min) / y_range
+        } else {
+            0.5
+        };
+        let y = plot_bottom - plot_height * value_ratio;
+
+        if i == 0 {
+            path_data.push_str(&format!("M {} {}", x, y));
+        } else {
+            path_data.push_str(&format!(" L {} {}", x, y));
+        }
+    }
+
+    let line = SvgElement::Path {
+        d: path_data,
+        attrs: Attrs::new()
+            .with_fill("none")
+            .with_stroke(color)
+            .with_stroke_width(2.0)
+            .with_class("xychart-line"),
+    };
+    doc.add_element(line);
+
+    // Add circles at data points
+    for (i, data_point) in plot.data.iter().enumerate() {
+        let x = if num_points > 1 {
+            plot_left + x_spacing * i as f64
+        } else {
+            plot_left + plot_width / 2.0
+        };
+
+        let value_ratio = if y_range != 0.0 {
+            (data_point.value - y_min) / y_range
+        } else {
+            0.5
+        };
+        let y = plot_bottom - plot_height * value_ratio;
+
+        let point = SvgElement::Circle {
+            cx: x,
+            cy: y,
+            r: 4.0,
+            attrs: Attrs::new()
+                .with_fill(color)
+                .with_stroke(color)
+                .with_class("xychart-point"),
+        };
+        doc.add_element(point);
+    }
+}
+
+/// Render a line for a line plot (horizontal orientation)
+fn render_horizontal_line(
+    doc: &mut SvgDocument,
+    plot: &Plot,
+    color: &str,
+    plot_left: f64,
+    plot_top: f64,
+    plot_width: f64,
+    plot_height: f64,
+    y_min: f64,
+    y_max: f64,
+    num_points: usize,
+    _line_index: usize,
+) {
+    if plot.data.is_empty() {
+        return;
+    }
+
+    let y_spacing = if num_points > 1 {
+        plot_height / (num_points - 1) as f64
+    } else {
+        plot_height
+    };
+
+    let y_range = y_max - y_min;
+
+    let mut path_data = String::new();
+
+    for (i, data_point) in plot.data.iter().enumerate() {
+        let y = if num_points > 1 {
+            plot_top + y_spacing * i as f64
+        } else {
+            plot_top + plot_height / 2.0
+        };
+
+        let value_ratio = if y_range != 0.0 {
+            (data_point.value - y_min) / y_range
+        } else {
+            0.5
+        };
+        let x = plot_left + plot_width * value_ratio;
+
+        if i == 0 {
+            path_data.push_str(&format!("M {} {}", x, y));
+        } else {
+            path_data.push_str(&format!(" L {} {}", x, y));
+        }
+    }
+
+    let line = SvgElement::Path {
+        d: path_data,
+        attrs: Attrs::new()
+            .with_fill("none")
+            .with_stroke(color)
+            .with_stroke_width(2.0)
+            .with_class("xychart-line"),
+    };
+    doc.add_element(line);
+
+    // Add circles at data points
+    for (i, data_point) in plot.data.iter().enumerate() {
+        let y = if num_points > 1 {
+            plot_top + y_spacing * i as f64
+        } else {
+            plot_top + plot_height / 2.0
+        };
+
+        let value_ratio = if y_range != 0.0 {
+            (data_point.value - y_min) / y_range
+        } else {
+            0.5
+        };
+        let x = plot_left + plot_width * value_ratio;
+
+        let point = SvgElement::Circle {
+            cx: x,
+            cy: y,
+            r: 4.0,
+            attrs: Attrs::new()
+                .with_fill(color)
+                .with_stroke(color)
+                .with_class("xychart-point"),
+        };
+        doc.add_element(point);
+    }
+}
+
+/// Render the Y-axis
+fn render_y_axis(
+    doc: &mut SvgDocument,
+    db: &XYChartDb,
+    config: &RenderConfig,
+    plot_left: f64,
+    plot_top: f64,
+    axis_length: f64,
+    y_min: f64,
+    y_max: f64,
+    is_horizontal: bool,
+) {
+    // Axis line
+    let (x1, y1, x2, y2) = if is_horizontal {
+        // Horizontal chart: Y-axis is at top, running horizontally
+        (plot_left, plot_top, plot_left + axis_length, plot_top)
+    } else {
+        // Vertical chart: Y-axis is at left, running vertically
+        (plot_left, plot_top, plot_left, plot_top + axis_length)
+    };
+
+    let axis_line = SvgElement::Path {
+        d: format!("M {} {} L {} {}", x1, y1, x2, y2),
+        attrs: Attrs::new()
+            .with_stroke(&config.theme.line_color)
+            .with_stroke_width(1.0)
+            .with_fill("none")
+            .with_class("xychart-axis"),
+    };
+    doc.add_element(axis_line);
+
+    // Y-axis title
+    if let Some(YAxisData::Linear(axis_data)) = &db.y_axis {
+        if !axis_data.title.is_empty() {
+            let (title_x, title_y, rotation) = if is_horizontal {
+                (plot_left + axis_length / 2.0, plot_top - 25.0, 0.0)
+            } else {
+                (15.0, plot_top + axis_length / 2.0, -90.0)
+            };
+
+            let title = SvgElement::Text {
+                x: title_x,
+                y: title_y,
+                content: axis_data.title.clone(),
+                attrs: Attrs::new()
+                    .with_attr("text-anchor", "middle")
+                    .with_attr("dominant-baseline", "middle")
+                    .with_attr("transform", &format!("rotate({} {} {})", rotation, title_x, title_y))
+                    .with_class("xychart-axis-title")
+                    .with_attr("font-size", "12")
+                    .with_fill(&config.theme.primary_text_color),
+            };
+            doc.add_element(title);
+        }
+    }
+
+    // Y-axis tick marks and labels
+    let num_ticks = 5;
+    let y_range = y_max - y_min;
+
+    for i in 0..=num_ticks {
+        let ratio = i as f64 / num_ticks as f64;
+        let value = y_min + y_range * ratio;
+
+        let (tick_x, tick_y, label_x, label_y) = if is_horizontal {
+            let x = plot_left + axis_length * ratio;
+            (x, plot_top, x, plot_top - 10.0)
+        } else {
+            let y = plot_top + axis_length * (1.0 - ratio); // Inverted for y-axis
+            (plot_left, y, plot_left - 10.0, y)
+        };
+
+        // Tick mark
+        let (tick_dx, tick_dy) = if is_horizontal {
+            (0.0, -TICK_LENGTH)
+        } else {
+            (-TICK_LENGTH, 0.0)
+        };
+
+        let tick = SvgElement::Path {
+            d: format!("M {} {} L {} {}", tick_x, tick_y, tick_x + tick_dx, tick_y + tick_dy),
+            attrs: Attrs::new()
+                .with_stroke(&config.theme.line_color)
+                .with_stroke_width(1.0)
+                .with_fill("none")
+                .with_class("xychart-tick"),
+        };
+        doc.add_element(tick);
+
+        // Label
+        let label_text = format_number(value);
+        let label = SvgElement::Text {
+            x: label_x,
+            y: label_y,
+            content: label_text,
+            attrs: Attrs::new()
+                .with_attr("text-anchor", if is_horizontal { "middle" } else { "end" })
+                .with_attr("dominant-baseline", if is_horizontal { "auto" } else { "middle" })
+                .with_class("xychart-axis-label")
+                .with_attr("font-size", "10")
+                .with_fill(&config.theme.primary_text_color),
+        };
+        doc.add_element(label);
+    }
+}
+
+/// Render the X-axis
+fn render_x_axis(
+    doc: &mut SvgDocument,
+    db: &XYChartDb,
+    config: &RenderConfig,
+    plot_left: f64,
+    axis_y: f64,
+    axis_length: f64,
+    num_points: usize,
+    is_horizontal: bool,
+) {
+    // Axis line
+    let (x1, y1, x2, y2) = if is_horizontal {
+        // Horizontal chart: X-axis is at left, running vertically
+        (plot_left, axis_y, plot_left, axis_y + axis_length)
+    } else {
+        // Vertical chart: X-axis is at bottom, running horizontally
+        (plot_left, axis_y, plot_left + axis_length, axis_y)
+    };
+
+    let axis_line = SvgElement::Path {
+        d: format!("M {} {} L {} {}", x1, y1, x2, y2),
+        attrs: Attrs::new()
+            .with_stroke(&config.theme.line_color)
+            .with_stroke_width(1.0)
+            .with_fill("none")
+            .with_class("xychart-axis"),
+    };
+    doc.add_element(axis_line);
+
+    // Get category labels
+    let categories = get_x_axis_categories(db, num_points);
+
+    // X-axis title
+    if let Some(x_axis) = &db.x_axis {
+        let title = match x_axis {
+            XAxisData::Band(axis_data) => &axis_data.title,
+            XAxisData::Linear(axis_data) => &axis_data.title,
+        };
+
+        if !title.is_empty() {
+            let (title_x, title_y, rotation) = if is_horizontal {
+                (plot_left - 25.0, axis_y + axis_length / 2.0, -90.0)
+            } else {
+                (plot_left + axis_length / 2.0, axis_y + 35.0, 0.0)
+            };
+
+            let title_elem = SvgElement::Text {
+                x: title_x,
+                y: title_y,
+                content: title.clone(),
+                attrs: Attrs::new()
+                    .with_attr("text-anchor", "middle")
+                    .with_attr("dominant-baseline", "middle")
+                    .with_attr("transform", &format!("rotate({} {} {})", rotation, title_x, title_y))
+                    .with_class("xychart-axis-title")
+                    .with_attr("font-size", "12")
+                    .with_fill(&config.theme.primary_text_color),
+            };
+            doc.add_element(title_elem);
+        }
+    }
+
+    // X-axis tick marks and labels
+    let spacing = if num_points > 0 {
+        axis_length / num_points as f64
+    } else {
+        axis_length
+    };
+
+    for (i, category) in categories.iter().enumerate() {
+        let (tick_x, tick_y, label_x, label_y) = if is_horizontal {
+            let y = axis_y + spacing * (i as f64 + 0.5);
+            (plot_left, y, plot_left - 10.0, y)
+        } else {
+            let x = plot_left + spacing * (i as f64 + 0.5);
+            (x, axis_y, x, axis_y + 15.0)
+        };
+
+        // Tick mark
+        let (tick_dx, tick_dy) = if is_horizontal {
+            (-TICK_LENGTH, 0.0)
+        } else {
+            (0.0, TICK_LENGTH)
+        };
+
+        let tick = SvgElement::Path {
+            d: format!("M {} {} L {} {}", tick_x, tick_y, tick_x + tick_dx, tick_y + tick_dy),
+            attrs: Attrs::new()
+                .with_stroke(&config.theme.line_color)
+                .with_stroke_width(1.0)
+                .with_fill("none")
+                .with_class("xychart-tick"),
+        };
+        doc.add_element(tick);
+
+        // Label
+        let label = SvgElement::Text {
+            x: label_x,
+            y: label_y,
+            content: truncate_label(category, 10),
+            attrs: Attrs::new()
+                .with_attr("text-anchor", if is_horizontal { "end" } else { "middle" })
+                .with_attr("dominant-baseline", if is_horizontal { "middle" } else { "hanging" })
+                .with_class("xychart-axis-label")
+                .with_attr("font-size", "10")
+                .with_fill(&config.theme.primary_text_color),
+        };
+        doc.add_element(label);
+    }
+}
+
+/// Calculate the Y-axis range from the data
+fn calculate_y_range(db: &XYChartDb) -> (f64, f64) {
+    // First check if Y-axis has explicit range
+    if let Some(YAxisData::Linear(axis_data)) = &db.y_axis {
+        if axis_data.min != 0.0 || axis_data.max != 0.0 {
+            return (axis_data.min, axis_data.max);
+        }
+    }
+
+    // Otherwise calculate from data
+    let mut min = f64::MAX;
+    let mut max = f64::MIN;
+
+    for plot in db.get_plots() {
+        for data_point in &plot.data {
+            min = min.min(data_point.value);
+            max = max.max(data_point.value);
+        }
+    }
+
+    if min == f64::MAX || max == f64::MIN {
+        return (0.0, 100.0); // Default range
+    }
+
+    // Add some padding
+    let range = max - min;
+    let padding = if range > 0.0 { range * 0.1 } else { 1.0 };
+
+    // Include 0 if data is all positive or all negative
+    if min >= 0.0 {
+        min = 0.0;
+    }
+
+    (min - padding.min(min.abs() * 0.1), max + padding)
+}
+
+/// Calculate the number of data points
+fn calculate_num_points(db: &XYChartDb) -> usize {
+    // First check x-axis for categories
+    if let Some(XAxisData::Band(axis_data)) = &db.x_axis {
+        if !axis_data.categories.is_empty() {
+            return axis_data.categories.len();
+        }
+    }
+
+    // Otherwise get max from plots
+    db.get_plots()
+        .iter()
+        .map(|p| p.data.len())
+        .max()
+        .unwrap_or(0)
+}
+
+/// Get X-axis category labels
+fn get_x_axis_categories(db: &XYChartDb, num_points: usize) -> Vec<String> {
+    if let Some(XAxisData::Band(axis_data)) = &db.x_axis {
+        if !axis_data.categories.is_empty() {
+            return axis_data.categories.clone();
+        }
+    }
+
+    // Generate numeric labels
+    (1..=num_points).map(|i| i.to_string()).collect()
+}
+
+/// Format a number for display
+fn format_number(value: f64) -> String {
+    if value.abs() >= 1000.0 {
+        format!("{:.0}", value)
+    } else if value.fract() == 0.0 {
+        format!("{:.0}", value)
+    } else {
+        format!("{:.1}", value)
+    }
+}
+
+/// Truncate a label if too long
+fn truncate_label(label: &str, max_len: usize) -> String {
+    if label.len() > max_len {
+        format!("{}...", &label[..max_len - 3])
+    } else {
+        label.to_string()
+    }
+}
+
+/// Generate CSS for XY chart styling
+fn generate_xychart_css(theme: &crate::render::svg::Theme) -> String {
+    format!(
+        r#"
+.xychart-background {{
+  fill: {background};
+}}
+
+.xychart-title {{
+  fill: {text_color};
+  font-family: {font_family};
+}}
+
+.xychart-axis {{
+  stroke: {line_color};
+  stroke-width: 1px;
+}}
+
+.xychart-axis-title {{
+  fill: {text_color};
+  font-family: {font_family};
+}}
+
+.xychart-axis-label {{
+  fill: {text_color};
+  font-family: {font_family};
+}}
+
+.xychart-tick {{
+  stroke: {line_color};
+  stroke-width: 1px;
+}}
+
+.xychart-bar {{
+  stroke-width: 0;
+}}
+
+.xychart-line {{
+  fill: none;
+  stroke-width: 2px;
+}}
+
+.xychart-point {{
+  stroke-width: 1px;
+}}
+"#,
+        background = theme.background,
+        text_color = theme.primary_text_color,
+        line_color = theme.line_color,
+        font_family = theme.font_family,
+    )
+}

--- a/src/render/xychart.rs
+++ b/src/render/xychart.rs
@@ -375,16 +375,23 @@ fn render_horizontal_line(doc: &mut SvgDocument, plot: &Plot, color: &str, area:
         return;
     }
 
-    // Use same spacing as bars - centered on each category slot
-    let y_spacing = area.plot_height / area.num_points as f64;
+    // Use edge-to-edge spacing (like vertical lines) for visual consistency
+    let y_spacing = if area.num_points > 1 {
+        area.plot_height / (area.num_points - 1) as f64
+    } else {
+        area.plot_height
+    };
 
     let y_range = area.y_max - area.y_min;
 
     let mut path_data = String::new();
 
     for (i, data_point) in plot.data.iter().enumerate() {
-        // Center on each category slot (same as bars)
-        let y = area.plot_top + y_spacing * (i as f64 + 0.5);
+        let y = if area.num_points > 1 {
+            area.plot_top + y_spacing * i as f64
+        } else {
+            area.plot_top + area.plot_height / 2.0
+        };
 
         let value_ratio = if y_range != 0.0 {
             (data_point.value - area.y_min) / y_range
@@ -412,8 +419,11 @@ fn render_horizontal_line(doc: &mut SvgDocument, plot: &Plot, color: &str, area:
 
     // Add circles at data points
     for (i, data_point) in plot.data.iter().enumerate() {
-        // Center on each category slot (same as bars)
-        let y = area.plot_top + y_spacing * (i as f64 + 0.5);
+        let y = if area.num_points > 1 {
+            area.plot_top + y_spacing * i as f64
+        } else {
+            area.plot_top + area.plot_height / 2.0
+        };
 
         let value_ratio = if y_range != 0.0 {
             (data_point.value - area.y_min) / y_range

--- a/src/render/xychart.rs
+++ b/src/render/xychart.rs
@@ -375,22 +375,16 @@ fn render_horizontal_line(doc: &mut SvgDocument, plot: &Plot, color: &str, area:
         return;
     }
 
-    let y_spacing = if area.num_points > 1 {
-        area.plot_height / (area.num_points - 1) as f64
-    } else {
-        area.plot_height
-    };
+    // Use same spacing as bars - centered on each category slot
+    let y_spacing = area.plot_height / area.num_points as f64;
 
     let y_range = area.y_max - area.y_min;
 
     let mut path_data = String::new();
 
     for (i, data_point) in plot.data.iter().enumerate() {
-        let y = if area.num_points > 1 {
-            area.plot_top + y_spacing * i as f64
-        } else {
-            area.plot_top + area.plot_height / 2.0
-        };
+        // Center on each category slot (same as bars)
+        let y = area.plot_top + y_spacing * (i as f64 + 0.5);
 
         let value_ratio = if y_range != 0.0 {
             (data_point.value - area.y_min) / y_range
@@ -418,11 +412,8 @@ fn render_horizontal_line(doc: &mut SvgDocument, plot: &Plot, color: &str, area:
 
     // Add circles at data points
     for (i, data_point) in plot.data.iter().enumerate() {
-        let y = if area.num_points > 1 {
-            area.plot_top + y_spacing * i as f64
-        } else {
-            area.plot_top + area.plot_height / 2.0
-        };
+        // Center on each category slot (same as bars)
+        let y = area.plot_top + y_spacing * (i as f64 + 0.5);
 
         let value_ratio = if y_range != 0.0 {
             (data_point.value - area.y_min) / y_range

--- a/src/render/xychart.rs
+++ b/src/render/xychart.rs
@@ -2,9 +2,7 @@
 //!
 //! Renders XY charts with line and bar plots, supporting both vertical and horizontal orientations.
 
-use crate::diagrams::xychart::{
-    ChartOrientation, Plot, PlotType, XAxisData, XYChartDb, YAxisData,
-};
+use crate::diagrams::xychart::{ChartOrientation, Plot, PlotType, XAxisData, XYChartDb, YAxisData};
 use crate::error::Result;
 use crate::render::svg::{Attrs, RenderConfig, SvgDocument, SvgElement};
 
@@ -137,8 +135,27 @@ fn render_vertical_chart(
     let plot_bottom = area.plot_top + area.plot_height;
 
     // Render axes
-    render_y_axis(doc, db, config, area.plot_left, area.plot_top, area.plot_height, area.y_min, area.y_max, false);
-    render_x_axis(doc, db, config, area.plot_left, plot_bottom, area.plot_width, area.num_points, false);
+    render_y_axis(
+        doc,
+        db,
+        config,
+        area.plot_left,
+        area.plot_top,
+        area.plot_height,
+        area.y_min,
+        area.y_max,
+        false,
+    );
+    render_x_axis(
+        doc,
+        db,
+        config,
+        area.plot_left,
+        plot_bottom,
+        area.plot_width,
+        area.num_points,
+        false,
+    );
 
     // Render plots
     for (plot_idx, plot) in db.get_plots().iter().enumerate() {
@@ -162,8 +179,27 @@ fn render_horizontal_chart(
     // X-axis (categories) goes on the left (vertical)
     // Y-axis (values) goes on the top (horizontal)
 
-    render_y_axis(doc, db, config, area.plot_left, area.plot_top, area.plot_width, area.y_min, area.y_max, true);
-    render_x_axis(doc, db, config, area.plot_left, area.plot_top, area.plot_height, area.num_points, true);
+    render_y_axis(
+        doc,
+        db,
+        config,
+        area.plot_left,
+        area.plot_top,
+        area.plot_width,
+        area.y_min,
+        area.y_max,
+        true,
+    );
+    render_x_axis(
+        doc,
+        db,
+        config,
+        area.plot_left,
+        area.plot_top,
+        area.plot_height,
+        area.num_points,
+        true,
+    );
 
     // Render plots
     for (plot_idx, plot) in db.get_plots().iter().enumerate() {
@@ -218,9 +254,7 @@ fn render_vertical_bars(doc: &mut SvgDocument, plot: &Plot, color: &str, area: &
             height: actual_height.max(0.0),
             rx: None,
             ry: None,
-            attrs: Attrs::new()
-                .with_fill(color)
-                .with_class("xychart-bar"),
+            attrs: Attrs::new().with_fill(color).with_class("xychart-bar"),
         };
         doc.add_element(bar);
     }
@@ -253,9 +287,7 @@ fn render_horizontal_bars(doc: &mut SvgDocument, plot: &Plot, color: &str, area:
             height: bar_height.max(1.0),
             rx: None,
             ry: None,
-            attrs: Attrs::new()
-                .with_fill(color)
-                .with_class("xychart-bar"),
+            attrs: Attrs::new().with_fill(color).with_class("xychart-bar"),
         };
         doc.add_element(bar);
     }
@@ -460,7 +492,10 @@ fn render_y_axis(
                 attrs: Attrs::new()
                     .with_attr("text-anchor", "middle")
                     .with_attr("dominant-baseline", "middle")
-                    .with_attr("transform", &format!("rotate({} {} {})", rotation, title_x, title_y))
+                    .with_attr(
+                        "transform",
+                        &format!("rotate({} {} {})", rotation, title_x, title_y),
+                    )
                     .with_class("xychart-axis-title")
                     .with_attr("font-size", "12")
                     .with_fill(&config.theme.primary_text_color),
@@ -493,7 +528,13 @@ fn render_y_axis(
         };
 
         let tick = SvgElement::Path {
-            d: format!("M {} {} L {} {}", tick_x, tick_y, tick_x + tick_dx, tick_y + tick_dy),
+            d: format!(
+                "M {} {} L {} {}",
+                tick_x,
+                tick_y,
+                tick_x + tick_dx,
+                tick_y + tick_dy
+            ),
             attrs: Attrs::new()
                 .with_stroke(&config.theme.line_color)
                 .with_stroke_width(1.0)
@@ -510,7 +551,10 @@ fn render_y_axis(
             content: label_text,
             attrs: Attrs::new()
                 .with_attr("text-anchor", if is_horizontal { "middle" } else { "end" })
-                .with_attr("dominant-baseline", if is_horizontal { "auto" } else { "middle" })
+                .with_attr(
+                    "dominant-baseline",
+                    if is_horizontal { "auto" } else { "middle" },
+                )
                 .with_class("xychart-axis-label")
                 .with_attr("font-size", "10")
                 .with_fill(&config.theme.primary_text_color),
@@ -574,7 +618,10 @@ fn render_x_axis(
                 attrs: Attrs::new()
                     .with_attr("text-anchor", "middle")
                     .with_attr("dominant-baseline", "middle")
-                    .with_attr("transform", &format!("rotate({} {} {})", rotation, title_x, title_y))
+                    .with_attr(
+                        "transform",
+                        &format!("rotate({} {} {})", rotation, title_x, title_y),
+                    )
                     .with_class("xychart-axis-title")
                     .with_attr("font-size", "12")
                     .with_fill(&config.theme.primary_text_color),
@@ -607,7 +654,13 @@ fn render_x_axis(
         };
 
         let tick = SvgElement::Path {
-            d: format!("M {} {} L {} {}", tick_x, tick_y, tick_x + tick_dx, tick_y + tick_dy),
+            d: format!(
+                "M {} {} L {} {}",
+                tick_x,
+                tick_y,
+                tick_x + tick_dx,
+                tick_y + tick_dy
+            ),
             attrs: Attrs::new()
                 .with_stroke(&config.theme.line_color)
                 .with_stroke_width(1.0)
@@ -623,7 +676,10 @@ fn render_x_axis(
             content: truncate_label(category, 10),
             attrs: Attrs::new()
                 .with_attr("text-anchor", if is_horizontal { "end" } else { "middle" })
-                .with_attr("dominant-baseline", if is_horizontal { "middle" } else { "hanging" })
+                .with_attr(
+                    "dominant-baseline",
+                    if is_horizontal { "middle" } else { "hanging" },
+                )
                 .with_class("xychart-axis-label")
                 .with_attr("font-size", "10")
                 .with_fill(&config.theme.primary_text_color),

--- a/src/render/xychart.rs
+++ b/src/render/xychart.rs
@@ -28,6 +28,17 @@ const PLOT_COLORS: &[&str] = &[
     "#FF9DA6", // Pink
 ];
 
+/// Chart area dimensions and data range
+struct ChartArea {
+    plot_left: f64,
+    plot_top: f64,
+    plot_width: f64,
+    plot_height: f64,
+    y_min: f64,
+    y_max: f64,
+    num_points: usize,
+}
+
 /// Render an XY chart to SVG
 pub fn render_xychart(db: &XYChartDb, config: &RenderConfig) -> Result<String> {
     let mut doc = SvgDocument::new();
@@ -96,36 +107,21 @@ pub fn render_xychart(db: &XYChartDb, config: &RenderConfig) -> Result<String> {
         return Ok(doc.to_string());
     }
 
-    // Create scaling functions
-    let is_horizontal = db.orientation == ChartOrientation::Horizontal;
+    let area = ChartArea {
+        plot_left,
+        plot_top,
+        plot_width,
+        plot_height,
+        y_min,
+        y_max,
+        num_points,
+    };
 
     // Render based on orientation
-    if is_horizontal {
-        render_horizontal_chart(
-            &mut doc,
-            db,
-            config,
-            plot_left,
-            plot_top,
-            plot_width,
-            plot_height,
-            y_min,
-            y_max,
-            num_points,
-        );
+    if db.orientation == ChartOrientation::Horizontal {
+        render_horizontal_chart(&mut doc, db, config, &area);
     } else {
-        render_vertical_chart(
-            &mut doc,
-            db,
-            config,
-            plot_left,
-            plot_top,
-            plot_width,
-            plot_height,
-            y_min,
-            y_max,
-            num_points,
-        );
+        render_vertical_chart(&mut doc, db, config, &area);
     }
 
     Ok(doc.to_string())
@@ -136,80 +132,21 @@ fn render_vertical_chart(
     doc: &mut SvgDocument,
     db: &XYChartDb,
     config: &RenderConfig,
-    plot_left: f64,
-    plot_top: f64,
-    plot_width: f64,
-    plot_height: f64,
-    y_min: f64,
-    y_max: f64,
-    num_points: usize,
+    area: &ChartArea,
 ) {
-    let plot_bottom = plot_top + plot_height;
-    let _plot_right = plot_left + plot_width;
+    let plot_bottom = area.plot_top + area.plot_height;
 
     // Render axes
-    render_y_axis(
-        doc,
-        db,
-        config,
-        plot_left,
-        plot_top,
-        plot_height,
-        y_min,
-        y_max,
-        false,
-    );
-    render_x_axis(
-        doc,
-        db,
-        config,
-        plot_left,
-        plot_bottom,
-        plot_width,
-        num_points,
-        false,
-    );
+    render_y_axis(doc, db, config, area.plot_left, area.plot_top, area.plot_height, area.y_min, area.y_max, false);
+    render_x_axis(doc, db, config, area.plot_left, plot_bottom, area.plot_width, area.num_points, false);
 
     // Render plots
-    let mut bar_index = 0;
-    let mut line_index = 0;
-
     for (plot_idx, plot) in db.get_plots().iter().enumerate() {
         let color = PLOT_COLORS[plot_idx % PLOT_COLORS.len()];
 
         match plot.plot_type {
-            PlotType::Bar => {
-                render_vertical_bars(
-                    doc,
-                    plot,
-                    color,
-                    plot_left,
-                    plot_top,
-                    plot_width,
-                    plot_height,
-                    y_min,
-                    y_max,
-                    num_points,
-                    bar_index,
-                );
-                bar_index += 1;
-            }
-            PlotType::Line => {
-                render_vertical_line(
-                    doc,
-                    plot,
-                    color,
-                    plot_left,
-                    plot_top,
-                    plot_width,
-                    plot_height,
-                    y_min,
-                    y_max,
-                    num_points,
-                    line_index,
-                );
-                line_index += 1;
-            }
+            PlotType::Bar => render_vertical_bars(doc, plot, color, area),
+            PlotType::Line => render_vertical_line(doc, plot, color, area),
         }
     }
 }
@@ -219,116 +156,46 @@ fn render_horizontal_chart(
     doc: &mut SvgDocument,
     db: &XYChartDb,
     config: &RenderConfig,
-    plot_left: f64,
-    plot_top: f64,
-    plot_width: f64,
-    plot_height: f64,
-    y_min: f64,
-    y_max: f64,
-    num_points: usize,
+    area: &ChartArea,
 ) {
     // In horizontal mode, x and y are swapped visually
     // X-axis (categories) goes on the left (vertical)
     // Y-axis (values) goes on the top (horizontal)
 
-    render_y_axis(
-        doc,
-        db,
-        config,
-        plot_left,
-        plot_top,
-        plot_width,
-        y_min,
-        y_max,
-        true,
-    );
-    render_x_axis(
-        doc,
-        db,
-        config,
-        plot_left,
-        plot_top,
-        plot_height,
-        num_points,
-        true,
-    );
+    render_y_axis(doc, db, config, area.plot_left, area.plot_top, area.plot_width, area.y_min, area.y_max, true);
+    render_x_axis(doc, db, config, area.plot_left, area.plot_top, area.plot_height, area.num_points, true);
 
     // Render plots
-    let mut bar_index = 0;
-    let mut line_index = 0;
-
     for (plot_idx, plot) in db.get_plots().iter().enumerate() {
         let color = PLOT_COLORS[plot_idx % PLOT_COLORS.len()];
 
         match plot.plot_type {
-            PlotType::Bar => {
-                render_horizontal_bars(
-                    doc,
-                    plot,
-                    color,
-                    plot_left,
-                    plot_top,
-                    plot_width,
-                    plot_height,
-                    y_min,
-                    y_max,
-                    num_points,
-                    bar_index,
-                );
-                bar_index += 1;
-            }
-            PlotType::Line => {
-                render_horizontal_line(
-                    doc,
-                    plot,
-                    color,
-                    plot_left,
-                    plot_top,
-                    plot_width,
-                    plot_height,
-                    y_min,
-                    y_max,
-                    num_points,
-                    line_index,
-                );
-                line_index += 1;
-            }
+            PlotType::Bar => render_horizontal_bars(doc, plot, color, area),
+            PlotType::Line => render_horizontal_line(doc, plot, color, area),
         }
     }
 }
 
 /// Render vertical bars for a bar plot
-fn render_vertical_bars(
-    doc: &mut SvgDocument,
-    plot: &Plot,
-    color: &str,
-    plot_left: f64,
-    plot_top: f64,
-    plot_width: f64,
-    plot_height: f64,
-    y_min: f64,
-    y_max: f64,
-    num_points: usize,
-    _bar_index: usize,
-) {
-    let bar_spacing = plot_width / num_points as f64;
+fn render_vertical_bars(doc: &mut SvgDocument, plot: &Plot, color: &str, area: &ChartArea) {
+    let bar_spacing = area.plot_width / area.num_points as f64;
     let bar_padding = 0.1; // 10% padding on each side
     let bar_width = bar_spacing * (1.0 - 2.0 * bar_padding);
 
-    let plot_bottom = plot_top + plot_height;
-    let y_range = y_max - y_min;
+    let plot_bottom = area.plot_top + area.plot_height;
+    let y_range = area.y_max - area.y_min;
 
     for (i, data_point) in plot.data.iter().enumerate() {
-        let x = plot_left + bar_spacing * (i as f64 + 0.5) - bar_width / 2.0;
+        let x = area.plot_left + bar_spacing * (i as f64 + 0.5) - bar_width / 2.0;
 
         // Calculate bar height and y position
         let value_ratio = if y_range != 0.0 {
-            (data_point.value - y_min) / y_range
+            (data_point.value - area.y_min) / y_range
         } else {
             0.5
         };
 
-        let bar_height = plot_height * value_ratio;
+        let bar_height = area.plot_height * value_ratio;
         let y = plot_bottom - bar_height;
 
         // Handle negative values
@@ -337,7 +204,7 @@ fn render_vertical_bars(
         } else {
             // For negative values, the bar goes down from the zero line
             let zero_y = if y_range != 0.0 {
-                plot_bottom - plot_height * ((0.0 - y_min) / y_range)
+                plot_bottom - area.plot_height * ((0.0 - area.y_min) / y_range)
             } else {
                 plot_bottom
             };
@@ -360,39 +227,27 @@ fn render_vertical_bars(
 }
 
 /// Render horizontal bars for a bar plot
-fn render_horizontal_bars(
-    doc: &mut SvgDocument,
-    plot: &Plot,
-    color: &str,
-    plot_left: f64,
-    plot_top: f64,
-    plot_width: f64,
-    plot_height: f64,
-    y_min: f64,
-    y_max: f64,
-    num_points: usize,
-    _bar_index: usize,
-) {
-    let bar_spacing = plot_height / num_points as f64;
+fn render_horizontal_bars(doc: &mut SvgDocument, plot: &Plot, color: &str, area: &ChartArea) {
+    let bar_spacing = area.plot_height / area.num_points as f64;
     let bar_padding = 0.1;
     let bar_height = bar_spacing * (1.0 - 2.0 * bar_padding);
 
-    let y_range = y_max - y_min;
+    let y_range = area.y_max - area.y_min;
 
     for (i, data_point) in plot.data.iter().enumerate() {
-        let y = plot_top + bar_spacing * (i as f64 + 0.5) - bar_height / 2.0;
+        let y = area.plot_top + bar_spacing * (i as f64 + 0.5) - bar_height / 2.0;
 
         // Calculate bar width
         let value_ratio = if y_range != 0.0 {
-            (data_point.value - y_min) / y_range
+            (data_point.value - area.y_min) / y_range
         } else {
             0.5
         };
 
-        let bar_width_calc = plot_width * value_ratio;
+        let bar_width_calc = area.plot_width * value_ratio;
 
         let bar = SvgElement::Rect {
-            x: plot_left,
+            x: area.plot_left,
             y,
             width: bar_width_calc.max(0.0),
             height: bar_height.max(1.0),
@@ -407,47 +262,35 @@ fn render_horizontal_bars(
 }
 
 /// Render a line for a line plot (vertical orientation)
-fn render_vertical_line(
-    doc: &mut SvgDocument,
-    plot: &Plot,
-    color: &str,
-    plot_left: f64,
-    plot_top: f64,
-    plot_width: f64,
-    plot_height: f64,
-    y_min: f64,
-    y_max: f64,
-    num_points: usize,
-    _line_index: usize,
-) {
+fn render_vertical_line(doc: &mut SvgDocument, plot: &Plot, color: &str, area: &ChartArea) {
     if plot.data.is_empty() {
         return;
     }
 
-    let x_spacing = if num_points > 1 {
-        plot_width / (num_points - 1) as f64
+    let x_spacing = if area.num_points > 1 {
+        area.plot_width / (area.num_points - 1) as f64
     } else {
-        plot_width
+        area.plot_width
     };
 
-    let plot_bottom = plot_top + plot_height;
-    let y_range = y_max - y_min;
+    let plot_bottom = area.plot_top + area.plot_height;
+    let y_range = area.y_max - area.y_min;
 
     let mut path_data = String::new();
 
     for (i, data_point) in plot.data.iter().enumerate() {
-        let x = if num_points > 1 {
-            plot_left + x_spacing * i as f64
+        let x = if area.num_points > 1 {
+            area.plot_left + x_spacing * i as f64
         } else {
-            plot_left + plot_width / 2.0
+            area.plot_left + area.plot_width / 2.0
         };
 
         let value_ratio = if y_range != 0.0 {
-            (data_point.value - y_min) / y_range
+            (data_point.value - area.y_min) / y_range
         } else {
             0.5
         };
-        let y = plot_bottom - plot_height * value_ratio;
+        let y = plot_bottom - area.plot_height * value_ratio;
 
         if i == 0 {
             path_data.push_str(&format!("M {} {}", x, y));
@@ -468,18 +311,18 @@ fn render_vertical_line(
 
     // Add circles at data points
     for (i, data_point) in plot.data.iter().enumerate() {
-        let x = if num_points > 1 {
-            plot_left + x_spacing * i as f64
+        let x = if area.num_points > 1 {
+            area.plot_left + x_spacing * i as f64
         } else {
-            plot_left + plot_width / 2.0
+            area.plot_left + area.plot_width / 2.0
         };
 
         let value_ratio = if y_range != 0.0 {
-            (data_point.value - y_min) / y_range
+            (data_point.value - area.y_min) / y_range
         } else {
             0.5
         };
-        let y = plot_bottom - plot_height * value_ratio;
+        let y = plot_bottom - area.plot_height * value_ratio;
 
         let point = SvgElement::Circle {
             cx: x,
@@ -495,46 +338,34 @@ fn render_vertical_line(
 }
 
 /// Render a line for a line plot (horizontal orientation)
-fn render_horizontal_line(
-    doc: &mut SvgDocument,
-    plot: &Plot,
-    color: &str,
-    plot_left: f64,
-    plot_top: f64,
-    plot_width: f64,
-    plot_height: f64,
-    y_min: f64,
-    y_max: f64,
-    num_points: usize,
-    _line_index: usize,
-) {
+fn render_horizontal_line(doc: &mut SvgDocument, plot: &Plot, color: &str, area: &ChartArea) {
     if plot.data.is_empty() {
         return;
     }
 
-    let y_spacing = if num_points > 1 {
-        plot_height / (num_points - 1) as f64
+    let y_spacing = if area.num_points > 1 {
+        area.plot_height / (area.num_points - 1) as f64
     } else {
-        plot_height
+        area.plot_height
     };
 
-    let y_range = y_max - y_min;
+    let y_range = area.y_max - area.y_min;
 
     let mut path_data = String::new();
 
     for (i, data_point) in plot.data.iter().enumerate() {
-        let y = if num_points > 1 {
-            plot_top + y_spacing * i as f64
+        let y = if area.num_points > 1 {
+            area.plot_top + y_spacing * i as f64
         } else {
-            plot_top + plot_height / 2.0
+            area.plot_top + area.plot_height / 2.0
         };
 
         let value_ratio = if y_range != 0.0 {
-            (data_point.value - y_min) / y_range
+            (data_point.value - area.y_min) / y_range
         } else {
             0.5
         };
-        let x = plot_left + plot_width * value_ratio;
+        let x = area.plot_left + area.plot_width * value_ratio;
 
         if i == 0 {
             path_data.push_str(&format!("M {} {}", x, y));
@@ -555,18 +386,18 @@ fn render_horizontal_line(
 
     // Add circles at data points
     for (i, data_point) in plot.data.iter().enumerate() {
-        let y = if num_points > 1 {
-            plot_top + y_spacing * i as f64
+        let y = if area.num_points > 1 {
+            area.plot_top + y_spacing * i as f64
         } else {
-            plot_top + plot_height / 2.0
+            area.plot_top + area.plot_height / 2.0
         };
 
         let value_ratio = if y_range != 0.0 {
-            (data_point.value - y_min) / y_range
+            (data_point.value - area.y_min) / y_range
         } else {
             0.5
         };
-        let x = plot_left + plot_width * value_ratio;
+        let x = area.plot_left + area.plot_width * value_ratio;
 
         let point = SvgElement::Circle {
             cx: x,
@@ -582,6 +413,7 @@ fn render_horizontal_line(
 }
 
 /// Render the Y-axis
+#[allow(clippy::too_many_arguments)]
 fn render_y_axis(
     doc: &mut SvgDocument,
     db: &XYChartDb,
@@ -688,6 +520,7 @@ fn render_y_axis(
 }
 
 /// Render the X-axis
+#[allow(clippy::too_many_arguments)]
 fn render_x_axis(
     doc: &mut SvgDocument,
     db: &XYChartDb,
@@ -866,9 +699,7 @@ fn get_x_axis_categories(db: &XYChartDb, num_points: usize) -> Vec<String> {
 
 /// Format a number for display
 fn format_number(value: f64) -> String {
-    if value.abs() >= 1000.0 {
-        format!("{:.0}", value)
-    } else if value.fract() == 0.0 {
+    if value.fract() == 0.0 || value.abs() >= 1000.0 {
         format!("{:.0}", value)
     } else {
         format!("{:.1}", value)

--- a/tests/xychart_render.rs
+++ b/tests/xychart_render.rs
@@ -325,7 +325,10 @@ fn test_many_bars_vertical() {
 
     assert_valid_svg(&svg);
     // Verify bar elements exist
-    assert!(svg.contains("<rect"), "Should contain rect elements for bars");
+    assert!(
+        svg.contains("<rect"),
+        "Should contain rect elements for bars"
+    );
 }
 
 #[test]
@@ -391,7 +394,10 @@ fn test_line_chart_only() {
 
     assert_valid_svg(&svg);
     // Verify path elements exist for lines
-    assert!(svg.contains("<path"), "Should contain path elements for lines");
+    assert!(
+        svg.contains("<path"),
+        "Should contain path elements for lines"
+    );
 }
 
 #[test]
@@ -429,8 +435,14 @@ fn test_bar_and_line_combined() {
     let svg = render(&diagram).expect("Failed to render chart");
 
     assert_valid_svg(&svg);
-    assert!(svg.contains("<rect"), "Should contain rect elements for bars");
-    assert!(svg.contains("<path"), "Should contain path elements for lines");
+    assert!(
+        svg.contains("<rect"),
+        "Should contain rect elements for bars"
+    );
+    assert!(
+        svg.contains("<path"),
+        "Should contain path elements for lines"
+    );
 }
 
 // ============================================================================
@@ -450,7 +462,8 @@ fn test_with_dark_theme() {
         theme: Theme::dark(),
         ..Default::default()
     };
-    let svg = render_with_config(&diagram, &config).expect("Failed to render chart with dark theme");
+    let svg =
+        render_with_config(&diagram, &config).expect("Failed to render chart with dark theme");
 
     assert_valid_svg(&svg);
 }
@@ -468,7 +481,8 @@ fn test_with_forest_theme() {
         theme: Theme::forest(),
         ..Default::default()
     };
-    let svg = render_with_config(&diagram, &config).expect("Failed to render chart with forest theme");
+    let svg =
+        render_with_config(&diagram, &config).expect("Failed to render chart with forest theme");
 
     assert_valid_svg(&svg);
 }
@@ -486,7 +500,8 @@ fn test_with_neutral_theme() {
         theme: Theme::neutral(),
         ..Default::default()
     };
-    let svg = render_with_config(&diagram, &config).expect("Failed to render chart with neutral theme");
+    let svg =
+        render_with_config(&diagram, &config).expect("Failed to render chart with neutral theme");
 
     assert_valid_svg(&svg);
 }

--- a/tests/xychart_render.rs
+++ b/tests/xychart_render.rs
@@ -1,0 +1,582 @@
+//! XY Chart rendering tests
+//!
+//! Test cases ported from Mermaid.js Cypress tests (xyChart.spec.js)
+
+use selkie::render::{RenderConfig, Theme};
+use selkie::{parse, render, render_with_config};
+
+/// Helper to check basic SVG structure
+fn assert_valid_svg(svg: &str) {
+    assert!(svg.contains("<svg"), "SVG should have opening tag");
+    assert!(svg.contains("</svg>"), "SVG should have closing tag");
+    assert!(
+        svg.contains("xmlns=\"http://www.w3.org/2000/svg\""),
+        "SVG should have namespace"
+    );
+}
+
+// ============================================================================
+// Basic Chart Rendering Tests (from Cypress xyChart.spec.js)
+// ============================================================================
+
+#[test]
+fn test_simplest_xy_beta_chart() {
+    // From Cypress: should render the simplest possible xy-beta chart
+    let input = r#"xychart-beta
+        line [10, 30, 20]"#;
+
+    let diagram = parse(input).expect("Failed to parse xychart-beta");
+    let svg = render(&diagram).expect("Failed to render xychart-beta");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_simplest_xy_chart() {
+    // From Cypress: should render the simplest possible xy chart
+    let input = r#"xychart
+        line [10, 30, 20]"#;
+
+    let diagram = parse(input).expect("Failed to parse xychart");
+    let svg = render(&diagram).expect("Failed to render xychart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_complete_chart() {
+    // From Cypress: Should render a complete chart
+    let input = r#"xychart
+        title "Sales Revenue"
+        x-axis Months [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]
+        y-axis "Revenue (in $)" 4000 --> 11000
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]
+        line [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]"#;
+
+    let diagram = parse(input).expect("Failed to parse complete chart");
+    let svg = render(&diagram).expect("Failed to render complete chart");
+
+    assert_valid_svg(&svg);
+    assert!(svg.contains("Sales Revenue"), "Should contain title");
+}
+
+#[test]
+fn test_chart_without_title() {
+    // From Cypress: Should render a chart without title
+    let input = r#"xychart
+        x-axis Months [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]
+        y-axis "Revenue (in $)" 4000 --> 11000
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]
+        line [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart without title");
+    let svg = render(&diagram).expect("Failed to render chart without title");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_y_axis_title_not_required() {
+    // From Cypress: y-axis title not required
+    let input = r#"xychart
+        x-axis Months [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]
+        y-axis 4000 --> 11000
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]
+        line [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_chart_without_y_axis_different_range() {
+    // From Cypress: Should render a chart without y-axis with different range
+    let input = r#"xychart
+        x-axis Months [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 14000, 3200, 9200, 9900, 3400, 6000]
+        line [2000, 7000, 6500, 9200, 9500, 7500, 11000, 10200, 3200, 8500, 7000, 8800]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_x_axis_title_not_required() {
+    // From Cypress: x axis title not required
+    let input = r#"xychart
+        x-axis [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 14000, 3200, 9200, 9900, 3400, 6000]
+        line [2000, 7000, 6500, 9200, 9500, 7500, 11000, 10200, 3200, 8500, 7000, 8800]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_multiple_plots() {
+    // From Cypress: Multiple plots can be rendered
+    let input = r#"xychart
+        line [23, 46, 77, 34]
+        line [45, 32, 33, 12]
+        bar [87, 54, 99, 85]
+        line [78, 88, 22, 4]
+        line [22, 29, 75, 33]
+        bar [52, 96, 35, 10]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart with multiple plots");
+    let svg = render(&diagram).expect("Failed to render chart with multiple plots");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_decimals_and_negatives() {
+    // From Cypress: Decimals and negative numbers are supported
+    let input = r#"xychart
+        y-axis -2.4 --> 3.5
+        line [+1.3, 0.6, 2.4, -0.34]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart with decimals");
+    let svg = render(&diagram).expect("Failed to render chart with decimals");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_correct_distances_between_data_points() {
+    // From Cypress: should use the correct distances between data points
+    let input = r#"xychart
+        x-axis 0 --> 2
+        line [0, 1, 0, 1]
+        bar [1, 0, 1, 0]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+// ============================================================================
+// Orientation Tests
+// ============================================================================
+
+#[test]
+fn test_horizontal_orientation() {
+    // From Cypress demo: XY Charts horizontal
+    let input = r#"xychart horizontal
+        title "Basic xychart"
+        x-axis "this is x axis" [category1, "category 2", category3, category4]
+        y-axis yaxisText 10 --> 150
+        bar "sample bar" [52, 96, 35, 10]
+        line [23, 46, 75, 43]"#;
+
+    let diagram = parse(input).expect("Failed to parse horizontal chart");
+    let svg = render(&diagram).expect("Failed to render horizontal chart");
+
+    assert_valid_svg(&svg);
+    assert!(svg.contains("Basic xychart"), "Should contain title");
+}
+
+#[test]
+fn test_vertical_bar_chart_with_labels() {
+    // From Cypress: should render vertical bar chart with labels
+    let input = r#"xychart
+        title "Sales Revenue"
+        x-axis Months [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]
+        y-axis "Revenue (in $)" 4000 --> 11000
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_horizontal_bar_chart_without_labels_default() {
+    // From Cypress: should render horizontal bar chart without labels by default
+    let input = r#"xychart horizontal
+        title "Sales Revenue"
+        x-axis Months [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]
+        y-axis "Revenue (in $)" 4000 --> 11000
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+// ============================================================================
+// Multiple Bar Plots Tests
+// ============================================================================
+
+#[test]
+fn test_multiple_bar_plots_vertical() {
+    // From Cypress: should render multiple bar plots vertically with labels correctly
+    let input = r#"xychart
+        title "Multiple Bar Plots"
+        x-axis Categories [A, B, C]
+        y-axis "Values" 0 --> 100
+        bar [10, 50, 90]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_multiple_bar_plots_horizontal() {
+    // From Cypress: should render multiple bar plots horizontally with labels correctly
+    let input = r#"xychart horizontal
+        title "Multiple Bar Plots"
+        x-axis Categories [A, B, C]
+        y-axis "Values" 0 --> 100
+        bar [10, 50, 90]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_single_bar_vertical() {
+    // From Cypress: should render a single bar with label for a vertical xy-chart
+    let input = r#"xychart
+        title "Single Bar Chart"
+        x-axis Categories [A]
+        y-axis "Value" 0 --> 100
+        bar [75]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_single_bar_horizontal() {
+    // From Cypress: should render a single bar with label for a horizontal xy-chart
+    let input = r#"xychart horizontal
+        title "Single Bar Chart"
+        x-axis Categories [A]
+        y-axis "Value" 0 --> 100
+        bar [75]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_negative_decimal_values_vertical() {
+    // From Cypress: should render negative and decimal values with correct labels for vertical xy-chart
+    let input = r#"xychart
+        title "Decimal and Negative Values"
+        x-axis Categories [A, B, C]
+        y-axis -10 --> 10
+        bar [ -2.5, 0.75, 5.1 ]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_negative_decimal_values_horizontal() {
+    // From Cypress: should render negative and decimal values with correct labels for horizontal xy-chart
+    let input = r#"xychart horizontal
+        title "Decimal and Negative Values"
+        x-axis Categories [A, B, C]
+        y-axis -10 --> 10
+        bar [ -2.5, 0.75, 5.1 ]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+// ============================================================================
+// Many Bars Tests
+// ============================================================================
+
+#[test]
+fn test_many_bars_vertical() {
+    // From Cypress: should render data labels within each bar in the vertical xy-chart with a lot of bars
+    let input = r#"xychart
+        title "Sales Revenue"
+        x-axis Months [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]
+        y-axis "Revenue (in $)" 4000 --> 12000
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+    // Verify bar elements exist
+    assert!(svg.contains("<rect"), "Should contain rect elements for bars");
+}
+
+#[test]
+fn test_many_bars_horizontal() {
+    // From Cypress: should render data labels within each bar in the horizontal xy-chart with a lot of bars
+    let input = r#"xychart horizontal
+        title "Sales Revenue"
+        x-axis Months [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]
+        y-axis "Revenue (in $)" 4000 --> 12000
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_many_different_size_bars_vertical() {
+    // From Cypress: should render data labels within each bar in the vertical xy-chart with a lot of bars of different sizes
+    let input = r#"xychart
+        title "Sales Revenue"
+        x-axis Months [jan,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s]
+        y-axis "Revenue (in $)" 4000 --> 12000
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000, 8000, 10000, 5000, 7600, 4999, 11000, 5000, 6000]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_many_different_size_bars_horizontal() {
+    // From Cypress: should render data labels within each bar in the horizontal xy-chart with a lot of bars of different sizes
+    let input = r#"xychart horizontal
+        title "Sales Revenue"
+        x-axis Months [jan,a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s]
+        y-axis "Revenue (in $)" 4000 --> 12000
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000, 8000, 10000, 5000, 7600, 4999, 11000, 5000, 6000]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+// ============================================================================
+// Line Chart Tests
+// ============================================================================
+
+#[test]
+fn test_line_chart_only() {
+    // Line chart without bars
+    let input = r#"xychart
+        title "Line Chart Only"
+        x-axis [jan, feb, mar, apr]
+        y-axis 0 --> 100
+        line [10, 50, 30, 80]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+    // Verify path elements exist for lines
+    assert!(svg.contains("<path"), "Should contain path elements for lines");
+}
+
+#[test]
+fn test_multiple_lines() {
+    // Multiple line plots
+    let input = r#"xychart
+        title "Multiple Lines"
+        x-axis [A, B, C, D]
+        y-axis 0 --> 100
+        line [10, 30, 20, 40]
+        line [50, 40, 60, 30]
+        line [25, 55, 35, 65]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+// ============================================================================
+// Combined Bar and Line Tests
+// ============================================================================
+
+#[test]
+fn test_bar_and_line_combined() {
+    // From mermaid demo
+    let input = r#"xychart
+        title "Sales Revenue"
+        x-axis [jan, feb, mar, apr, may, jun, jul, aug, sep, oct, nov, dec]
+        y-axis "Revenue (in $)" 4000 --> 11000
+        bar [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]
+        line [5000, 6000, 7500, 8200, 9500, 10500, 11000, 10200, 9200, 8500, 7000, 6000]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+    assert!(svg.contains("<rect"), "Should contain rect elements for bars");
+    assert!(svg.contains("<path"), "Should contain path elements for lines");
+}
+
+// ============================================================================
+// Theme Tests
+// ============================================================================
+
+#[test]
+fn test_with_dark_theme() {
+    let input = r#"xychart
+        title "Dark Theme Chart"
+        x-axis [A, B, C]
+        y-axis 0 --> 100
+        bar [30, 60, 90]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let config = RenderConfig {
+        theme: Theme::dark(),
+        ..Default::default()
+    };
+    let svg = render_with_config(&diagram, &config).expect("Failed to render chart with dark theme");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_with_forest_theme() {
+    let input = r#"xychart
+        title "Forest Theme Chart"
+        x-axis [A, B, C]
+        y-axis 0 --> 100
+        bar [30, 60, 90]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let config = RenderConfig {
+        theme: Theme::forest(),
+        ..Default::default()
+    };
+    let svg = render_with_config(&diagram, &config).expect("Failed to render chart with forest theme");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_with_neutral_theme() {
+    let input = r#"xychart
+        title "Neutral Theme Chart"
+        x-axis [A, B, C]
+        y-axis 0 --> 100
+        bar [30, 60, 90]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let config = RenderConfig {
+        theme: Theme::neutral(),
+        ..Default::default()
+    };
+    let svg = render_with_config(&diagram, &config).expect("Failed to render chart with neutral theme");
+
+    assert_valid_svg(&svg);
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+#[test]
+fn test_minimal_data() {
+    // Minimal data with single point
+    let input = r#"xychart
+        line [10]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_large_values() {
+    // Large values
+    let input = r#"xychart
+        x-axis [Q1, Q2, Q3, Q4]
+        y-axis 0 --> 1000000
+        bar [250000, 500000, 750000, 1000000]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_zero_values() {
+    // Zero values
+    let input = r#"xychart
+        x-axis [A, B, C, D]
+        y-axis 0 --> 100
+        bar [0, 50, 0, 75]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_all_same_values() {
+    // All same values
+    let input = r#"xychart
+        x-axis [A, B, C, D]
+        y-axis 0 --> 100
+        bar [50, 50, 50, 50]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+// ============================================================================
+// Axis Label Tests
+// ============================================================================
+
+#[test]
+fn test_long_category_names() {
+    // Long category names
+    let input = r#"xychart
+        x-axis ["Very Long Category Name", "Another Long One", "Short"]
+        y-axis 0 --> 100
+        bar [30, 60, 90]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}
+
+#[test]
+fn test_numeric_x_axis_range() {
+    // Numeric x-axis range (linear axis)
+    let input = r#"xychart
+        x-axis 0 --> 100
+        y-axis 0 --> 50
+        line [10, 20, 30, 40, 50]"#;
+
+    let diagram = parse(input).expect("Failed to parse chart");
+    let svg = render(&diagram).expect("Failed to render chart");
+
+    assert_valid_svg(&svg);
+}


### PR DESCRIPTION
- Add src/render/xychart.rs with full SVG rendering support
- Support both vertical and horizontal chart orientations
- Render bar plots with proper scaling and positioning
- Render line plots with data points and connecting lines
- Add x-axis and y-axis with titles, tick marks, and labels
- Support themes (default, dark, forest, neutral)
- Port 35 cypress test cases from mermaid.js to Rust
- Add sample SVGs to docs/images for documentation