### PR TITLE
Add GitHub Actions caching for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+# Caching enabled for faster builds
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Cache Cargo registry and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-
       - run: cargo test --features all-formats
 
   lint:
@@ -26,5 +37,16 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy, rustfmt
+      - name: Cache Cargo registry and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-lint-
+            ${{ runner.os }}-cargo-
       - run: cargo fmt --check
       - run: cargo clippy --features all-formats -- -D warnings

--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -26,16 +26,59 @@ jobs:
         with:
           target: wasm32-unknown-unknown
 
+      - name: Cache Cargo registry and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-deploy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-deploy-
+            ${{ runner.os }}-cargo-
+
+      - name: Cache wasm-pack
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: ${{ runner.os }}-wasm-pack-0.12.1
+
       - name: Install wasm-pack
-        run: cargo install wasm-pack@0.12.1
+        run: |
+          if ! command -v wasm-pack &> /dev/null; then
+            cargo install wasm-pack@0.12.1
+          fi
 
       - name: Build WASM package
         run: |
           wasm-pack build --target web --features wasm
           mv pkg playground/pkg
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Cache npm global packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-global-mermaid-cli
+          restore-keys: |
+            ${{ runner.os }}-npm-global-
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-chromium
+
       - name: Install Chromium dependencies
         run: npx playwright install-deps chromium
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium
 
       - name: Install mermaid-cli
         run: npm install -g @mermaid-js/mermaid-cli


### PR DESCRIPTION
- ci.yml: Add Cargo registry/git/target caching for test and lint jobs
- deploy-playground.yml: Add caching for Cargo, wasm-pack, npm, and Playwright

This should significantly reduce build times on cache hits by avoiding repeated downloads and compilations.