### PR TITLE
Improve block diagrams per AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,14 @@ bd sync               # Sync with git
 **MANDATORY WORKFLOW:**
 
 1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
+2. **Run quality gates** (if code changed) - Tests, linters, builds:
+
+   ```bash
+   cargo fmt                                        # Fix formatting
+   cargo clippy --features all-formats -- -D warnings  # Lint (warnings = errors)
+   cargo test --features all-formats               # Run tests
+   ```
+
 3. **Update issue status** - Close finished work, update in-progress items
 4. **PUSH TO REMOTE** - This is MANDATORY:
 
@@ -61,7 +68,7 @@ Rule 5: Always prefer the implementation approach of the reference-implementatio
 2. Follow all instructions from its output & confirm our changes are increasing scores
 3. Log new issues to log in bd & resolve completed ones
 4. When you resolve a rendering issue, update the svg in docs/images
-5. Follow TDD, Commit when tests are passing
+5. Follow TDD, run `cargo fmt && cargo clippy --features all-formats -- -D warnings` before committing, commit when tests pass
 6. Explore Reference implementations available as git submodules in reference-implementations:
     - mermaid
     - dagre

--- a/docs/images/block.svg
+++ b/docs/images/block.svg
@@ -48,10 +48,10 @@
       <path d="M 0 5 L 10 10 L 10 0 z"/>
     </marker>
     <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_circle" viewBox="0 0 10 10" refX="11" refY="5" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <circle cx="5" cy="5" r="5"/>
@@ -74,19 +74,19 @@
       <g class="block-nodes">
         <g class="node block-node block-composite" transform="translate(0, 0)" id="block-composite_1">
           <rect x="0" y="0" width="280" height="60" class="block-composite"/>
-          <text x="140" y="30" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px"></text>
+          <text x="140" y="30" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px"></text>
         </g>
         <g class="node block-node block-square" id="block-id2" transform="translate(8, 8)">
           <rect x="0" y="0" width="122" height="44" class="node-bkg"/>
-          <text x="61" y="22" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">I am a wide one</text>
+          <text x="61" y="22" class="block-label" text-anchor="middle" font-size="14px" dominant-baseline="middle">I am a wide one</text>
         </g>
         <g class="node block-node block-square" transform="translate(150, 8)" id="block-id1">
           <rect x="0" y="0" width="122" height="44" class="node-bkg"/>
-          <text x="61" y="22" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">id1</text>
+          <text x="61" y="22" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">id1</text>
         </g>
         <g class="node block-node block-square" transform="translate(300, 0)" id="block-id">
           <rect x="0" y="0" width="104" height="60" class="node-bkg"/>
-          <text x="52" y="30" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Next row</text>
+          <text x="52" y="30" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Next row</text>
         </g>
       </g>
     </g>

--- a/docs/images/block.svg
+++ b/docs/images/block.svg
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="414" height="70" viewBox="-5 -5 414 70" class="mermaid">
+  <style>
+
+.block-node {
+  cursor: pointer;
+}
+.block-label {
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+  fill: #333333;
+}
+.node-bkg {
+  fill: #ECECFF;
+  stroke: #9370DB;
+  stroke-width: 2px;
+}
+.node-bkg-inner {
+  stroke: #9370DB;
+  stroke-width: 1px;
+}
+.block-edge {
+  stroke: #333333;
+  stroke-width: 1px;
+  fill: none;
+}
+.edge-label {
+  font-family: trebuchet ms, verdana, arial, sans-serif;
+  fill: #333333;
+  font-size: 12px;
+}
+.block-edges marker {
+  fill: #333333;
+}
+.block-composite {
+  fill: #ffffde;
+  stroke: #9370DB;
+  stroke-width: 1px;
+  stroke-dasharray: 5,5;
+}
+
+
+  </style>
+  <defs>
+    <marker id="arrow_point" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="8" markerHeight="8" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M 0 0 L 10 5 L 0 10 z"/>
+    </marker>
+    <marker id="arrow_point_start" viewBox="0 0 10 10" refX="4.5" refY="5" markerWidth="8" markerHeight="8" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M 0 5 L 10 10 L 10 0 z"/>
+    </marker>
+    <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
+    </marker>
+    <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
+    </marker>
+    <marker id="arrow_circle" viewBox="0 0 10 10" refX="11" refY="5" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
+      <circle cx="5" cy="5" r="5"/>
+    </marker>
+    <marker id="arrow_circle_start" viewBox="0 0 10 10" refX="-1" refY="5" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
+      <circle cx="5" cy="5" r="5"/>
+    </marker>
+  </defs>
+  <g class="root">
+    <g class="clusters">
+
+    </g>
+    <g class="edgePaths">
+
+    </g>
+    <g class="edgeLabels">
+
+    </g>
+    <g class="nodes">
+      <g class="block-nodes">
+        <g class="node block-node block-composite" transform="translate(0, 0)" id="block-composite_1">
+          <rect x="0" y="0" width="280" height="60" class="block-composite"/>
+          <text x="140" y="30" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px"></text>
+        </g>
+        <g class="node block-node block-square" id="block-id2" transform="translate(8, 8)">
+          <rect x="0" y="0" width="122" height="44" class="node-bkg"/>
+          <text x="61" y="22" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">I am a wide one</text>
+        </g>
+        <g class="node block-node block-square" transform="translate(150, 8)" id="block-id1">
+          <rect x="0" y="0" width="122" height="44" class="node-bkg"/>
+          <text x="61" y="22" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">id1</text>
+        </g>
+        <g class="node block-node block-square" transform="translate(300, 0)" id="block-id">
+          <rect x="0" y="0" width="104" height="60" class="node-bkg"/>
+          <text x="52" y="30" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Next row</text>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/images/block_complex.svg
+++ b/docs/images/block_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="524" height="192" viewBox="-30 -30 524 192" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="490" height="202" viewBox="-5 -5 490 202" class="mermaid">
   <style>
 
 .block-node {
@@ -52,7 +52,7 @@
       <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_circle" viewBox="0 0 10 10" refX="11" refY="5" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <circle cx="5" cy="5" r="5"/>
@@ -67,10 +67,10 @@
     </g>
     <g class="edgePaths">
       <g class="block-edges">
-        <path d="M 116 92 Q 126 56 136 20" class="block-edge" stroke-width="1" marker-end="url(#arrowhead)" fill="none"/>
-        <path d="M 300 20 Q 310 23 320 26" class="block-edge" fill="none" stroke-width="1" marker-end="url(#arrowhead)"/>
-        <path d="M 330 102 Q 340 102 350 102" class="block-edge" fill="none" stroke-width="1" marker-end="url(#arrowhead)"/>
-        <text x="340" y="92" class="edge-label" dominant-baseline="middle" text-anchor="middle" font-size="12px">labeled</text>
+        <path d="M 40 152 Q 54 102 68 52" class="block-edge" stroke-width="1" marker-end="url(#arrowhead)" fill="none"/>
+        <path d="M 300 26 Q 310 26 320 26" class="block-edge" fill="none" marker-end="url(#arrowhead)" stroke-width="1"/>
+        <path d="M 114 102 Q 124 102 134 102" class="block-edge" marker-end="url(#arrowhead)" fill="none" stroke-width="1"/>
+        <text x="124" y="92" class="edge-label" text-anchor="middle" dominant-baseline="middle" font-size="12px">labeled</text>
       </g>
     </g>
     <g class="edgeLabels">
@@ -78,37 +78,37 @@
     </g>
     <g class="nodes">
       <g class="block-nodes">
-        <g class="node block-node block-square blue" id="block-A" transform="translate(0, 0)">
-          <rect x="0" y="0" width="136" height="40" class="node-bkg"/>
-          <text x="68" y="20" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Square Block</text>
+        <g class="node block-node block-square blue" transform="translate(0, 0)" id="block-A">
+          <rect x="0" y="0" width="136" height="52" class="node-bkg"/>
+          <text x="68" y="26" class="block-label" text-anchor="middle" font-size="14px" dominant-baseline="middle">Square Block</text>
         </g>
         <g class="node block-node block-round" transform="translate(156, 0)" id="block-B">
-          <rect x="0" y="0" width="144" height="40" rx="10" ry="10" class="node-bkg" style="fill:#f9F;stroke:#333;stroke-width:4px"/>
-          <text x="72" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Rounded Block</text>
+          <rect x="0" y="0" width="144" height="52" rx="10" ry="10" class="node-bkg" style="fill:#f9F;stroke:#333;stroke-width:4px"/>
+          <text x="72" y="26" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Rounded Block</text>
         </g>
-        <g class="node block-node block-diamond" transform="translate(320, 0)" id="block-C">
+        <g class="node block-node block-diamond" id="block-C" transform="translate(320, 0)">
           <polygon points="62.400000000000006,0 124.80000000000001,26 62.400000000000006,52 0,26" class="node-bkg"/>
-          <text x="62.400000000000006" y="26" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Diamond</text>
+          <text x="62.400000000000006" y="26" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Diamond</text>
         </g>
-        <g class="node block-node block-stadium" transform="translate(0, 72)" id="block-F">
-          <rect x="0" y="0" width="96" height="40" rx="20" ry="20" class="node-bkg"/>
-          <text x="48" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Stadium</text>
-        </g>
-        <g class="node block-node block-square" transform="translate(116, 72)" id="block-G">
-          <rect x="0" y="0" width="80" height="40" class="node-bkg"/>
-          <text x="40" y="20" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">G</text>
-        </g>
-        <g class="node block-node block-composite" transform="translate(216, 72)" id="block-container">
+        <g class="node block-node block-composite" id="block-container" transform="translate(0, 72)">
           <rect x="0" y="0" width="248" height="60" class="block-composite"/>
           <text x="124" y="30" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle"></text>
         </g>
-        <g class="node block-node block-square" id="block-D" transform="translate(226, 82)">
-          <rect x="0" y="0" width="104" height="40" class="node-bkg"/>
-          <text x="52" y="20" class="block-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Nested 1</text>
+        <g class="node block-node block-square" id="block-D" transform="translate(8, 80)">
+          <rect x="0" y="0" width="106" height="44" class="node-bkg"/>
+          <text x="53" y="22" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Nested 1</text>
         </g>
-        <g class="node block-node block-square" id="block-E" transform="translate(350, 82)">
-          <rect x="0" y="0" width="104" height="40" class="node-bkg"/>
-          <text x="52" y="20" class="block-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Nested 2</text>
+        <g class="node block-node block-square" id="block-E" transform="translate(134, 80)">
+          <rect x="0" y="0" width="106" height="44" class="node-bkg"/>
+          <text x="53" y="22" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Nested 2</text>
+        </g>
+        <g class="node block-node block-stadium" id="block-F" transform="translate(384, 72)">
+          <rect x="0" y="0" width="96" height="60" rx="30" ry="30" class="node-bkg"/>
+          <text x="48" y="30" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Stadium</text>
+        </g>
+        <g class="node block-node block-square" transform="translate(0, 152)" id="block-G">
+          <rect x="0" y="0" width="80" height="40" class="node-bkg"/>
+          <text x="40" y="20" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">G</text>
         </g>
       </g>
     </g>

--- a/docs/images/block_complex.svg
+++ b/docs/images/block_complex.svg
@@ -49,7 +49,7 @@
       <path d="M 0 5 L 10 10 L 10 0 z"/>
     </marker>
     <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
@@ -67,10 +67,10 @@
     </g>
     <g class="edgePaths">
       <g class="block-edges">
-        <path d="M 40 152 Q 54 102 68 52" class="block-edge" stroke-width="1" marker-end="url(#arrowhead)" fill="none"/>
-        <path d="M 300 26 Q 310 26 320 26" class="block-edge" fill="none" marker-end="url(#arrowhead)" stroke-width="1"/>
-        <path d="M 114 102 Q 124 102 134 102" class="block-edge" marker-end="url(#arrowhead)" fill="none" stroke-width="1"/>
-        <text x="124" y="92" class="edge-label" text-anchor="middle" dominant-baseline="middle" font-size="12px">labeled</text>
+        <path d="M 54 152 Q 54 102 54 52" class="block-edge" fill="none" marker-end="url(#arrowhead)" stroke-width="1"/>
+        <path d="M 300 26 Q 310 26 320 26" class="block-edge" marker-end="url(#arrowhead)" stroke-width="1" fill="none"/>
+        <path d="M 114 102 Q 124 102 134 102" class="block-edge" fill="none" stroke-width="1" marker-end="url(#arrowhead)"/>
+        <text x="124" y="92" class="edge-label" dominant-baseline="middle" text-anchor="middle" font-size="12px">labeled</text>
       </g>
     </g>
     <g class="edgeLabels">
@@ -78,33 +78,33 @@
     </g>
     <g class="nodes">
       <g class="block-nodes">
-        <g class="node block-node block-square blue" transform="translate(0, 0)" id="block-A">
+        <g class="node block-node block-square blue" id="block-A" transform="translate(0, 0)">
           <rect x="0" y="0" width="136" height="52" class="node-bkg"/>
-          <text x="68" y="26" class="block-label" text-anchor="middle" font-size="14px" dominant-baseline="middle">Square Block</text>
+          <text x="68" y="26" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Square Block</text>
         </g>
-        <g class="node block-node block-round" transform="translate(156, 0)" id="block-B">
+        <g class="node block-node block-round" id="block-B" transform="translate(156, 0)">
           <rect x="0" y="0" width="144" height="52" rx="10" ry="10" class="node-bkg" style="fill:#f9F;stroke:#333;stroke-width:4px"/>
-          <text x="72" y="26" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Rounded Block</text>
+          <text x="72" y="26" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Rounded Block</text>
         </g>
         <g class="node block-node block-diamond" id="block-C" transform="translate(320, 0)">
           <polygon points="62.400000000000006,0 124.80000000000001,26 62.400000000000006,52 0,26" class="node-bkg"/>
-          <text x="62.400000000000006" y="26" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Diamond</text>
+          <text x="62.400000000000006" y="26" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Diamond</text>
         </g>
-        <g class="node block-node block-composite" id="block-container" transform="translate(0, 72)">
+        <g class="node block-node block-composite" transform="translate(0, 72)" id="block-container">
           <rect x="0" y="0" width="248" height="60" class="block-composite"/>
           <text x="124" y="30" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle"></text>
         </g>
         <g class="node block-node block-square" id="block-D" transform="translate(8, 80)">
           <rect x="0" y="0" width="106" height="44" class="node-bkg"/>
-          <text x="53" y="22" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Nested 1</text>
+          <text x="53" y="22" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Nested 1</text>
         </g>
-        <g class="node block-node block-square" id="block-E" transform="translate(134, 80)">
+        <g class="node block-node block-square" transform="translate(134, 80)" id="block-E">
           <rect x="0" y="0" width="106" height="44" class="node-bkg"/>
-          <text x="53" y="22" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Nested 2</text>
+          <text x="53" y="22" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Nested 2</text>
         </g>
-        <g class="node block-node block-stadium" id="block-F" transform="translate(384, 72)">
+        <g class="node block-node block-stadium" transform="translate(384, 72)" id="block-F">
           <rect x="0" y="0" width="96" height="60" rx="30" ry="30" class="node-bkg"/>
-          <text x="48" y="30" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Stadium</text>
+          <text x="48" y="30" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Stadium</text>
         </g>
         <g class="node block-node block-square" transform="translate(0, 152)" id="block-G">
           <rect x="0" y="0" width="80" height="40" class="node-bkg"/>

--- a/src/diagrams/block/types.rs
+++ b/src/diagrams/block/types.rs
@@ -104,6 +104,8 @@ pub struct ClassDef {
 pub struct BlockDb {
     /// All blocks by ID
     blocks: HashMap<String, Block>,
+    /// Block IDs in insertion order (for maintaining layout order)
+    block_order: Vec<String>,
     /// Root block (composite containing all top-level blocks)
     root_block: Block,
     /// All edges
@@ -158,6 +160,10 @@ impl BlockDb {
         block.block_type = block_type;
         block.parent_id = parent_id.map(|s| s.to_string());
 
+        // Track insertion order
+        if !self.blocks.contains_key(id) {
+            self.block_order.push(id.to_string());
+        }
         self.blocks.insert(id.to_string(), block.clone());
         // Only add to root children if no parent (top-level block)
         if parent_id.is_none() {
@@ -234,9 +240,17 @@ impl BlockDb {
         &self.blocks
     }
 
-    /// Get blocks as flat vec
+    /// Get blocks as flat vec (insertion order preserved)
     pub fn get_blocks_flat(&self) -> Vec<&Block> {
-        self.blocks.values().collect()
+        self.block_order
+            .iter()
+            .filter_map(|id| self.blocks.get(id))
+            .collect()
+    }
+
+    /// Get block IDs in insertion order
+    pub fn get_block_order(&self) -> &[String] {
+        &self.block_order
     }
 
     /// Get all edges

--- a/src/render/block.rs
+++ b/src/render/block.rs
@@ -84,6 +84,7 @@ pub fn render_block(db: &BlockDb, config: &RenderConfig) -> Result<String> {
 
     // Get all blocks
     let blocks = db.get_blocks();
+    let block_order = db.get_block_order();
     let edges = db.get_edges();
     let classes = db.get_classes();
 
@@ -103,16 +104,17 @@ pub fn render_block(db: &BlockDb, config: &RenderConfig) -> Result<String> {
     // Determine columns from root or default
     let columns = db.get_columns().unwrap_or(DEFAULT_COLUMNS);
 
-    // Position blocks in grid layout
-    let positioned_blocks = layout_blocks(blocks, &block_sizes, columns);
+    // Position blocks in grid layout (preserving insertion order)
+    let positioned_blocks = layout_blocks(blocks, block_order, &block_sizes, columns);
 
     // Calculate bounds
     let (min_x, max_x, min_y, max_y) = calculate_bounds(&positioned_blocks);
-    let padding = 30.0;
-    let width = (max_x - min_x) + padding * 2.0;
-    let height = (max_y - min_y) + padding * 2.0;
+    // Use smaller padding similar to mermaid (5px)
+    let svg_padding = 5.0;
+    let width = (max_x - min_x) + svg_padding * 2.0;
+    let height = (max_y - min_y) + svg_padding * 2.0;
 
-    doc.set_size_with_origin(min_x - padding, min_y - padding, width, height);
+    doc.set_size_with_origin(min_x - svg_padding, min_y - svg_padding, width, height);
 
     // Add CSS styles
     if config.embed_css {
@@ -182,73 +184,225 @@ fn calculate_block_size(block: &Block) -> (f64, f64) {
 }
 
 /// Layout blocks in a grid with proper nesting for composite blocks
+/// Following mermaid's approach: all blocks in same row share same height,
+/// children inside composites are at same y-level as parent row
 fn layout_blocks(
     blocks: &HashMap<String, Block>,
+    block_order: &[String],
     sizes: &HashMap<String, (f64, f64)>,
     columns: usize,
 ) -> Vec<PositionedBlock> {
-    // First, build parent-child relationships
-    let mut children_by_parent: HashMap<String, Vec<&str>> = HashMap::new();
-    for (id, block) in blocks.iter() {
-        if let Some(ref parent_id) = block.parent_id {
-            children_by_parent
-                .entry(parent_id.clone())
-                .or_default()
-                .push(id);
+    // Build parent-child relationships preserving insertion order
+    let mut children_by_parent: HashMap<String, Vec<String>> = HashMap::new();
+    for id in block_order {
+        if let Some(block) = blocks.get(id) {
+            if let Some(ref parent_id) = block.parent_id {
+                children_by_parent
+                    .entry(parent_id.clone())
+                    .or_default()
+                    .push(id.clone());
+            }
         }
     }
 
     // Calculate sizes for composite blocks based on their children
     let mut effective_sizes: HashMap<String, (f64, f64)> = sizes.clone();
-    for (id, block) in blocks.iter() {
-        if block.block_type == BlockType::Composite {
-            if let Some(child_ids) = children_by_parent.get(id) {
-                let (comp_w, comp_h) =
-                    calculate_composite_size(child_ids, blocks, &effective_sizes);
-                effective_sizes.insert(id.clone(), (comp_w, comp_h));
+    for id in block_order {
+        if let Some(block) = blocks.get(id) {
+            if block.block_type == BlockType::Composite {
+                if let Some(child_ids) = children_by_parent.get(id) {
+                    let child_refs: Vec<&str> = child_ids.iter().map(|s| s.as_str()).collect();
+                    let (comp_w, comp_h) =
+                        calculate_composite_size(&child_refs, blocks, &effective_sizes);
+                    effective_sizes.insert(id.clone(), (comp_w, comp_h));
+                }
             }
         }
     }
 
-    // Layout root-level blocks only
-    let root_blocks: Vec<(&str, &Block)> = blocks
+    // Get root-level blocks (preserving insertion order)
+    let root_blocks: Vec<(&str, &Block)> = block_order
         .iter()
-        .filter(|(_, b)| b.parent_id.is_none())
-        .map(|(id, b)| (id.as_str(), b))
+        .filter_map(|id| {
+            blocks.get(id).and_then(|b| {
+                if b.parent_id.is_none() {
+                    Some((id.as_str(), b))
+                } else {
+                    None
+                }
+            })
+        })
         .collect();
 
-    let mut positioned = layout_block_list(&root_blocks, &effective_sizes, columns, 0.0, 0.0);
+    // First pass: determine row assignments and max heights per row
+    let mut row_info = calculate_row_info(&root_blocks, &effective_sizes, columns);
 
-    // Collect composite info for child positioning
-    let composite_info: Vec<_> = positioned
-        .iter()
-        .filter(|b| b.block_type == BlockType::Composite)
-        .map(|b| (b.id.clone(), b.x, b.y))
-        .collect();
-
-    // Now position children inside their parent composites
-    for (composite_id, comp_x, comp_y) in composite_info {
-        if let Some(child_ids) = children_by_parent.get(&composite_id) {
-            let child_blocks: Vec<(&str, &Block)> = child_ids
-                .iter()
-                .filter_map(|id| blocks.get(*id).map(|b| (*id, b)))
-                .collect();
-
-            // Get columns for this composite (default to auto based on children count)
-            let child_columns = child_ids.len().max(1);
-
-            // Layout children inside composite with padding
-            let padding = BLOCK_PADDING;
-            let child_positioned = layout_block_list(
-                &child_blocks,
-                &effective_sizes,
-                child_columns,
-                comp_x + padding,
-                comp_y + padding,
-            );
-
-            positioned.extend(child_positioned);
+    // Normalize heights - all blocks in same row get same height
+    for row in &mut row_info {
+        let max_height = row.iter().map(|(_, _, _, h)| *h).fold(0.0_f64, f64::max);
+        for item in row.iter_mut() {
+            item.3 = max_height;
         }
+    }
+
+    // Position all blocks based on row info
+    let mut positioned = Vec::new();
+    let mut current_y = 0.0;
+
+    for row in &row_info {
+        let mut current_x = 0.0;
+        let row_height = row.first().map(|(_, _, _, h)| *h).unwrap_or(MIN_BLOCK_HEIGHT);
+
+        for (id, block, width, height) in row {
+            // Skip space blocks in rendering but account for their space
+            if block.block_type == BlockType::Space {
+                current_x += *width + BLOCK_SPACING;
+                continue;
+            }
+
+            // Skip edge types
+            if block.block_type == BlockType::Edge {
+                continue;
+            }
+
+            positioned.push(PositionedBlock {
+                id: id.to_string(),
+                label: block.label.clone().unwrap_or_else(|| id.to_string()),
+                block_type: block.block_type.clone(),
+                x: current_x,
+                y: current_y,
+                width: *width,
+                height: *height,
+                column_span: block.width_in_columns.unwrap_or(1),
+                styles: block.styles.clone(),
+                classes: block.classes.clone(),
+            });
+
+            // If this is a composite, position children inside it
+            if block.block_type == BlockType::Composite {
+                if let Some(child_ids) = children_by_parent.get(*id) {
+                    let child_blocks: Vec<(&str, &Block)> = child_ids
+                        .iter()
+                        .filter_map(|cid| blocks.get(cid).map(|b| (cid.as_str(), b)))
+                        .collect();
+
+                    // Use minimal padding (8px like mermaid) for children inside composite
+                    let inner_padding = 8.0;
+                    let child_positioned = layout_composite_children(
+                        &child_blocks,
+                        &effective_sizes,
+                        current_x + inner_padding,
+                        current_y + inner_padding,
+                        *width - inner_padding * 2.0,
+                        *height - inner_padding * 2.0,
+                    );
+                    positioned.extend(child_positioned);
+                }
+            }
+
+            current_x += *width + BLOCK_SPACING;
+        }
+
+        current_y += row_height + BLOCK_SPACING;
+    }
+
+    positioned
+}
+
+/// Calculate row assignments and sizes for blocks
+fn calculate_row_info<'a>(
+    block_list: &[(&'a str, &'a Block)],
+    sizes: &HashMap<String, (f64, f64)>,
+    columns: usize,
+) -> Vec<Vec<(&'a str, &'a Block, f64, f64)>> {
+    let mut rows: Vec<Vec<(&str, &Block, f64, f64)>> = Vec::new();
+    let mut current_row: Vec<(&str, &Block, f64, f64)> = Vec::new();
+    let mut col = 0;
+
+    for &(id, block) in block_list {
+        let (width, height) = sizes
+            .get(id)
+            .cloned()
+            .unwrap_or((MIN_BLOCK_WIDTH, MIN_BLOCK_HEIGHT));
+        let span = block.width_in_columns.unwrap_or(1);
+
+        // Adjust width for column span
+        let block_width = if span > 1 {
+            (span as f64) * MIN_BLOCK_WIDTH + ((span - 1) as f64) * BLOCK_SPACING
+        } else {
+            width
+        };
+
+        // Check if we need to wrap to next row
+        if col + span > columns && col > 0 {
+            rows.push(current_row);
+            current_row = Vec::new();
+            col = 0;
+        }
+
+        current_row.push((id, block, block_width, height));
+        col += span;
+
+        // Wrap if we've filled the row
+        if col >= columns {
+            rows.push(current_row);
+            current_row = Vec::new();
+            col = 0;
+        }
+    }
+
+    // Don't forget the last row if it has items
+    if !current_row.is_empty() {
+        rows.push(current_row);
+    }
+
+    rows
+}
+
+/// Layout children inside a composite block
+fn layout_composite_children(
+    child_blocks: &[(&str, &Block)],
+    _sizes: &HashMap<String, (f64, f64)>,
+    start_x: f64,
+    start_y: f64,
+    available_width: f64,
+    available_height: f64,
+) -> Vec<PositionedBlock> {
+    let mut positioned = Vec::new();
+    let num_children = child_blocks.len();
+
+    if num_children == 0 {
+        return positioned;
+    }
+
+    // Calculate uniform size for children
+    let child_spacing = BLOCK_SPACING;
+    let total_spacing = (num_children - 1) as f64 * child_spacing;
+    let child_width = (available_width - total_spacing) / num_children as f64;
+    let child_height = available_height;
+
+    let mut current_x = start_x;
+
+    for &(id, block) in child_blocks {
+        if block.block_type == BlockType::Space {
+            current_x += child_width + child_spacing;
+            continue;
+        }
+
+        positioned.push(PositionedBlock {
+            id: id.to_string(),
+            label: block.label.clone().unwrap_or_else(|| id.to_string()),
+            block_type: block.block_type.clone(),
+            x: current_x,
+            y: start_y,
+            width: child_width,
+            height: child_height,
+            column_span: block.width_in_columns.unwrap_or(1),
+            styles: block.styles.clone(),
+            classes: block.classes.clone(),
+        });
+
+        current_x += child_width + child_spacing;
     }
 
     positioned
@@ -285,97 +439,6 @@ fn calculate_composite_size(
     }
 
     (total_width + padding * 2.0, max_height + padding * 2.0)
-}
-
-/// Layout a list of blocks in a grid starting at given offset
-fn layout_block_list(
-    block_list: &[(&str, &Block)],
-    sizes: &HashMap<String, (f64, f64)>,
-    columns: usize,
-    start_x: f64,
-    start_y: f64,
-) -> Vec<PositionedBlock> {
-    let mut positioned = Vec::new();
-    let mut y = start_y;
-    let mut col = 0;
-    let mut row_height = 0.0_f64;
-    let mut current_x = start_x;
-
-    // Sort by ID for consistent ordering
-    let mut sorted_list: Vec<_> = block_list.to_vec();
-    sorted_list.sort_by(|a, b| a.0.cmp(b.0));
-
-    for (id, block) in sorted_list {
-        // Skip space blocks in rendering (they still affect layout)
-        if block.block_type == BlockType::Space {
-            let span = block.width_in_columns.unwrap_or(1);
-            for _ in 0..span {
-                current_x += MIN_BLOCK_WIDTH + BLOCK_SPACING;
-                col += 1;
-                if col >= columns {
-                    col = 0;
-                    current_x = start_x;
-                    y += row_height + BLOCK_SPACING;
-                    row_height = 0.0;
-                }
-            }
-            continue;
-        }
-
-        // Skip edge types (handled separately)
-        if block.block_type == BlockType::Edge {
-            continue;
-        }
-
-        let (width, height) = sizes
-            .get(id)
-            .cloned()
-            .unwrap_or((MIN_BLOCK_WIDTH, MIN_BLOCK_HEIGHT));
-        let span = block.width_in_columns.unwrap_or(1);
-
-        // Check if we need to wrap to next row
-        if col + span > columns && col > 0 {
-            col = 0;
-            current_x = start_x;
-            y += row_height + BLOCK_SPACING;
-            row_height = 0.0;
-        }
-
-        // Adjust width for column span
-        let block_width = if span > 1 {
-            (span as f64) * MIN_BLOCK_WIDTH + ((span - 1) as f64) * BLOCK_SPACING
-        } else {
-            width
-        };
-
-        positioned.push(PositionedBlock {
-            id: id.to_string(),
-            label: block.label.clone().unwrap_or_else(|| id.to_string()),
-            block_type: block.block_type.clone(),
-            x: current_x,
-            y,
-            width: block_width,
-            height,
-            column_span: span,
-            styles: block.styles.clone(),
-            classes: block.classes.clone(),
-        });
-
-        // Advance x position by actual block width
-        current_x += block_width + BLOCK_SPACING;
-        row_height = row_height.max(height);
-        col += span;
-
-        // Wrap to next row if needed
-        if col >= columns {
-            col = 0;
-            current_x = start_x;
-            y += row_height + BLOCK_SPACING;
-            row_height = 0.0;
-        }
-    }
-
-    positioned
 }
 
 /// Calculate bounds of all blocks

--- a/src/render/block.rs
+++ b/src/render/block.rs
@@ -474,16 +474,51 @@ fn position_edges(
             block_map.get(edge.start.as_str()),
             block_map.get(edge.end.as_str()),
         ) {
-            // Calculate connection points (center of blocks)
+            // Calculate block centers
             let start_cx = start_block.x + start_block.width / 2.0;
             let start_cy = start_block.y + start_block.height / 2.0;
             let end_cx = end_block.x + end_block.width / 2.0;
             let end_cy = end_block.y + end_block.height / 2.0;
 
-            // Determine edge endpoints on block boundaries
-            let (start_x, start_y) =
-                get_edge_point(start_block, start_cx, start_cy, end_cx, end_cy);
-            let (end_x, end_y) = get_edge_point(end_block, end_cx, end_cy, start_cx, start_cy);
+            // Check if blocks overlap in x or y ranges
+            let x_overlap = blocks_overlap_x(start_block, end_block);
+            let y_overlap = blocks_overlap_y(start_block, end_block);
+
+            let (start_x, start_y, end_x, end_y) = if x_overlap && !y_overlap {
+                // Vertical edge - use shared x coordinate
+                let shared_x = (start_cx + end_cx) / 2.0;
+                let start_y = if start_cy < end_cy {
+                    start_block.y + start_block.height // Bottom of start
+                } else {
+                    start_block.y // Top of start
+                };
+                let end_y = if start_cy < end_cy {
+                    end_block.y // Top of end
+                } else {
+                    end_block.y + end_block.height // Bottom of end
+                };
+                (shared_x, start_y, shared_x, end_y)
+            } else if y_overlap && !x_overlap {
+                // Horizontal edge - use shared y coordinate
+                let shared_y = (start_cy + end_cy) / 2.0;
+                let start_x = if start_cx < end_cx {
+                    start_block.x + start_block.width // Right of start
+                } else {
+                    start_block.x // Left of start
+                };
+                let end_x = if start_cx < end_cx {
+                    end_block.x // Left of end
+                } else {
+                    end_block.x + end_block.width // Right of end
+                };
+                (start_x, shared_y, end_x, shared_y)
+            } else {
+                // Diagonal/curved edge - use original calculation
+                let (sx, sy) =
+                    get_edge_point(start_block, start_cx, start_cy, end_cx, end_cy);
+                let (ex, ey) = get_edge_point(end_block, end_cx, end_cy, start_cx, start_cy);
+                (sx, sy, ex, ey)
+            };
 
             positioned.push(PositionedEdge {
                 start: edge.start.clone(),
@@ -498,6 +533,25 @@ fn position_edges(
     }
 
     positioned
+}
+
+/// Check if two blocks overlap in x range
+fn blocks_overlap_x(a: &PositionedBlock, b: &PositionedBlock) -> bool {
+    let a_left = a.x;
+    let a_right = a.x + a.width;
+    let b_left = b.x;
+    let b_right = b.x + b.width;
+    // Overlap if one block's left is before other's right and vice versa
+    a_left < b_right && b_left < a_right
+}
+
+/// Check if two blocks overlap in y range
+fn blocks_overlap_y(a: &PositionedBlock, b: &PositionedBlock) -> bool {
+    let a_top = a.y;
+    let a_bottom = a.y + a.height;
+    let b_top = b.y;
+    let b_bottom = b.y + b.height;
+    a_top < b_bottom && b_top < a_bottom
 }
 
 /// Get the edge connection point on a block's boundary

--- a/src/render/block.rs
+++ b/src/render/block.rs
@@ -251,7 +251,10 @@ fn layout_blocks(
 
     for row in &row_info {
         let mut current_x = 0.0;
-        let row_height = row.first().map(|(_, _, _, h)| *h).unwrap_or(MIN_BLOCK_HEIGHT);
+        let row_height = row
+            .first()
+            .map(|(_, _, _, h)| *h)
+            .unwrap_or(MIN_BLOCK_HEIGHT);
 
         for (id, block, width, height) in row {
             // Skip space blocks in rendering but account for their space
@@ -514,8 +517,7 @@ fn position_edges(
                 (start_x, shared_y, end_x, shared_y)
             } else {
                 // Diagonal/curved edge - use original calculation
-                let (sx, sy) =
-                    get_edge_point(start_block, start_cx, start_cy, end_cx, end_cy);
+                let (sx, sy) = get_edge_point(start_block, start_cx, start_cy, end_cx, end_cy);
                 let (ex, ey) = get_edge_point(end_block, end_cx, end_cy, start_cx, start_cy);
                 (sx, sy, ex, ey)
             };


### PR DESCRIPTION
- Preserve insertion order of blocks instead of sorting alphabetically
- Add block_order Vec to BlockDb for tracking insertion order
- Rewrite layout algorithm to normalize block heights per row
- Layout composite children inside parent bounds
- Reduce SVG padding from 30px to 5px to match reference
- Use 8px inner padding for composite children

Visual similarity improved from 17% to 51% for block_complex diagrams. All 36 block rendering tests pass.