### PR TITLE
Fix deploy workflow to ignore eval report exit code

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Generate eval report
         run: |
-          cargo run --release --features eval --bin selkie -- eval -o /tmp/selkie-eval
+          cargo run --release --features eval --bin selkie -- eval -o /tmp/selkie-eval || true
           mv /tmp/selkie-eval/selkie-eval-*/  playground/eval
 
       - name: Copy assets


### PR DESCRIPTION
The eval command intentionally returns exit code 1 when there are
evaluation errors, which is useful for CI but shouldn't fail the
playground deployment - we want to publish the report regardless.