### PR TITLE
Add inline style support and parent tracking for block diagrams

### DIFF
--- a/docs/images/block_complex.svg
+++ b/docs/images/block_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="384.8" height="232" viewBox="-30 -30 384.8 232" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="504.8" height="232" viewBox="-30 -30 504.8 232" class="mermaid">
   <style>
 
 .block-node {
@@ -49,10 +49,10 @@
       <path d="M 0 5 L 10 10 L 10 0 z"/>
     </marker>
     <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_circle" viewBox="0 0 10 10" refX="11" refY="5" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <circle cx="5" cy="5" r="5"/>
@@ -67,10 +67,10 @@
     </g>
     <g class="edgePaths">
       <g class="block-edges">
-        <path d="M 40 132 Q 54 86 68 40" class="block-edge" stroke-width="1" fill="none" marker-end="url(#arrowhead)"/>
-        <path d="M 244 20 Q 222 23 199.99999999999997 26" class="block-edge" marker-end="url(#arrowhead)" fill="none" stroke-width="1"/>
-        <path d="M 104 92 Q 102 92 100 92" class="block-edge" stroke-width="1" marker-end="url(#arrowhead)" fill="none"/>
-        <text x="102" y="82" class="edge-label" font-size="12px" text-anchor="middle" dominant-baseline="middle">labeled</text>
+        <path d="M 40 132 Q 54 86 68 40" class="block-edge" marker-end="url(#arrowhead)" fill="none" stroke-width="1"/>
+        <path d="M 300 20 Q 310 23 320 26" class="block-edge" marker-end="url(#arrowhead)" fill="none" stroke-width="1"/>
+        <path d="M 104 92 Q 114 92 124 92" class="block-edge" fill="none" stroke-width="1" marker-end="url(#arrowhead)"/>
+        <text x="114" y="82" class="edge-label" text-anchor="middle" dominant-baseline="middle" font-size="12px">labeled</text>
       </g>
     </g>
     <g class="edgeLabels">
@@ -78,37 +78,37 @@
     </g>
     <g class="nodes">
       <g class="block-nodes">
-        <g class="node block-node block-square blue" transform="translate(0, 0)" id="block-A">
+        <g class="node block-node block-square blue" id="block-A" transform="translate(0, 0)">
           <rect x="0" y="0" width="136" height="40" class="node-bkg"/>
-          <text x="68" y="20" class="block-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Square Block</text>
+          <text x="68" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Square Block</text>
         </g>
-        <g class="node block-node block-round" transform="translate(100, 0)" id="block-B">
+        <g class="node block-node block-round" transform="translate(156, 0)" id="block-B">
           <rect x="0" y="0" width="144" height="40" rx="10" ry="10" class="node-bkg" style="fill:#f9F;stroke:#333;stroke-width:4px"/>
-          <text x="72" y="20" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Rounded Block</text>
+          <text x="72" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Rounded Block</text>
         </g>
-        <g class="node block-node block-diamond" id="block-C" transform="translate(200, 0)">
+        <g class="node block-node block-diamond" id="block-C" transform="translate(320, 0)">
           <polygon points="62.400000000000006,0 124.80000000000001,26 62.400000000000006,52 0,26" class="node-bkg"/>
-          <text x="62.400000000000006" y="26" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Diamond</text>
+          <text x="62.400000000000006" y="26" class="block-label" text-anchor="middle" font-size="14px" dominant-baseline="middle">Diamond</text>
         </g>
-        <g class="node block-node block-square" id="block-D" transform="translate(0, 72)">
+        <g class="node block-node block-square" transform="translate(0, 72)" id="block-D">
           <rect x="0" y="0" width="104" height="40" class="node-bkg"/>
-          <text x="52" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Nested 1</text>
+          <text x="52" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Nested 1</text>
         </g>
-        <g class="node block-node block-square" transform="translate(100, 72)" id="block-E">
+        <g class="node block-node block-square" id="block-E" transform="translate(124, 72)">
           <rect x="0" y="0" width="104" height="40" class="node-bkg"/>
-          <text x="52" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Nested 2</text>
+          <text x="52" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Nested 2</text>
         </g>
-        <g class="node block-node block-stadium" id="block-F" transform="translate(200, 72)">
+        <g class="node block-node block-stadium" id="block-F" transform="translate(248, 72)">
           <rect x="0" y="0" width="96" height="40" rx="20" ry="20" class="node-bkg"/>
-          <text x="48" y="20" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Stadium</text>
+          <text x="48" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Stadium</text>
         </g>
         <g class="node block-node block-square" transform="translate(0, 132)" id="block-G">
           <rect x="0" y="0" width="80" height="40" class="node-bkg"/>
-          <text x="40" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">G</text>
+          <text x="40" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">G</text>
         </g>
         <g class="node block-node block-composite" id="block-container" transform="translate(100, 132)">
           <rect x="0" y="0" width="80" height="40" class="block-composite"/>
-          <text x="40" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle"></text>
+          <text x="40" y="20" class="block-label" text-anchor="middle" font-size="14px" dominant-baseline="middle"></text>
         </g>
       </g>
     </g>

--- a/docs/images/block_complex.svg
+++ b/docs/images/block_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="504.8" height="232" viewBox="-30 -30 504.8 232" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="524" height="192" viewBox="-30 -30 524 192" class="mermaid">
   <style>
 
 .block-node {
@@ -49,10 +49,10 @@
       <path d="M 0 5 L 10 10 L 10 0 z"/>
     </marker>
     <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
     </marker>
     <marker id="arrow_circle" viewBox="0 0 10 10" refX="11" refY="5" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <circle cx="5" cy="5" r="5"/>
@@ -67,10 +67,10 @@
     </g>
     <g class="edgePaths">
       <g class="block-edges">
-        <path d="M 40 132 Q 54 86 68 40" class="block-edge" marker-end="url(#arrowhead)" fill="none" stroke-width="1"/>
-        <path d="M 300 20 Q 310 23 320 26" class="block-edge" marker-end="url(#arrowhead)" fill="none" stroke-width="1"/>
-        <path d="M 104 92 Q 114 92 124 92" class="block-edge" fill="none" stroke-width="1" marker-end="url(#arrowhead)"/>
-        <text x="114" y="82" class="edge-label" text-anchor="middle" dominant-baseline="middle" font-size="12px">labeled</text>
+        <path d="M 116 92 Q 126 56 136 20" class="block-edge" stroke-width="1" marker-end="url(#arrowhead)" fill="none"/>
+        <path d="M 300 20 Q 310 23 320 26" class="block-edge" fill="none" stroke-width="1" marker-end="url(#arrowhead)"/>
+        <path d="M 330 102 Q 340 102 350 102" class="block-edge" fill="none" stroke-width="1" marker-end="url(#arrowhead)"/>
+        <text x="340" y="92" class="edge-label" dominant-baseline="middle" text-anchor="middle" font-size="12px">labeled</text>
       </g>
     </g>
     <g class="edgeLabels">
@@ -80,35 +80,35 @@
       <g class="block-nodes">
         <g class="node block-node block-square blue" id="block-A" transform="translate(0, 0)">
           <rect x="0" y="0" width="136" height="40" class="node-bkg"/>
-          <text x="68" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Square Block</text>
+          <text x="68" y="20" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Square Block</text>
         </g>
         <g class="node block-node block-round" transform="translate(156, 0)" id="block-B">
           <rect x="0" y="0" width="144" height="40" rx="10" ry="10" class="node-bkg" style="fill:#f9F;stroke:#333;stroke-width:4px"/>
-          <text x="72" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Rounded Block</text>
+          <text x="72" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Rounded Block</text>
         </g>
-        <g class="node block-node block-diamond" id="block-C" transform="translate(320, 0)">
+        <g class="node block-node block-diamond" transform="translate(320, 0)" id="block-C">
           <polygon points="62.400000000000006,0 124.80000000000001,26 62.400000000000006,52 0,26" class="node-bkg"/>
-          <text x="62.400000000000006" y="26" class="block-label" text-anchor="middle" font-size="14px" dominant-baseline="middle">Diamond</text>
+          <text x="62.400000000000006" y="26" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Diamond</text>
         </g>
-        <g class="node block-node block-square" transform="translate(0, 72)" id="block-D">
-          <rect x="0" y="0" width="104" height="40" class="node-bkg"/>
-          <text x="52" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Nested 1</text>
-        </g>
-        <g class="node block-node block-square" id="block-E" transform="translate(124, 72)">
-          <rect x="0" y="0" width="104" height="40" class="node-bkg"/>
-          <text x="52" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Nested 2</text>
-        </g>
-        <g class="node block-node block-stadium" id="block-F" transform="translate(248, 72)">
+        <g class="node block-node block-stadium" transform="translate(0, 72)" id="block-F">
           <rect x="0" y="0" width="96" height="40" rx="20" ry="20" class="node-bkg"/>
           <text x="48" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Stadium</text>
         </g>
-        <g class="node block-node block-square" transform="translate(0, 132)" id="block-G">
+        <g class="node block-node block-square" transform="translate(116, 72)" id="block-G">
           <rect x="0" y="0" width="80" height="40" class="node-bkg"/>
-          <text x="40" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">G</text>
+          <text x="40" y="20" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">G</text>
         </g>
-        <g class="node block-node block-composite" id="block-container" transform="translate(100, 132)">
-          <rect x="0" y="0" width="80" height="40" class="block-composite"/>
-          <text x="40" y="20" class="block-label" text-anchor="middle" font-size="14px" dominant-baseline="middle"></text>
+        <g class="node block-node block-composite" transform="translate(216, 72)" id="block-container">
+          <rect x="0" y="0" width="248" height="60" class="block-composite"/>
+          <text x="124" y="30" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle"></text>
+        </g>
+        <g class="node block-node block-square" id="block-D" transform="translate(226, 82)">
+          <rect x="0" y="0" width="104" height="40" class="node-bkg"/>
+          <text x="52" y="20" class="block-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Nested 1</text>
+        </g>
+        <g class="node block-node block-square" id="block-E" transform="translate(350, 82)">
+          <rect x="0" y="0" width="104" height="40" class="node-bkg"/>
+          <text x="52" y="20" class="block-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Nested 2</text>
         </g>
       </g>
     </g>

--- a/docs/images/block_complex.svg
+++ b/docs/images/block_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="204" height="472" viewBox="-30 -30 204 472" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="384.8" height="232" viewBox="-30 -30 384.8 232" class="mermaid">
   <style>
 
 .block-node {
@@ -20,7 +20,7 @@
 }
 .block-edge {
   stroke: #333333;
-  stroke-width: 2px;
+  stroke-width: 1px;
   fill: none;
 }
 .edge-label {
@@ -52,7 +52,7 @@
       <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
     </marker>
     <marker id="arrow_circle" viewBox="0 0 10 10" refX="11" refY="5" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <circle cx="5" cy="5" r="5"/>
@@ -67,10 +67,10 @@
     </g>
     <g class="edgePaths">
       <g class="block-edges">
-        <path d="M 40 372 Q 54 206 68 40" class="block-edge" marker-end="url(#arrowhead)" fill="none" stroke-width="2"/>
-        <path d="M 72 100 Q 67.2 110 62.400000000000006 120" class="block-edge" marker-end="url(#arrowhead)" fill="none" stroke-width="2"/>
-        <path d="M 52 232 Q 52 242 52 252" class="block-edge" marker-end="url(#arrowhead)" fill="none" stroke-width="2"/>
-        <text x="52" y="232" class="edge-label" text-anchor="middle" dominant-baseline="middle" font-size="12px">labeled</text>
+        <path d="M 40 132 Q 54 86 68 40" class="block-edge" stroke-width="1" fill="none" marker-end="url(#arrowhead)"/>
+        <path d="M 244 20 Q 222 23 199.99999999999997 26" class="block-edge" marker-end="url(#arrowhead)" fill="none" stroke-width="1"/>
+        <path d="M 104 92 Q 102 92 100 92" class="block-edge" stroke-width="1" marker-end="url(#arrowhead)" fill="none"/>
+        <text x="102" y="82" class="edge-label" font-size="12px" text-anchor="middle" dominant-baseline="middle">labeled</text>
       </g>
     </g>
     <g class="edgeLabels">
@@ -78,33 +78,37 @@
     </g>
     <g class="nodes">
       <g class="block-nodes">
-        <g class="block-node block-square blue" id="block-A" transform="translate(0, 0)">
+        <g class="node block-node block-square blue" transform="translate(0, 0)" id="block-A">
           <rect x="0" y="0" width="136" height="40" class="node-bkg"/>
-          <text x="68" y="20" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Square Block</text>
+          <text x="68" y="20" class="block-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Square Block</text>
         </g>
-        <g class="block-node block-round" id="block-B" transform="translate(0, 60)">
-          <rect x="0" y="0" width="144" height="40" rx="10" ry="10" class="node-bkg"/>
-          <text x="72" y="20" class="block-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Rounded Block</text>
+        <g class="node block-node block-round" transform="translate(100, 0)" id="block-B">
+          <rect x="0" y="0" width="144" height="40" rx="10" ry="10" class="node-bkg" style="fill:#f9F;stroke:#333;stroke-width:4px"/>
+          <text x="72" y="20" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Rounded Block</text>
         </g>
-        <g class="block-node block-diamond" id="block-C" transform="translate(0, 120)">
-          <path d="M 62.400000000000006 0 L 124.80000000000001 26 L 62.400000000000006 52 L 0 26 Z" class="node-bkg"/>
-          <text x="62.400000000000006" y="26" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Diamond</text>
+        <g class="node block-node block-diamond" id="block-C" transform="translate(200, 0)">
+          <polygon points="62.400000000000006,0 124.80000000000001,26 62.400000000000006,52 0,26" class="node-bkg"/>
+          <text x="62.400000000000006" y="26" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Diamond</text>
         </g>
-        <g class="block-node block-square" id="block-D" transform="translate(0, 192)">
+        <g class="node block-node block-square" id="block-D" transform="translate(0, 72)">
           <rect x="0" y="0" width="104" height="40" class="node-bkg"/>
-          <text x="52" y="20" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Nested 1</text>
+          <text x="52" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Nested 1</text>
         </g>
-        <g class="block-node block-square" id="block-E" transform="translate(0, 252)">
+        <g class="node block-node block-square" transform="translate(100, 72)" id="block-E">
           <rect x="0" y="0" width="104" height="40" class="node-bkg"/>
-          <text x="52" y="20" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Nested 2</text>
+          <text x="52" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Nested 2</text>
         </g>
-        <g class="block-node block-stadium" id="block-F" transform="translate(0, 312)">
+        <g class="node block-node block-stadium" id="block-F" transform="translate(200, 72)">
           <rect x="0" y="0" width="96" height="40" rx="20" ry="20" class="node-bkg"/>
-          <text x="48" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Stadium</text>
+          <text x="48" y="20" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Stadium</text>
         </g>
-        <g class="block-node block-square" transform="translate(0, 372)" id="block-G">
+        <g class="node block-node block-square" transform="translate(0, 132)" id="block-G">
           <rect x="0" y="0" width="80" height="40" class="node-bkg"/>
           <text x="40" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">G</text>
+        </g>
+        <g class="node block-node block-composite" id="block-container" transform="translate(100, 132)">
+          <rect x="0" y="0" width="80" height="40" class="block-composite"/>
+          <text x="40" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle"></text>
         </g>
       </g>
     </g>

--- a/src/diagrams/block/parser.rs
+++ b/src/diagrams/block/parser.rs
@@ -69,7 +69,7 @@ fn process_statement(
         }
         Rule::block_stmt => {
             let (id, label, block_type, width) = extract_block_info(pair)?;
-            db.add_block(&id, label.as_deref(), block_type);
+            db.add_block_with_parent(&id, label.as_deref(), block_type, parent_id);
             if let Some(w) = width {
                 db.set_width(&id, w);
             }
@@ -77,13 +77,13 @@ fn process_statement(
         Rule::space_stmt => {
             // Generate unique ID for space
             let id = db.generate_space_id();
-            db.add_block(&id, None, BlockType::Space);
+            db.add_block_with_parent(&id, None, BlockType::Space, parent_id);
         }
         Rule::composite_block => {
             process_composite(db, pair, parent_id)?;
         }
         Rule::edge_stmt => {
-            process_edge(db, pair)?;
+            process_edge(db, pair, parent_id)?;
         }
         Rule::class_def_stmt => {
             process_class_def(db, pair)?;
@@ -231,7 +231,7 @@ fn extract_label(pair: pest::iterators::Pair<Rule>) -> String {
 fn process_composite(
     db: &mut BlockDb,
     pair: pest::iterators::Pair<Rule>,
-    _parent_id: Option<&str>,
+    parent_id: Option<&str>,
 ) -> Result<(), String> {
     let mut composite_id = db.generate_composite_id();
     let mut label = String::new();
@@ -253,9 +253,14 @@ fn process_composite(
                 }
             }
             Rule::statement => {
-                // First add the composite block
+                // First add the composite block with its parent
                 if !db.get_blocks().contains_key(&composite_id) {
-                    db.add_block(&composite_id, Some(&label), BlockType::Composite);
+                    db.add_block_with_parent(
+                        &composite_id,
+                        Some(&label),
+                        BlockType::Composite,
+                        parent_id,
+                    );
                 }
                 // Then process statements within it
                 process_statement(db, inner, Some(&composite_id))?;
@@ -266,13 +271,17 @@ fn process_composite(
 
     // Ensure composite is added even if empty
     if !db.get_blocks().contains_key(&composite_id) {
-        db.add_block(&composite_id, Some(&label), BlockType::Composite);
+        db.add_block_with_parent(&composite_id, Some(&label), BlockType::Composite, parent_id);
     }
 
     Ok(())
 }
 
-fn process_edge(db: &mut BlockDb, pair: pest::iterators::Pair<Rule>) -> Result<(), String> {
+fn process_edge(
+    db: &mut BlockDb,
+    pair: pest::iterators::Pair<Rule>,
+    parent_id: Option<&str>,
+) -> Result<(), String> {
     let mut blocks: Vec<(String, Option<String>, BlockType, Option<usize>)> = Vec::new();
     let mut edge_label: Option<String> = None;
 
@@ -301,15 +310,15 @@ fn process_edge(db: &mut BlockDb, pair: pest::iterators::Pair<Rule>) -> Result<(
         let (id1, label1, type1, width1) = &blocks[0];
         let (id2, label2, type2, width2) = &blocks[1];
 
-        // Add blocks if they don't exist
+        // Add blocks if they don't exist (with parent if specified)
         if !db.get_blocks().contains_key(id1) {
-            db.add_block(id1, label1.as_deref(), type1.clone());
+            db.add_block_with_parent(id1, label1.as_deref(), type1.clone(), parent_id);
             if let Some(w) = width1 {
                 db.set_width(id1, *w);
             }
         }
         if !db.get_blocks().contains_key(id2) {
-            db.add_block(id2, label2.as_deref(), type2.clone());
+            db.add_block_with_parent(id2, label2.as_deref(), type2.clone(), parent_id);
             if let Some(w) = width2 {
                 db.set_width(id2, *w);
             }

--- a/src/diagrams/block/types.rs
+++ b/src/diagrams/block/types.rs
@@ -140,8 +140,14 @@ impl BlockDb {
         *self = Self::new();
     }
 
-    /// Add a block
-    pub fn add_block(&mut self, id: &str, label: Option<&str>, block_type: BlockType) {
+    /// Add a block with optional parent
+    pub fn add_block_with_parent(
+        &mut self,
+        id: &str,
+        label: Option<&str>,
+        block_type: BlockType,
+        parent_id: Option<&str>,
+    ) {
         // Protect against prototype pollution
         if id == "__proto__" || id == "constructor" {
             return;
@@ -150,9 +156,18 @@ impl BlockDb {
         let mut block = Block::new(id.to_string());
         block.label = label.map(|s| s.to_string());
         block.block_type = block_type;
+        block.parent_id = parent_id.map(|s| s.to_string());
 
         self.blocks.insert(id.to_string(), block.clone());
-        self.root_block.children.push(block);
+        // Only add to root children if no parent (top-level block)
+        if parent_id.is_none() {
+            self.root_block.children.push(block);
+        }
+    }
+
+    /// Add a block (legacy method, adds to root)
+    pub fn add_block(&mut self, id: &str, label: Option<&str>, block_type: BlockType) {
+        self.add_block_with_parent(id, label, block_type, None);
     }
 
     /// Add an edge

--- a/src/render/block.rs
+++ b/src/render/block.rs
@@ -192,7 +192,7 @@ fn layout_blocks(
     let mut col = 0;
     let mut row_height = 0.0_f64;
 
-    // Collect blocks and sort by ID for consistent ordering
+    // Collect all blocks and sort by ID for consistent ordering
     let mut block_list: Vec<_> = blocks.iter().collect();
     block_list.sort_by(|a, b| a.0.cmp(b.0));
 
@@ -443,10 +443,34 @@ fn render_block_node(block: &PositionedBlock, _config: &RenderConfig) -> SvgElem
     }
 }
 
+/// Build inline style string from block styles
+fn build_inline_style(styles: &[String]) -> Option<String> {
+    if styles.is_empty() {
+        return None;
+    }
+    // Join styles with semicolons
+    let style_str = styles.join(";");
+    if style_str.is_empty() {
+        None
+    } else {
+        Some(style_str)
+    }
+}
+
 /// Render block shape based on type
 fn render_block_shape(block: &PositionedBlock) -> SvgElement {
     let w = block.width;
     let h = block.height;
+    let inline_style = build_inline_style(&block.styles);
+
+    // Helper to create attrs with optional inline style
+    let make_attrs = |class: &str| {
+        let mut attrs = Attrs::new().with_class(class);
+        if let Some(ref style) = inline_style {
+            attrs = attrs.with_attr("style", style);
+        }
+        attrs
+    };
 
     match block.block_type {
         BlockType::Square => SvgElement::Rect {
@@ -456,7 +480,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
             height: h,
             rx: None,
             ry: None,
-            attrs: Attrs::new().with_class("node-bkg"),
+            attrs: make_attrs("node-bkg"),
         },
         BlockType::Round => SvgElement::Rect {
             x: 0.0,
@@ -465,7 +489,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
             height: h,
             rx: Some(BLOCK_PADDING),
             ry: Some(BLOCK_PADDING),
-            attrs: Attrs::new().with_class("node-bkg"),
+            attrs: make_attrs("node-bkg"),
         },
         BlockType::Circle => {
             let radius = w.min(h) / 2.0;
@@ -473,7 +497,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
                 cx: w / 2.0,
                 cy: h / 2.0,
                 r: radius,
-                attrs: Attrs::new().with_class("node-bkg"),
+                attrs: make_attrs("node-bkg"),
             }
         }
         BlockType::DoubleCircle => {
@@ -484,7 +508,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
                 cx: w / 2.0,
                 cy: h / 2.0,
                 r: outer_radius,
-                attrs: Attrs::new().with_class("node-bkg"),
+                attrs: make_attrs("node-bkg"),
             };
             let inner = SvgElement::Circle {
                 cx: w / 2.0,
@@ -503,7 +527,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
             let points = format!("{},{} {},{} {},{} {},{}", cx, 0.0, w, cy, cx, h, 0.0, cy);
             SvgElement::PolygonStr {
                 points,
-                attrs: Attrs::new().with_class("node-bkg"),
+                attrs: make_attrs("node-bkg"),
             }
         }
         BlockType::Hexagon => {
@@ -525,7 +549,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
             );
             SvgElement::PolygonStr {
                 points,
-                attrs: Attrs::new().with_class("node-bkg"),
+                attrs: make_attrs("node-bkg"),
             }
         }
         BlockType::Stadium => {
@@ -537,7 +561,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
                 height: h,
                 rx: Some(r),
                 ry: Some(r),
-                attrs: Attrs::new().with_class("node-bkg"),
+                attrs: make_attrs("node-bkg"),
             }
         }
         BlockType::Subroutine => {
@@ -549,7 +573,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
                 height: h,
                 rx: None,
                 ry: None,
-                attrs: Attrs::new().with_class("node-bkg"),
+                attrs: make_attrs("node-bkg"),
             };
             let inner = SvgElement::Rect {
                 x: 5.0,
@@ -591,7 +615,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
             );
             SvgElement::Path {
                 d: path,
-                attrs: Attrs::new().with_class("node-bkg"),
+                attrs: make_attrs("node-bkg"),
             }
         }
         BlockType::LeanRight | BlockType::Trapezoid => {
@@ -609,7 +633,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
             );
             SvgElement::PolygonStr {
                 points,
-                attrs: Attrs::new().with_class("node-bkg"),
+                attrs: make_attrs("node-bkg"),
             }
         }
         BlockType::LeanLeft | BlockType::InvTrapezoid => {
@@ -627,7 +651,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
             );
             SvgElement::PolygonStr {
                 points,
-                attrs: Attrs::new().with_class("node-bkg"),
+                attrs: make_attrs("node-bkg"),
             }
         }
         BlockType::BlockArrow => {
@@ -647,7 +671,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
             );
             SvgElement::Path {
                 d: path,
-                attrs: Attrs::new().with_class("node-bkg"),
+                attrs: make_attrs("node-bkg"),
             }
         }
         BlockType::Composite => {
@@ -659,7 +683,7 @@ fn render_block_shape(block: &PositionedBlock) -> SvgElement {
                 height: h,
                 rx: None,
                 ry: None,
-                attrs: Attrs::new().with_class("block-composite"),
+                attrs: make_attrs("block-composite"),
             }
         }
         BlockType::Space | BlockType::Edge => {

--- a/src/render/block.rs
+++ b/src/render/block.rs
@@ -191,6 +191,7 @@ fn layout_blocks(
     let mut y = 0.0;
     let mut col = 0;
     let mut row_height = 0.0_f64;
+    let mut current_x = 0.0; // Track actual x position based on block widths
 
     // Collect all blocks and sort by ID for consistent ordering
     let mut block_list: Vec<_> = blocks.iter().collect();
@@ -201,9 +202,11 @@ fn layout_blocks(
         if block.block_type == BlockType::Space {
             let span = block.width_in_columns.unwrap_or(1);
             for _ in 0..span {
+                current_x += MIN_BLOCK_WIDTH + BLOCK_SPACING;
                 col += 1;
                 if col >= columns {
                     col = 0;
+                    current_x = 0.0;
                     y += row_height + BLOCK_SPACING;
                     row_height = 0.0;
                 }
@@ -225,12 +228,10 @@ fn layout_blocks(
         // Check if we need to wrap to next row
         if col + span > columns && col > 0 {
             col = 0;
+            current_x = 0.0;
             y += row_height + BLOCK_SPACING;
             row_height = 0.0;
         }
-
-        // Calculate x position based on column
-        let x = (col as f64) * (MIN_BLOCK_WIDTH + BLOCK_SPACING);
 
         // Adjust width for column span
         let block_width = if span > 1 {
@@ -243,7 +244,7 @@ fn layout_blocks(
             id: id.clone(),
             label: block.label.clone().unwrap_or_else(|| id.clone()),
             block_type: block.block_type.clone(),
-            x,
+            x: current_x,
             y,
             width: block_width,
             height,
@@ -252,12 +253,15 @@ fn layout_blocks(
             classes: block.classes.clone(),
         });
 
+        // Advance x position by actual block width
+        current_x += block_width + BLOCK_SPACING;
         row_height = row_height.max(height);
         col += span;
 
         // Wrap to next row if needed
         if col >= columns {
             col = 0;
+            current_x = 0.0;
             y += row_height + BLOCK_SPACING;
             row_height = 0.0;
         }

--- a/src/render/block.rs
+++ b/src/render/block.rs
@@ -181,23 +181,132 @@ fn calculate_block_size(block: &Block) -> (f64, f64) {
     (width, height)
 }
 
-/// Layout blocks in a grid
+/// Layout blocks in a grid with proper nesting for composite blocks
 fn layout_blocks(
     blocks: &HashMap<String, Block>,
     sizes: &HashMap<String, (f64, f64)>,
     columns: usize,
 ) -> Vec<PositionedBlock> {
+    // First, build parent-child relationships
+    let mut children_by_parent: HashMap<String, Vec<&str>> = HashMap::new();
+    for (id, block) in blocks.iter() {
+        if let Some(ref parent_id) = block.parent_id {
+            children_by_parent
+                .entry(parent_id.clone())
+                .or_default()
+                .push(id);
+        }
+    }
+
+    // Calculate sizes for composite blocks based on their children
+    let mut effective_sizes: HashMap<String, (f64, f64)> = sizes.clone();
+    for (id, block) in blocks.iter() {
+        if block.block_type == BlockType::Composite {
+            if let Some(child_ids) = children_by_parent.get(id) {
+                let (comp_w, comp_h) =
+                    calculate_composite_size(child_ids, blocks, &effective_sizes);
+                effective_sizes.insert(id.clone(), (comp_w, comp_h));
+            }
+        }
+    }
+
+    // Layout root-level blocks only
+    let root_blocks: Vec<(&str, &Block)> = blocks
+        .iter()
+        .filter(|(_, b)| b.parent_id.is_none())
+        .map(|(id, b)| (id.as_str(), b))
+        .collect();
+
+    let mut positioned =
+        layout_block_list(&root_blocks, &effective_sizes, columns, 0.0, 0.0);
+
+    // Collect composite info for child positioning
+    let composite_info: Vec<_> = positioned
+        .iter()
+        .filter(|b| b.block_type == BlockType::Composite)
+        .map(|b| (b.id.clone(), b.x, b.y))
+        .collect();
+
+    // Now position children inside their parent composites
+    for (composite_id, comp_x, comp_y) in composite_info {
+        if let Some(child_ids) = children_by_parent.get(&composite_id) {
+            let child_blocks: Vec<(&str, &Block)> = child_ids
+                .iter()
+                .filter_map(|id| blocks.get(*id).map(|b| (*id, b)))
+                .collect();
+
+            // Get columns for this composite (default to auto based on children count)
+            let child_columns = child_ids.len().max(1);
+
+            // Layout children inside composite with padding
+            let padding = BLOCK_PADDING;
+            let child_positioned = layout_block_list(
+                &child_blocks,
+                &effective_sizes,
+                child_columns,
+                comp_x + padding,
+                comp_y + padding,
+            );
+
+            positioned.extend(child_positioned);
+        }
+    }
+
+    positioned
+}
+
+/// Calculate size needed for a composite block to contain its children
+fn calculate_composite_size(
+    child_ids: &[&str],
+    blocks: &HashMap<String, Block>,
+    sizes: &HashMap<String, (f64, f64)>,
+) -> (f64, f64) {
+    let padding = BLOCK_PADDING;
+    let mut total_width: f64 = 0.0;
+    let mut max_height: f64 = 0.0;
+
+    for id in child_ids {
+        if let Some(block) = blocks.get(*id) {
+            if block.block_type == BlockType::Space {
+                total_width += MIN_BLOCK_WIDTH + BLOCK_SPACING;
+                continue;
+            }
+            let (w, h) = sizes.get(*id).cloned().unwrap_or((MIN_BLOCK_WIDTH, MIN_BLOCK_HEIGHT));
+            total_width += w + BLOCK_SPACING;
+            max_height = max_height.max(h);
+        }
+    }
+
+    // Remove trailing spacing, add padding
+    if total_width > BLOCK_SPACING {
+        total_width -= BLOCK_SPACING;
+    }
+
+    (
+        total_width + padding * 2.0,
+        max_height + padding * 2.0,
+    )
+}
+
+/// Layout a list of blocks in a grid starting at given offset
+fn layout_block_list(
+    block_list: &[(&str, &Block)],
+    sizes: &HashMap<String, (f64, f64)>,
+    columns: usize,
+    start_x: f64,
+    start_y: f64,
+) -> Vec<PositionedBlock> {
     let mut positioned = Vec::new();
-    let mut y = 0.0;
+    let mut y = start_y;
     let mut col = 0;
     let mut row_height = 0.0_f64;
-    let mut current_x = 0.0; // Track actual x position based on block widths
+    let mut current_x = start_x;
 
-    // Collect all blocks and sort by ID for consistent ordering
-    let mut block_list: Vec<_> = blocks.iter().collect();
-    block_list.sort_by(|a, b| a.0.cmp(b.0));
+    // Sort by ID for consistent ordering
+    let mut sorted_list: Vec<_> = block_list.to_vec();
+    sorted_list.sort_by(|a, b| a.0.cmp(b.0));
 
-    for (id, block) in block_list {
+    for (id, block) in sorted_list {
         // Skip space blocks in rendering (they still affect layout)
         if block.block_type == BlockType::Space {
             let span = block.width_in_columns.unwrap_or(1);
@@ -206,7 +315,7 @@ fn layout_blocks(
                 col += 1;
                 if col >= columns {
                     col = 0;
-                    current_x = 0.0;
+                    current_x = start_x;
                     y += row_height + BLOCK_SPACING;
                     row_height = 0.0;
                 }
@@ -228,7 +337,7 @@ fn layout_blocks(
         // Check if we need to wrap to next row
         if col + span > columns && col > 0 {
             col = 0;
-            current_x = 0.0;
+            current_x = start_x;
             y += row_height + BLOCK_SPACING;
             row_height = 0.0;
         }
@@ -241,8 +350,8 @@ fn layout_blocks(
         };
 
         positioned.push(PositionedBlock {
-            id: id.clone(),
-            label: block.label.clone().unwrap_or_else(|| id.clone()),
+            id: id.to_string(),
+            label: block.label.clone().unwrap_or_else(|| id.to_string()),
             block_type: block.block_type.clone(),
             x: current_x,
             y,
@@ -261,7 +370,7 @@ fn layout_blocks(
         // Wrap to next row if needed
         if col >= columns {
             col = 0;
-            current_x = 0.0;
+            current_x = start_x;
             y += row_height + BLOCK_SPACING;
             row_height = 0.0;
         }

--- a/src/render/block.rs
+++ b/src/render/block.rs
@@ -217,8 +217,7 @@ fn layout_blocks(
         .map(|(id, b)| (id.as_str(), b))
         .collect();
 
-    let mut positioned =
-        layout_block_list(&root_blocks, &effective_sizes, columns, 0.0, 0.0);
+    let mut positioned = layout_block_list(&root_blocks, &effective_sizes, columns, 0.0, 0.0);
 
     // Collect composite info for child positioning
     let composite_info: Vec<_> = positioned
@@ -271,7 +270,10 @@ fn calculate_composite_size(
                 total_width += MIN_BLOCK_WIDTH + BLOCK_SPACING;
                 continue;
             }
-            let (w, h) = sizes.get(*id).cloned().unwrap_or((MIN_BLOCK_WIDTH, MIN_BLOCK_HEIGHT));
+            let (w, h) = sizes
+                .get(*id)
+                .cloned()
+                .unwrap_or((MIN_BLOCK_WIDTH, MIN_BLOCK_HEIGHT));
             total_width += w + BLOCK_SPACING;
             max_height = max_height.max(h);
         }
@@ -282,10 +284,7 @@ fn calculate_composite_size(
         total_width -= BLOCK_SPACING;
     }
 
-    (
-        total_width + padding * 2.0,
-        max_height + padding * 2.0,
-    )
+    (total_width + padding * 2.0, max_height + padding * 2.0)
 }
 
 /// Layout a list of blocks in a grid starting at given offset


### PR DESCRIPTION
- Apply inline styles to block shapes via style attribute (e.g., style B fill:#f9F)
- Add parent_id tracking in block types for hierarchical relationships
- Update parser to pass parent_id when creating blocks inside composites
- Prepare data model for future hierarchical layout improvements