### PR TITLE
Fix packet diagram visual parity with mermaid

### DIFF
--- a/docs/images/packet.svg
+++ b/docs/images/packet.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1026" height="80" viewBox="0 0 1026 80" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1026" height="94" viewBox="0 0 1026 94" class="mermaid">
   <style>
 
 .mermaid {
@@ -116,18 +116,18 @@ marker path {
     <g class="nodes">
 
     </g>
-    <rect x="1" y="8" width="254" height="32" class="packetBlock"/>
-    <text x="128" y="24" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Header</text>
-    <text x="1" y="6" class="packetByte start" dominant-baseline="auto" text-anchor="start">0</text>
-    <text x="255" y="6" class="packetByte end" text-anchor="end" dominant-baseline="auto">7</text>
-    <rect x="257" y="8" width="254" height="32" class="packetBlock"/>
-    <text x="384" y="24" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Length</text>
-    <text x="257" y="6" class="packetByte start" dominant-baseline="auto" text-anchor="start">8</text>
-    <text x="511" y="6" class="packetByte end" text-anchor="end" dominant-baseline="auto">15</text>
-    <rect x="513" y="8" width="510" height="32" class="packetBlock"/>
-    <text x="768" y="24" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Data</text>
-    <text x="513" y="6" class="packetByte start" text-anchor="start" dominant-baseline="auto">16</text>
-    <text x="1023" y="6" class="packetByte end" text-anchor="end" dominant-baseline="auto">31</text>
-    <text x="513" y="60" class="packetTitle" dominant-baseline="middle" text-anchor="middle">Simple Packet</text>
+    <rect x="1" y="15" width="251" height="32" class="packetBlock"/>
+    <text x="126.5" y="31" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Header</text>
+    <text x="1" y="13" class="packetByte start" dominant-baseline="auto" text-anchor="start">0</text>
+    <text x="252" y="13" class="packetByte end" dominant-baseline="auto" text-anchor="end">7</text>
+    <rect x="257" y="15" width="251" height="32" class="packetBlock"/>
+    <text x="382.5" y="31" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Length</text>
+    <text x="257" y="13" class="packetByte start" dominant-baseline="auto" text-anchor="start">8</text>
+    <text x="508" y="13" class="packetByte end" dominant-baseline="auto" text-anchor="end">15</text>
+    <rect x="513" y="15" width="507" height="32" class="packetBlock"/>
+    <text x="766.5" y="31" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Data</text>
+    <text x="513" y="13" class="packetByte start" text-anchor="start" dominant-baseline="auto">16</text>
+    <text x="1020" y="13" class="packetByte end" dominant-baseline="auto" text-anchor="end">31</text>
+    <text x="513" y="70.5" class="packetTitle" dominant-baseline="middle" text-anchor="middle">Simple Packet</text>
   </g>
 </svg>

--- a/docs/images/packet_complex.svg
+++ b/docs/images/packet_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1026" height="360" viewBox="0 0 1026 360" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1026" height="423" viewBox="0 0 1026 423" class="mermaid">
   <style>
 
 .mermaid {
@@ -116,72 +116,72 @@ marker path {
     <g class="nodes">
 
     </g>
-    <rect x="1" y="8" width="510" height="32" class="packetBlock"/>
-    <text x="256" y="24" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Source Port</text>
-    <text x="1" y="6" class="packetByte start" dominant-baseline="auto" text-anchor="start">0</text>
-    <text x="511" y="6" class="packetByte end" dominant-baseline="auto" text-anchor="end">15</text>
-    <rect x="513" y="8" width="510" height="32" class="packetBlock"/>
-    <text x="768" y="24" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Destination Port</text>
-    <text x="513" y="6" class="packetByte start" dominant-baseline="auto" text-anchor="start">16</text>
-    <text x="1023" y="6" class="packetByte end" text-anchor="end" dominant-baseline="auto">31</text>
-    <rect x="1" y="48" width="1022" height="32" class="packetBlock"/>
-    <text x="512" y="64" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Sequence Number</text>
-    <text x="1" y="46" class="packetByte start" dominant-baseline="auto" text-anchor="start">32</text>
-    <text x="1023" y="46" class="packetByte end" dominant-baseline="auto" text-anchor="end">63</text>
-    <rect x="1" y="88" width="1022" height="32" class="packetBlock"/>
-    <text x="512" y="104" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Acknowledgment Number</text>
-    <text x="1" y="86" class="packetByte start" text-anchor="start" dominant-baseline="auto">64</text>
-    <text x="1023" y="86" class="packetByte end" dominant-baseline="auto" text-anchor="end">95</text>
-    <rect x="1" y="128" width="126" height="32" class="packetBlock"/>
-    <text x="64" y="144" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Data Offset</text>
-    <text x="1" y="126" class="packetByte start" dominant-baseline="auto" text-anchor="start">96</text>
-    <text x="127" y="126" class="packetByte end" text-anchor="end" dominant-baseline="auto">99</text>
-    <rect x="129" y="128" width="190" height="32" class="packetBlock"/>
-    <text x="224" y="144" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Reserved</text>
-    <text x="129" y="126" class="packetByte start" text-anchor="start" dominant-baseline="auto">100</text>
-    <text x="319" y="126" class="packetByte end" dominant-baseline="auto" text-anchor="end">105</text>
-    <rect x="321" y="128" width="30" height="32" class="packetBlock"/>
-    <text x="336" y="144" class="packetLabel" dominant-baseline="middle" text-anchor="middle">URG</text>
-    <text x="336" y="126" class="packetByte start" dominant-baseline="auto" text-anchor="middle">106</text>
-    <rect x="353" y="128" width="30" height="32" class="packetBlock"/>
-    <text x="368" y="144" class="packetLabel" text-anchor="middle" dominant-baseline="middle">ACK</text>
-    <text x="368" y="126" class="packetByte start" dominant-baseline="auto" text-anchor="middle">107</text>
-    <rect x="385" y="128" width="30" height="32" class="packetBlock"/>
-    <text x="400" y="144" class="packetLabel" dominant-baseline="middle" text-anchor="middle">PSH</text>
-    <text x="400" y="126" class="packetByte start" text-anchor="middle" dominant-baseline="auto">108</text>
-    <rect x="417" y="128" width="30" height="32" class="packetBlock"/>
-    <text x="432" y="144" class="packetLabel" dominant-baseline="middle" text-anchor="middle">RST</text>
-    <text x="432" y="126" class="packetByte start" dominant-baseline="auto" text-anchor="middle">109</text>
-    <rect x="449" y="128" width="30" height="32" class="packetBlock"/>
-    <text x="464" y="144" class="packetLabel" dominant-baseline="middle" text-anchor="middle">SYN</text>
-    <text x="464" y="126" class="packetByte start" text-anchor="middle" dominant-baseline="auto">110</text>
-    <rect x="481" y="128" width="30" height="32" class="packetBlock"/>
-    <text x="496" y="144" class="packetLabel" text-anchor="middle" dominant-baseline="middle">FIN</text>
-    <text x="496" y="126" class="packetByte start" text-anchor="middle" dominant-baseline="auto">111</text>
-    <rect x="513" y="128" width="510" height="32" class="packetBlock"/>
-    <text x="768" y="144" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Window</text>
-    <text x="513" y="126" class="packetByte start" text-anchor="start" dominant-baseline="auto">112</text>
-    <text x="1023" y="126" class="packetByte end" text-anchor="end" dominant-baseline="auto">127</text>
-    <rect x="1" y="168" width="510" height="32" class="packetBlock"/>
-    <text x="256" y="184" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Checksum</text>
-    <text x="1" y="166" class="packetByte start" dominant-baseline="auto" text-anchor="start">128</text>
-    <text x="511" y="166" class="packetByte end" text-anchor="end" dominant-baseline="auto">143</text>
-    <rect x="513" y="168" width="510" height="32" class="packetBlock"/>
-    <text x="768" y="184" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Urgent Pointer</text>
-    <text x="513" y="166" class="packetByte start" dominant-baseline="auto" text-anchor="start">144</text>
-    <text x="1023" y="166" class="packetByte end" text-anchor="end" dominant-baseline="auto">159</text>
-    <rect x="1" y="208" width="1022" height="32" class="packetBlock"/>
-    <text x="512" y="224" class="packetLabel" dominant-baseline="middle" text-anchor="middle">(Options and Padding)</text>
-    <text x="1" y="206" class="packetByte start" dominant-baseline="auto" text-anchor="start">160</text>
-    <text x="1023" y="206" class="packetByte end" dominant-baseline="auto" text-anchor="end">191</text>
-    <rect x="1" y="248" width="1022" height="32" class="packetBlock"/>
-    <text x="512" y="264" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Data</text>
-    <text x="1" y="246" class="packetByte start" dominant-baseline="auto" text-anchor="start">192</text>
-    <text x="1023" y="246" class="packetByte end" dominant-baseline="auto" text-anchor="end">223</text>
-    <rect x="1" y="288" width="1022" height="32" class="packetBlock"/>
-    <text x="512" y="304" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Data</text>
-    <text x="1" y="286" class="packetByte start" text-anchor="start" dominant-baseline="auto">224</text>
-    <text x="1023" y="286" class="packetByte end" dominant-baseline="auto" text-anchor="end">255</text>
-    <text x="513" y="340" class="packetTitle" text-anchor="middle" dominant-baseline="middle">TCP Packet Structure</text>
+    <rect x="1" y="15" width="507" height="32" class="packetBlock"/>
+    <text x="254.5" y="31" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Source Port</text>
+    <text x="1" y="13" class="packetByte start" text-anchor="start" dominant-baseline="auto">0</text>
+    <text x="508" y="13" class="packetByte end" dominant-baseline="auto" text-anchor="end">15</text>
+    <rect x="513" y="15" width="507" height="32" class="packetBlock"/>
+    <text x="766.5" y="31" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Destination Port</text>
+    <text x="513" y="13" class="packetByte start" dominant-baseline="auto" text-anchor="start">16</text>
+    <text x="1020" y="13" class="packetByte end" dominant-baseline="auto" text-anchor="end">31</text>
+    <rect x="1" y="62" width="1019" height="32" class="packetBlock"/>
+    <text x="510.5" y="78" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Sequence Number</text>
+    <text x="1" y="60" class="packetByte start" dominant-baseline="auto" text-anchor="start">32</text>
+    <text x="1020" y="60" class="packetByte end" text-anchor="end" dominant-baseline="auto">63</text>
+    <rect x="1" y="109" width="1019" height="32" class="packetBlock"/>
+    <text x="510.5" y="125" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Acknowledgment Number</text>
+    <text x="1" y="107" class="packetByte start" dominant-baseline="auto" text-anchor="start">64</text>
+    <text x="1020" y="107" class="packetByte end" text-anchor="end" dominant-baseline="auto">95</text>
+    <rect x="1" y="156" width="123" height="32" class="packetBlock"/>
+    <text x="62.5" y="172" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Data Offset</text>
+    <text x="1" y="154" class="packetByte start" dominant-baseline="auto" text-anchor="start">96</text>
+    <text x="124" y="154" class="packetByte end" text-anchor="end" dominant-baseline="auto">99</text>
+    <rect x="129" y="156" width="187" height="32" class="packetBlock"/>
+    <text x="222.5" y="172" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Reserved</text>
+    <text x="129" y="154" class="packetByte start" dominant-baseline="auto" text-anchor="start">100</text>
+    <text x="316" y="154" class="packetByte end" dominant-baseline="auto" text-anchor="end">105</text>
+    <rect x="321" y="156" width="27" height="32" class="packetBlock"/>
+    <text x="334.5" y="172" class="packetLabel" text-anchor="middle" dominant-baseline="middle">URG</text>
+    <text x="334.5" y="154" class="packetByte start" text-anchor="middle" dominant-baseline="auto">106</text>
+    <rect x="353" y="156" width="27" height="32" class="packetBlock"/>
+    <text x="366.5" y="172" class="packetLabel" text-anchor="middle" dominant-baseline="middle">ACK</text>
+    <text x="366.5" y="154" class="packetByte start" dominant-baseline="auto" text-anchor="middle">107</text>
+    <rect x="385" y="156" width="27" height="32" class="packetBlock"/>
+    <text x="398.5" y="172" class="packetLabel" dominant-baseline="middle" text-anchor="middle">PSH</text>
+    <text x="398.5" y="154" class="packetByte start" text-anchor="middle" dominant-baseline="auto">108</text>
+    <rect x="417" y="156" width="27" height="32" class="packetBlock"/>
+    <text x="430.5" y="172" class="packetLabel" dominant-baseline="middle" text-anchor="middle">RST</text>
+    <text x="430.5" y="154" class="packetByte start" dominant-baseline="auto" text-anchor="middle">109</text>
+    <rect x="449" y="156" width="27" height="32" class="packetBlock"/>
+    <text x="462.5" y="172" class="packetLabel" dominant-baseline="middle" text-anchor="middle">SYN</text>
+    <text x="462.5" y="154" class="packetByte start" text-anchor="middle" dominant-baseline="auto">110</text>
+    <rect x="481" y="156" width="27" height="32" class="packetBlock"/>
+    <text x="494.5" y="172" class="packetLabel" dominant-baseline="middle" text-anchor="middle">FIN</text>
+    <text x="494.5" y="154" class="packetByte start" text-anchor="middle" dominant-baseline="auto">111</text>
+    <rect x="513" y="156" width="507" height="32" class="packetBlock"/>
+    <text x="766.5" y="172" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Window</text>
+    <text x="513" y="154" class="packetByte start" dominant-baseline="auto" text-anchor="start">112</text>
+    <text x="1020" y="154" class="packetByte end" text-anchor="end" dominant-baseline="auto">127</text>
+    <rect x="1" y="203" width="507" height="32" class="packetBlock"/>
+    <text x="254.5" y="219" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Checksum</text>
+    <text x="1" y="201" class="packetByte start" dominant-baseline="auto" text-anchor="start">128</text>
+    <text x="508" y="201" class="packetByte end" text-anchor="end" dominant-baseline="auto">143</text>
+    <rect x="513" y="203" width="507" height="32" class="packetBlock"/>
+    <text x="766.5" y="219" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Urgent Pointer</text>
+    <text x="513" y="201" class="packetByte start" dominant-baseline="auto" text-anchor="start">144</text>
+    <text x="1020" y="201" class="packetByte end" dominant-baseline="auto" text-anchor="end">159</text>
+    <rect x="1" y="250" width="1019" height="32" class="packetBlock"/>
+    <text x="510.5" y="266" class="packetLabel" text-anchor="middle" dominant-baseline="middle">(Options and Padding)</text>
+    <text x="1" y="248" class="packetByte start" text-anchor="start" dominant-baseline="auto">160</text>
+    <text x="1020" y="248" class="packetByte end" text-anchor="end" dominant-baseline="auto">191</text>
+    <rect x="1" y="297" width="1019" height="32" class="packetBlock"/>
+    <text x="510.5" y="313" class="packetLabel" dominant-baseline="middle" text-anchor="middle">Data</text>
+    <text x="1" y="295" class="packetByte start" dominant-baseline="auto" text-anchor="start">192</text>
+    <text x="1020" y="295" class="packetByte end" dominant-baseline="auto" text-anchor="end">223</text>
+    <rect x="1" y="344" width="1019" height="32" class="packetBlock"/>
+    <text x="510.5" y="360" class="packetLabel" text-anchor="middle" dominant-baseline="middle">Data</text>
+    <text x="1" y="342" class="packetByte start" dominant-baseline="auto" text-anchor="start">224</text>
+    <text x="1020" y="342" class="packetByte end" dominant-baseline="auto" text-anchor="end">255</text>
+    <text x="513" y="399.5" class="packetTitle" text-anchor="middle" dominant-baseline="middle">TCP Packet Structure</text>
   </g>
 </svg>

--- a/src/render/packet.rs
+++ b/src/render/packet.rs
@@ -28,11 +28,26 @@ impl Default for PacketConfig {
     fn default() -> Self {
         Self {
             row_height: 32.0,
-            padding_y: 8.0,
-            padding_x: 2.0,
+            // Mermaid defaults: paddingY: 5 (base)
+            padding_y: 5.0,
+            // Mermaid defaults: paddingX: 5
+            padding_x: 5.0,
             bit_width: 32.0,
             bits_per_row: 32,
             show_bits: true,
+        }
+    }
+}
+
+impl PacketConfig {
+    /// Returns the effective padding_y, which increases by 10 when show_bits is true
+    /// to make room for the bit number labels above the blocks.
+    /// This matches mermaid's behavior in db.ts: `if (config.showBits) { config.paddingY += 10; }`
+    pub fn effective_padding_y(&self) -> f64 {
+        if self.show_bits {
+            self.padding_y + 10.0
+        } else {
+            self.padding_y
         }
     }
 }
@@ -44,11 +59,12 @@ pub fn render_packet(db: &PacketDb, config: &RenderConfig) -> Result<String> {
     let packet_config = PacketConfig::default();
     let PacketConfig {
         row_height,
-        padding_y,
         bit_width,
         bits_per_row,
         ..
     } = packet_config;
+    // Use effective_padding_y which adds 10 when show_bits is true (like mermaid)
+    let padding_y = packet_config.effective_padding_y();
 
     let words = db.get_packet();
     let title = db.get_title();
@@ -112,12 +128,14 @@ fn draw_word(
 ) {
     let PacketConfig {
         row_height,
-        padding_y,
         padding_x,
         bit_width,
         bits_per_row,
         show_bits,
+        ..
     } = *config;
+    // Use effective_padding_y which adds 10 when show_bits is true
+    let padding_y = config.effective_padding_y();
 
     let word_y = row_number as f64 * (row_height + padding_y) + padding_y;
 

--- a/tests/packet_rendering.rs
+++ b/tests/packet_rendering.rs
@@ -363,3 +363,126 @@ fn packet_title_renders_at_bottom() {
         "Should have packetTitle class"
     );
 }
+
+// ============================================================================
+// Mermaid Visual Parity Tests
+// ============================================================================
+
+fn get_svg_dimensions(doc: &Document<'_>) -> (f64, f64) {
+    let svg_node = doc
+        .descendants()
+        .find(|n| n.tag_name().name() == "svg")
+        .expect("SVG element not found");
+    let width: f64 = svg_node
+        .attribute("width")
+        .expect("width attribute missing")
+        .parse()
+        .expect("invalid width");
+    let height: f64 = svg_node
+        .attribute("height")
+        .expect("height attribute missing")
+        .parse()
+        .expect("invalid height");
+    (width, height)
+}
+
+fn get_first_rect_y(doc: &Document<'_>) -> f64 {
+    let rect = doc
+        .descendants()
+        .find(|n| n.tag_name().name() == "rect" && n.has_attribute("y"))
+        .expect("No rect found");
+    rect.attribute("y")
+        .expect("y attribute missing")
+        .parse()
+        .expect("invalid y")
+}
+
+fn get_first_rect_width(doc: &Document<'_>) -> f64 {
+    let rect = doc
+        .descendants()
+        .find(|n| n.tag_name().name() == "rect" && n.has_attribute("width"))
+        .expect("No rect found");
+    rect.attribute("width")
+        .expect("width attribute missing")
+        .parse()
+        .expect("invalid width")
+}
+
+#[test]
+fn packet_dimensions_match_mermaid_with_title() {
+    // Test case: TCP packet with title (from eval packet_complex)
+    // Mermaid calculates:
+    //   rowHeight: 32, paddingY: 5 (base) + 10 (showBits) = 15, bitWidth: 32, bitsPerRow: 32
+    //   totalRowHeight = 32 + 15 = 47
+    //   For 9 rows (bits 0-255 = 8 rows) + 1 title row: height = 47 * 9 = 423
+    //   Width = 32 * 32 + 2 = 1026
+    let input = r#"packet
+    title TCP Packet Structure
+    0-15: "Source Port"
+    16-31: "Destination Port"
+    32-63: "Sequence Number"
+    64-95: "Acknowledgment Number"
+    96-99: "Data Offset"
+    100-105: "Reserved"
+    106: "URG"
+    107: "ACK"
+    108: "PSH"
+    109: "RST"
+    110: "SYN"
+    111: "FIN"
+    112-127: "Window"
+    128-143: "Checksum"
+    144-159: "Urgent Pointer"
+    160-191: "(Options and Padding)"
+    192-255: "Data"
+"#;
+    let svg = render_packet_svg(input);
+    let doc = parse_svg(&svg);
+
+    let (width, height) = get_svg_dimensions(&doc);
+
+    // Width should be bitWidth * bitsPerRow + 2 = 32 * 32 + 2 = 1026
+    assert_eq!(width, 1026.0, "SVG width should match mermaid (1026)");
+
+    // Height should be totalRowHeight * (rows + 1) = 47 * 9 = 423
+    // (9 rows for 256 bits / 32 bits_per_row, + title row space, but actually
+    // the formula is: totalRowHeight * (words.length + 1) - (title ? 0 : rowHeight)
+    // With title: 47 * 9 = 423
+    assert_eq!(height, 423.0, "SVG height should match mermaid (423)");
+}
+
+#[test]
+fn packet_first_row_y_position_matches_mermaid() {
+    // First row should start at y = paddingY (15 when showBits is true)
+    let input = r#"packet
+    0-15: "Test"
+"#;
+    let svg = render_packet_svg(input);
+    let doc = parse_svg(&svg);
+
+    let first_y = get_first_rect_y(&doc);
+
+    // With showBits=true, paddingY = 5 + 10 = 15
+    assert_eq!(
+        first_y, 15.0,
+        "First row Y should be paddingY (15 with showBits)"
+    );
+}
+
+#[test]
+fn packet_block_width_matches_mermaid() {
+    // A 16-bit block should have width = 16 * bitWidth - paddingX = 16 * 32 - 5 = 507
+    let input = r#"packet
+    0-15: "Test"
+"#;
+    let svg = render_packet_svg(input);
+    let doc = parse_svg(&svg);
+
+    let first_width = get_first_rect_width(&doc);
+
+    // Width = bits * bitWidth - paddingX = 16 * 32 - 5 = 507
+    assert_eq!(
+        first_width, 507.0,
+        "16-bit block width should be 507 (16*32-5)"
+    );
+}


### PR DESCRIPTION
## Summary

- Fix padding values in packet diagram renderer to match mermaid defaults
- Visual similarity improved from **25% to 100%** for `packet_complex`
- Add padding_y +10 adjustment when showBits is true (matches mermaid db.ts behavior)

## Changes

| Setting | Before | After | Mermaid |
|---------|--------|-------|---------|
| padding_y | 8 | 5 (+10 when showBits) | 5 (+10) |
| padding_x | 2 | 5 | 5 |

## Test plan

- [x] Run `cargo test --features all-formats` - all 14 packet tests pass
- [x] Run `cargo clippy --features all-formats -- -D warnings` - no warnings
- [x] Run eval: `cargo run --features eval --bin selkie -- eval --type packet`
  - packet: PASSING
  - packet_complex: 100% visual similarity (was 25.1%)

## New tests added

- `packet_dimensions_match_mermaid_with_title` - verifies SVG dimensions match mermaid (1026x423)
- `packet_first_row_y_position_matches_mermaid` - verifies first row Y position (15 with showBits)
- `packet_block_width_matches_mermaid` - verifies 16-bit block width (507)

🤖 Generated with [Claude Code](https://claude.com/claude-code)