### PR TITLE
fix(sankey): Improve visual parity with mermaid reference

### DIFF
--- a/docs/images/sankey.svg
+++ b/docs/images/sankey.svg
@@ -118,23 +118,23 @@ marker path {
 
     </g>
     <g class="nodes">
-      <g class="node" transform="translate(0,15.375)" x="0" id="node-1" y="15.375">
-        <rect x="0" y="0" width="10" height="300" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" y="15.375" x="0" id="node-1" transform="translate(0,15.375)">
+        <rect x="0" y="0" width="10" height="300" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" id="node-2" transform="translate(590,0)" x="590" y="0">
-        <rect x="0" y="0" width="10" height="120" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" id="node-2" x="590" y="0" transform="translate(590,0)">
+        <rect x="0" y="0" width="10" height="120" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" id="node-3" x="590" transform="translate(590,145)" y="145">
-        <rect x="0" y="0" width="10" height="75" class="sankey-node" fill="#e15759"/>
+      <g class="node" y="145" x="590" id="node-3" transform="translate(590,145)">
+        <rect x="0" y="0" width="10" height="75" class="sankey-node" style="fill: #e15759"/>
       </g>
-      <g class="node" id="node-4" x="590" y="245" transform="translate(590,245)">
-        <rect x="0" y="0" width="10" height="45" class="sankey-node" fill="#76b7b2"/>
+      <g class="node" transform="translate(590,245)" y="245" id="node-4" x="590">
+        <rect x="0" y="0" width="10" height="45" class="sankey-node" style="fill: #76b7b2"/>
       </g>
-      <g class="node" id="node-5" y="315" x="590" transform="translate(590,315)">
-        <rect x="0" y="0" width="10" height="36" class="sankey-node" fill="#59a14f"/>
+      <g class="node" x="590" id="node-5" y="315" transform="translate(590,315)">
+        <rect x="0" y="0" width="10" height="36" class="sankey-node" style="fill: #59a14f"/>
       </g>
-      <g class="node" x="590" transform="translate(590,376)" y="376" id="node-6">
-        <rect x="0" y="0" width="10" height="24" class="sankey-node" fill="#edc949"/>
+      <g class="node" id="node-6" transform="translate(590,376)" x="590" y="376">
+        <rect x="0" y="0" width="10" height="24" class="sankey-node" style="fill: #edc949"/>
       </g>
     </g>
     <g class="node-labels" font-size="14">
@@ -156,7 +156,7 @@ marker path {
         <path d="M10,75.375 C300,75.375 300,60 590,60" stroke-width="120" stroke="url(#linearGradient-1)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,172.875 C300,172.875 300,182.5 590,182.5" stroke="url(#linearGradient-2)" stroke-width="75"/>
+        <path d="M10,172.875 C300,172.875 300,182.5 590,182.5" stroke-width="75" stroke="url(#linearGradient-2)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M10,232.875 C300,232.875 300,267.5 590,267.5" stroke-width="45" stroke="url(#linearGradient-3)"/>

--- a/docs/images/sankey_branching.svg
+++ b/docs/images/sankey_branching.svg
@@ -119,26 +119,26 @@ marker path {
 
     </g>
     <g class="nodes">
-      <g class="node" y="0" transform="translate(0,0)" id="node-1" x="0">
-        <rect x="0" y="0" width="10" height="250" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" transform="translate(0,0)" id="node-1" y="0" x="0">
+        <rect x="0" y="0" width="10" height="250" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" id="node-6" transform="translate(0,275)" y="275" x="0">
-        <rect x="0" y="0" width="10" height="125" class="sankey-node" fill="#edc949"/>
+      <g class="node" transform="translate(0,275)" x="0" y="275" id="node-6">
+        <rect x="0" y="0" width="10" height="125" class="sankey-node" style="fill: #edc949"/>
       </g>
-      <g class="node" x="147.5" id="node-2" y="38.54166666666666" transform="translate(147.5,38.54166666666666)">
-        <rect x="0" y="0" width="10" height="249.99999999999997" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" transform="translate(147.5,38.54166666666666)" y="38.54166666666666" id="node-2" x="147.5">
+        <rect x="0" y="0" width="10" height="249.99999999999997" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" id="node-3" transform="translate(295,14.583333333333314)" y="14.583333333333314" x="295">
-        <rect x="0" y="0" width="10" height="375" class="sankey-node" fill="#e15759"/>
+      <g class="node" transform="translate(295,14.583333333333314)" x="295" id="node-3" y="14.583333333333314">
+        <rect x="0" y="0" width="10" height="375" class="sankey-node" style="fill: #e15759"/>
       </g>
-      <g class="node" id="node-4" y="31.25" x="442.5" transform="translate(442.5,31.25)">
-        <rect x="0" y="0" width="10" height="250" class="sankey-node" fill="#76b7b2"/>
+      <g class="node" x="442.5" transform="translate(442.5,31.25)" y="31.25" id="node-4">
+        <rect x="0" y="0" width="10" height="250" class="sankey-node" style="fill: #76b7b2"/>
       </g>
-      <g class="node" transform="translate(590,0)" x="590" y="0" id="node-5">
-        <rect x="0" y="0" width="10" height="250" class="sankey-node" fill="#59a14f"/>
+      <g class="node" transform="translate(590,0)" id="node-5" y="0" x="590">
+        <rect x="0" y="0" width="10" height="250" class="sankey-node" style="fill: #59a14f"/>
       </g>
-      <g class="node" x="590" transform="translate(590,275)" id="node-7" y="275">
-        <rect x="0" y="0" width="10" height="125" class="sankey-node" fill="#af7aa1"/>
+      <g class="node" transform="translate(590,275)" y="275" x="590" id="node-7">
+        <rect x="0" y="0" width="10" height="125" class="sankey-node" style="fill: #af7aa1"/>
       </g>
     </g>
     <g class="node-labels" font-size="14">
@@ -157,7 +157,7 @@ marker path {
       <text x="584" y="337.5" dy="0em" text-anchor="end">y
 4</text>
     </g>
-    <g class="links" fill="none" stroke-opacity="0.5">
+    <g class="links" stroke-opacity="0.5" fill="none">
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M10,125 C78.75,125 78.75,163.54166666666666 147.5,163.54166666666666" stroke-width="250" stroke="url(#linearGradient-1)"/>
       </g>
@@ -165,13 +165,13 @@ marker path {
         <path d="M157.5,163.54166666666666 C226.25,163.54166666666666 226.25,139.58333333333331 295,139.58333333333331" stroke-width="250" stroke="url(#linearGradient-2)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M305,139.58333333333331 C373.75,139.58333333333331 373.75,156.25 442.5,156.25" stroke="url(#linearGradient-3)" stroke-width="250"/>
+        <path d="M305,139.58333333333331 C373.75,139.58333333333331 373.75,156.25 442.5,156.25" stroke-width="250" stroke="url(#linearGradient-3)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M452.5,156.25 C521.25,156.25 521.25,125 590,125" stroke="url(#linearGradient-4)" stroke-width="250"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,337.5 C152.5,337.5 152.5,327.0833333333333 295,327.0833333333333" stroke-width="125" stroke="url(#linearGradient-5)"/>
+        <path d="M10,337.5 C152.5,337.5 152.5,327.0833333333333 295,327.0833333333333" stroke="url(#linearGradient-5)" stroke-width="125"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M305,327.0833333333333 C447.5,327.0833333333333 447.5,337.5 590,337.5" stroke-width="125" stroke="url(#linearGradient-6)"/>

--- a/docs/images/sankey_chain.svg
+++ b/docs/images/sankey_chain.svg
@@ -116,17 +116,17 @@ marker path {
 
     </g>
     <g class="nodes">
-      <g class="node" x="0" id="node-1" y="0" transform="translate(0,0)">
-        <rect x="0" y="0" width="10" height="400" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" id="node-1" transform="translate(0,0)" x="0" y="0">
+        <rect x="0" y="0" width="10" height="400" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" x="196.66666666666666" y="0" transform="translate(196.66666666666666,0)" id="node-2">
-        <rect x="0" y="0" width="10" height="400" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" transform="translate(196.66666666666666,0)" x="196.66666666666666" id="node-2" y="0">
+        <rect x="0" y="0" width="10" height="400" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" y="0" x="393.3333333333333" id="node-3" transform="translate(393.3333333333333,0)">
-        <rect x="0" y="0" width="10" height="400" class="sankey-node" fill="#e15759"/>
+      <g class="node" id="node-3" x="393.3333333333333" y="0" transform="translate(393.3333333333333,0)">
+        <rect x="0" y="0" width="10" height="400" class="sankey-node" style="fill: #e15759"/>
       </g>
-      <g class="node" y="0" transform="translate(590,0)" id="node-4" x="590">
-        <rect x="0" y="0" width="10" height="400" class="sankey-node" fill="#76b7b2"/>
+      <g class="node" id="node-4" y="0" x="590" transform="translate(590,0)">
+        <rect x="0" y="0" width="10" height="400" class="sankey-node" style="fill: #76b7b2"/>
       </g>
     </g>
     <g class="node-labels" font-size="14">
@@ -141,13 +141,13 @@ marker path {
     </g>
     <g class="links" fill="none" stroke-opacity="0.5">
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,200 C103.33333333333333,200 103.33333333333333,200 196.66666666666666,200" stroke-width="400" stroke="url(#linearGradient-1)"/>
+        <path d="M10,200 C103.33333333333333,200 103.33333333333333,200 196.66666666666666,200" stroke="url(#linearGradient-1)" stroke-width="400"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M206.66666666666666,200 C300,200 300,200 393.3333333333333,200" stroke="url(#linearGradient-2)" stroke-width="400"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M403.3333333333333,200 C496.66666666666663,200 496.66666666666663,200 590,200" stroke-width="400" stroke="url(#linearGradient-3)"/>
+        <path d="M403.3333333333333,200 C496.66666666666663,200 496.66666666666663,200 590,200" stroke="url(#linearGradient-3)" stroke-width="400"/>
       </g>
     </g>
   </g>

--- a/docs/images/sankey_commas.svg
+++ b/docs/images/sankey_commas.svg
@@ -115,14 +115,14 @@ marker path {
 
     </g>
     <g class="nodes">
-      <g class="node" y="3.350044368937205" transform="translate(0,3.350044368937205)" x="0" id="node-1">
-        <rect x="0" y="0" width="10" height="375" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" transform="translate(0,3.350044368937205)" x="0" y="3.350044368937205" id="node-1">
+        <rect x="0" y="0" width="10" height="375" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" y="0" transform="translate(590,0)" x="590" id="node-2">
-        <rect x="0" y="0" width="10" height="274.49866893188425" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" y="0" id="node-2" transform="translate(590,0)" x="590">
+        <rect x="0" y="0" width="10" height="274.49866893188425" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" x="590" transform="translate(590,299.4986689318842)" y="299.4986689318842" id="node-3">
-        <rect x="0" y="0" width="10" height="100.5013310681158" class="sankey-node" fill="#e15759"/>
+      <g class="node" transform="translate(590,299.4986689318842)" x="590" id="node-3" y="299.4986689318842">
+        <rect x="0" y="0" width="10" height="100.5013310681158" class="sankey-node" style="fill: #e15759"/>
       </g>
     </g>
     <g class="node-labels" font-size="14">
@@ -133,12 +133,12 @@ marker path {
       <text x="584" y="349.74933446594207" dy="0em" text-anchor="end">Heating and cooling, commercial
 70.67</text>
     </g>
-    <g class="links" fill="none" stroke-opacity="0.5">
+    <g class="links" stroke-opacity="0.5" fill="none">
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,140.59937883487933 C300,140.59937883487933 300,137.24933446594213 590,137.24933446594213" stroke="url(#linearGradient-1)" stroke-width="274.49866893188425"/>
+        <path d="M10,140.59937883487933 C300,140.59937883487933 300,137.24933446594213 590,137.24933446594213" stroke-width="274.49866893188425" stroke="url(#linearGradient-1)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,328.0993788348794 C300,328.0993788348794 300,349.74933446594207 590,349.74933446594207" stroke="url(#linearGradient-2)" stroke-width="100.5013310681158"/>
+        <path d="M10,328.0993788348794 C300,328.0993788348794 300,349.74933446594207 590,349.74933446594207" stroke-width="100.5013310681158" stroke="url(#linearGradient-2)"/>
       </g>
     </g>
   </g>

--- a/docs/images/sankey_double_quotes.svg
+++ b/docs/images/sankey_double_quotes.svg
@@ -115,14 +115,14 @@ marker path {
 
     </g>
     <g class="nodes">
-      <g class="node" x="0" y="3.350044368937205" id="node-1" transform="translate(0,3.350044368937205)">
-        <rect x="0" y="0" width="10" height="375" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" y="3.350044368937205" x="0" transform="translate(0,3.350044368937205)" id="node-1">
+        <rect x="0" y="0" width="10" height="375" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" transform="translate(590,0)" x="590" y="0" id="node-2">
-        <rect x="0" y="0" width="10" height="274.49866893188425" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" x="590" id="node-2" y="0" transform="translate(590,0)">
+        <rect x="0" y="0" width="10" height="274.49866893188425" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" id="node-3" y="299.4986689318842" transform="translate(590,299.4986689318842)" x="590">
-        <rect x="0" y="0" width="10" height="100.5013310681158" class="sankey-node" fill="#e15759"/>
+      <g class="node" y="299.4986689318842" transform="translate(590,299.4986689318842)" id="node-3" x="590">
+        <rect x="0" y="0" width="10" height="100.5013310681158" class="sankey-node" style="fill: #e15759"/>
       </g>
     </g>
     <g class="node-labels" font-size="14">
@@ -135,10 +135,10 @@ marker path {
     </g>
     <g class="links" stroke-opacity="0.5" fill="none">
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,140.59937883487933 C300,140.59937883487933 300,137.24933446594213 590,137.24933446594213" stroke="url(#linearGradient-1)" stroke-width="274.49866893188425"/>
+        <path d="M10,140.59937883487933 C300,140.59937883487933 300,137.24933446594213 590,137.24933446594213" stroke-width="274.49866893188425" stroke="url(#linearGradient-1)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,328.0993788348794 C300,328.0993788348794 300,349.74933446594207 590,349.74933446594207" stroke-width="100.5013310681158" stroke="url(#linearGradient-2)"/>
+        <path d="M10,328.0993788348794 C300,328.0993788348794 300,349.74933446594207 590,349.74933446594207" stroke="url(#linearGradient-2)" stroke-width="100.5013310681158"/>
       </g>
     </g>
   </g>

--- a/docs/images/sankey_empty_lines.svg
+++ b/docs/images/sankey_empty_lines.svg
@@ -116,17 +116,17 @@ marker path {
 
     </g>
     <g class="nodes">
-      <g class="node" transform="translate(0,4.341304258255889)" x="0" id="node-1" y="4.341304258255889">
-        <rect x="0" y="0" width="10" height="350" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" id="node-1" x="0" y="4.341304258255889" transform="translate(0,4.341304258255889)">
+        <rect x="0" y="0" width="10" height="350" class="sankey-node" style="fill: #4e79a7"/>
       </g>
       <g class="node" x="590" y="375.7892812261799" transform="translate(590,375.7892812261799)" id="node-2">
-        <rect x="0" y="0" width="10" height="24.210718773820076" class="sankey-node" fill="#f28e2c"/>
+        <rect x="0" y="0" width="10" height="24.210718773820076" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" x="590" id="node-3" y="0.00000000000005684341886080802" transform="translate(590,0.00000000000005684341886080802)">
-        <rect x="0" y="0" width="10" height="252.65419954265462" class="sankey-node" fill="#e15759"/>
+      <g class="node" y="0.00000000000005684341886080802" x="590" id="node-3" transform="translate(590,0.00000000000005684341886080802)">
+        <rect x="0" y="0" width="10" height="252.65419954265462" class="sankey-node" style="fill: #e15759"/>
       </g>
-      <g class="node" y="277.6541995426547" id="node-4" x="590" transform="translate(590,277.6541995426547)">
-        <rect x="0" y="0" width="10" height="73.13508168352524" class="sankey-node" fill="#76b7b2"/>
+      <g class="node" id="node-4" x="590" y="277.6541995426547" transform="translate(590,277.6541995426547)">
+        <rect x="0" y="0" width="10" height="73.13508168352524" class="sankey-node" style="fill: #76b7b2"/>
       </g>
     </g>
     <g class="node-labels" font-size="14">
@@ -144,10 +144,10 @@ marker path {
         <path d="M10,16.44666364516592 C300,16.44666364516592 300,387.89464061308996 590,387.89464061308996" stroke="url(#linearGradient-1)" stroke-width="24.210718773820066"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,154.87912280340328 C300,154.87912280340328 300,126.32709977132737 590,126.32709977132737" stroke="url(#linearGradient-2)" stroke-width="252.65419954265462"/>
+        <path d="M10,154.87912280340328 C300,154.87912280340328 300,126.32709977132737 590,126.32709977132737" stroke-width="252.65419954265462" stroke="url(#linearGradient-2)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,317.77376341649324 C300,317.77376341649324 300,314.22174038441733 590,314.22174038441733" stroke-width="73.13508168352526" stroke="url(#linearGradient-3)"/>
+        <path d="M10,317.77376341649324 C300,317.77376341649324 300,314.22174038441733 590,314.22174038441733" stroke="url(#linearGradient-3)" stroke-width="73.13508168352526"/>
       </g>
     </g>
   </g>

--- a/docs/images/sankey_energy.svg
+++ b/docs/images/sankey_energy.svg
@@ -117,20 +117,20 @@ marker path {
 
     </g>
     <g class="nodes">
-      <g class="node" y="4.3224283843291005" transform="translate(0,4.3224283843291005)" id="node-1" x="0">
-        <rect x="0" y="0" width="10" height="325" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" x="0" id="node-1" y="4.3224283843291005" transform="translate(0,4.3224283843291005)">
+        <rect x="0" y="0" width="10" height="325" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" transform="translate(590,399)" y="399" x="590" id="node-2">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" x="590" id="node-2" transform="translate(590,399)" y="399">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" transform="translate(590,351.55312720961626)" y="351.55312720961626" x="590" id="node-3">
-        <rect x="0" y="0" width="10" height="22.446872790383736" class="sankey-node" fill="#e15759"/>
+      <g class="node" y="351.55312720961626" transform="translate(590,351.55312720961626)" x="590" id="node-3">
+        <rect x="0" y="0" width="10" height="22.446872790383736" class="sankey-node" style="fill: #e15759"/>
       </g>
-      <g class="node" x="590" transform="translate(590,0)" y="0" id="node-4">
-        <rect x="0" y="0" width="10" height="234.2473484605001" class="sankey-node" fill="#76b7b2"/>
+      <g class="node" id="node-4" x="590" transform="translate(590,0)" y="0">
+        <rect x="0" y="0" width="10" height="234.2473484605001" class="sankey-node" style="fill: #76b7b2"/>
       </g>
-      <g class="node" y="258.7462235649547" transform="translate(590,258.7462235649547)" x="590" id="node-5">
-        <rect x="0" y="0" width="10" height="67.80690364466159" class="sankey-node" fill="#59a14f"/>
+      <g class="node" transform="translate(590,258.7462235649547)" x="590" y="258.7462235649547" id="node-5">
+        <rect x="0" y="0" width="10" height="67.80690364466159" class="sankey-node" style="fill: #59a14f"/>
       </g>
     </g>
     <g class="node-labels" font-size="14">

--- a/docs/images/sankey_energy_full.svg
+++ b/docs/images/sankey_energy_full.svg
@@ -181,149 +181,149 @@ marker path {
 
     </g>
     <g class="nodes">
-      <g class="node" transform="translate(0,35.00000000000003)" y="35.00000000000003" x="0" id="node-1">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" id="node-1" x="0" y="35.00000000000003" transform="translate(0,35.00000000000003)">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" id="node-7" x="0" transform="translate(0,0)" y="0">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#af7aa1"/>
+      <g class="node" id="node-7" y="0" transform="translate(0,0)" x="0">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #af7aa1"/>
       </g>
-      <g class="node" x="0" y="61" transform="translate(0,61)" id="node-8">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#ff9da7"/>
+      <g class="node" transform="translate(0,61)" y="61" id="node-8" x="0">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #ff9da7"/>
       </g>
-      <g class="node" id="node-9" transform="translate(0,0)" y="0" x="0">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#9c755f"/>
+      <g class="node" x="0" id="node-9" transform="translate(0,0)" y="0">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #9c755f"/>
       </g>
       <g class="node" id="node-11" x="0" y="0" transform="translate(0,0)">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#4e79a7"/>
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" id="node-24" x="0" transform="translate(0,0)" y="0">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#76b7b2"/>
+      <g class="node" transform="translate(0,0)" y="0" x="0" id="node-24">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #76b7b2"/>
       </g>
       <g class="node" transform="translate(0,9.000000000000028)" x="0" id="node-26" y="9.000000000000028">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#edc949"/>
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #edc949"/>
       </g>
-      <g class="node" transform="translate(0,87)" x="0" y="87" id="node-28">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#ff9da7"/>
+      <g class="node" x="0" y="87" transform="translate(0,87)" id="node-28">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #ff9da7"/>
       </g>
-      <g class="node" id="node-30" transform="translate(0,113)" y="113" x="0">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#bab0ab"/>
+      <g class="node" transform="translate(0,113)" id="node-30" x="0" y="113">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #bab0ab"/>
       </g>
-      <g class="node" y="217" x="0" id="node-35" transform="translate(0,217)">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#59a14f"/>
+      <g class="node" transform="translate(0,217)" x="0" y="217" id="node-35">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #59a14f"/>
       </g>
-      <g class="node" y="139" transform="translate(0,139)" id="node-36" x="0">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#edc949"/>
+      <g class="node" id="node-36" x="0" transform="translate(0,139)" y="139">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #edc949"/>
       </g>
-      <g class="node" id="node-37" y="165" x="0" transform="translate(0,165)">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#af7aa1"/>
+      <g class="node" transform="translate(0,165)" id="node-37" x="0" y="165">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #af7aa1"/>
       </g>
-      <g class="node" y="191" x="0" id="node-39" transform="translate(0,191)">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#9c755f"/>
+      <g class="node" id="node-39" y="191" transform="translate(0,191)" x="0">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #9c755f"/>
       </g>
-      <g class="node" id="node-40" transform="translate(0,243)" x="0" y="243">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#bab0ab"/>
+      <g class="node" y="243" transform="translate(0,243)" x="0" id="node-40">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #bab0ab"/>
       </g>
-      <g class="node" x="0" y="347" transform="translate(0,347)" id="node-41">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" x="0" id="node-41" transform="translate(0,347)" y="347">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" transform="translate(0,295)" id="node-44" x="0" y="295">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#76b7b2"/>
+      <g class="node" y="295" id="node-44" transform="translate(0,295)" x="0">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #76b7b2"/>
       </g>
-      <g class="node" y="269" transform="translate(0,269)" id="node-45" x="0">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#59a14f"/>
+      <g class="node" x="0" y="269" transform="translate(0,269)" id="node-45">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #59a14f"/>
       </g>
-      <g class="node" x="0" transform="translate(0,399)" id="node-46" y="399">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#edc949"/>
+      <g class="node" x="0" y="399" transform="translate(0,399)" id="node-46">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #edc949"/>
       </g>
-      <g class="node" transform="translate(0,321)" id="node-47" y="321" x="0">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#af7aa1"/>
+      <g class="node" id="node-47" transform="translate(0,321)" y="321" x="0">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #af7aa1"/>
       </g>
-      <g class="node" x="0" id="node-48" y="373" transform="translate(0,373)">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#ff9da7"/>
+      <g class="node" id="node-48" x="0" y="373" transform="translate(0,373)">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #ff9da7"/>
       </g>
-      <g class="node" y="340.11202370043213" id="node-2" transform="translate(84.28571428571429,340.11202370043213)" x="84.28571428571429">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" id="node-2" x="84.28571428571429" y="340.11202370043213" transform="translate(84.28571428571429,340.11202370043213)">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" transform="translate(84.28571428571429,190.79729237491694)" x="84.28571428571429" y="190.79729237491694" id="node-10">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#bab0ab"/>
+      <g class="node" transform="translate(84.28571428571429,190.79729237491694)" y="190.79729237491694" id="node-10" x="84.28571428571429">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #bab0ab"/>
       </g>
-      <g class="node" transform="translate(84.28571428571429,144.3334217169975)" x="84.28571428571429" id="node-25" y="144.3334217169975">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#59a14f"/>
+      <g class="node" id="node-25" transform="translate(84.28571428571429,144.3334217169975)" x="84.28571428571429" y="144.3334217169975">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #59a14f"/>
       </g>
-      <g class="node" transform="translate(84.28571428571429,222.3334217169975)" x="84.28571428571429" id="node-38" y="222.3334217169975">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#ff9da7"/>
+      <g class="node" transform="translate(84.28571428571429,222.3334217169975)" y="222.3334217169975" id="node-38" x="84.28571428571429">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #ff9da7"/>
       </g>
-      <g class="node" id="node-42" transform="translate(84.28571428571429,311.54467675309184)" y="311.54467675309184" x="84.28571428571429">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" id="node-42" transform="translate(84.28571428571429,311.54467675309184)" x="84.28571428571429" y="311.54467675309184">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" transform="translate(84.28571428571429,386)" x="84.28571428571429" id="node-43" y="386">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#e15759"/>
+      <g class="node" transform="translate(84.28571428571429,386)" x="84.28571428571429" y="386" id="node-43">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #e15759"/>
       </g>
       <g class="node" id="node-3" transform="translate(168.57142857142858,201.66684343399498)" x="168.57142857142858" y="201.66684343399498">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#e15759"/>
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #e15759"/>
       </g>
-      <g class="node" id="node-5" y="320.59458474983387" x="168.57142857142858" transform="translate(168.57142857142858,320.59458474983387)">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#59a14f"/>
+      <g class="node" transform="translate(168.57142857142858,320.59458474983387)" x="168.57142857142858" y="320.59458474983387" id="node-5">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #59a14f"/>
       </g>
-      <g class="node" id="node-6" y="175.66684343399498" x="168.57142857142858" transform="translate(168.57142857142858,175.66684343399498)">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#edc949"/>
+      <g class="node" transform="translate(168.57142857142858,175.66684343399498)" id="node-6" y="175.66684343399498" x="168.57142857142858">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #edc949"/>
       </g>
-      <g class="node" transform="translate(252.8571428571429,245.05598415110927)" y="245.05598415110927" id="node-27" x="252.8571428571429">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#af7aa1"/>
+      <g class="node" id="node-27" y="245.05598415110927" x="252.8571428571429" transform="translate(252.8571428571429,245.05598415110927)">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #af7aa1"/>
       </g>
-      <g class="node" id="node-12" y="313.6075786607503" x="337.14285714285717" transform="translate(337.14285714285717,313.6075786607503)">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" y="313.6075786607503" x="337.14285714285717" transform="translate(337.14285714285717,313.6075786607503)" id="node-12">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" x="337.14285714285717" transform="translate(337.14285714285717,276.0893535061836)" id="node-16" y="276.0893535061836">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#edc949"/>
+      <g class="node" transform="translate(337.14285714285717,276.0893535061836)" x="337.14285714285717" y="276.0893535061836" id="node-16">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #edc949"/>
       </g>
-      <g class="node" y="231.76250967242714" x="421.42857142857144" transform="translate(421.42857142857144,231.76250967242714)" id="node-18">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#ff9da7"/>
+      <g class="node" id="node-18" transform="translate(421.42857142857144,231.76250967242714)" y="231.76250967242714" x="421.42857142857144">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #ff9da7"/>
       </g>
-      <g class="node" y="173.5" x="505.7142857142858" id="node-29" transform="translate(505.7142857142858,173.5)">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#9c755f"/>
+      <g class="node" transform="translate(505.7142857142858,173.5)" id="node-29" x="505.7142857142858" y="173.5">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #9c755f"/>
       </g>
-      <g class="node" transform="translate(590,191)" x="590" y="191" id="node-4">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#76b7b2"/>
+      <g class="node" id="node-4" x="590" y="191" transform="translate(590,191)">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #76b7b2"/>
       </g>
-      <g class="node" x="590" transform="translate(590,217)" id="node-13" y="217">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#e15759"/>
+      <g class="node" transform="translate(590,217)" id="node-13" x="590" y="217">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #e15759"/>
       </g>
-      <g class="node" x="590" id="node-14" y="373" transform="translate(590,373)">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#76b7b2"/>
+      <g class="node" transform="translate(590,373)" id="node-14" x="590" y="373">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #76b7b2"/>
       </g>
-      <g class="node" x="590" y="399" id="node-15" transform="translate(590,399)">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#59a14f"/>
+      <g class="node" y="399" id="node-15" transform="translate(590,399)" x="590">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #59a14f"/>
       </g>
-      <g class="node" y="243" transform="translate(590,243)" id="node-17" x="590">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#af7aa1"/>
+      <g class="node" transform="translate(590,243)" id="node-17" y="243" x="590">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #af7aa1"/>
       </g>
-      <g class="node" x="590" y="61" transform="translate(590,61)" id="node-19">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#9c755f"/>
+      <g class="node" transform="translate(590,61)" id="node-19" y="61" x="590">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #9c755f"/>
       </g>
-      <g class="node" y="269" x="590" transform="translate(590,269)" id="node-20">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#bab0ab"/>
+      <g class="node" transform="translate(590,269)" y="269" id="node-20" x="590">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #bab0ab"/>
       </g>
-      <g class="node" transform="translate(590,295)" x="590" id="node-21" y="295">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" transform="translate(590,295)" y="295" x="590" id="node-21">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" y="321" id="node-22" transform="translate(590,321)" x="590">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" transform="translate(590,321)" x="590" y="321" id="node-22">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" id="node-23" y="347" transform="translate(590,347)" x="590">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#e15759"/>
+      <g class="node" transform="translate(590,347)" id="node-23" x="590" y="347">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #e15759"/>
       </g>
-      <g class="node" x="590" transform="translate(590,87)" y="87" id="node-31">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" id="node-31" x="590" transform="translate(590,87)" y="87">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" transform="translate(590,113)" y="113" id="node-32" x="590">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" id="node-32" transform="translate(590,113)" x="590" y="113">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" y="139" x="590" transform="translate(590,139)" id="node-33">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#e15759"/>
+      <g class="node" x="590" id="node-33" transform="translate(590,139)" y="139">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #e15759"/>
       </g>
-      <g class="node" id="node-34" transform="translate(590,165)" x="590" y="165">
-        <rect x="0" y="0" width="10" height="1" class="sankey-node" fill="#76b7b2"/>
+      <g class="node" y="165" id="node-34" x="590" transform="translate(590,165)">
+        <rect x="0" y="0" width="10" height="1" class="sankey-node" style="fill: #76b7b2"/>
       </g>
     </g>
     <g class="node-labels" font-size="14">
@@ -424,39 +424,39 @@ marker path {
       <text x="584" y="165.5" dy="0em" text-anchor="end">National navigation
 33.22</text>
     </g>
-    <g class="links" fill="none" stroke-opacity="0.5">
+    <g class="links" stroke-opacity="0.5" fill="none">
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,35.50000000000003 C47.142857142857146,35.50000000000003 47.142857142857146,340.61202370043213 84.28571428571429,340.61202370043213" stroke="url(#linearGradient-1)" stroke-width="1"/>
+        <path d="M10,35.50000000000003 C47.142857142857146,35.50000000000003 47.142857142857146,340.61202370043213 84.28571428571429,340.61202370043213" stroke-width="1" stroke="url(#linearGradient-1)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M94.28571428571429,340.61202370043213 C131.42857142857144,340.61202370043213 131.42857142857144,202.16684343399498 168.57142857142858,202.16684343399498" stroke-width="1" stroke="url(#linearGradient-2)"/>
+        <path d="M94.28571428571429,340.61202370043213 C131.42857142857144,340.61202370043213 131.42857142857144,202.16684343399498 168.57142857142858,202.16684343399498" stroke="url(#linearGradient-2)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M94.28571428571429,341.61202370043213 C342.14285714285717,341.61202370043213 342.14285714285717,191.5 590,191.5" stroke-width="1" stroke="url(#linearGradient-3)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M94.28571428571429,342.61202370043213 C131.42857142857144,342.61202370043213 131.42857142857144,321.09458474983387 168.57142857142858,321.09458474983387" stroke-width="1" stroke="url(#linearGradient-4)"/>
+        <path d="M94.28571428571429,342.61202370043213 C131.42857142857144,342.61202370043213 131.42857142857144,321.09458474983387 168.57142857142858,321.09458474983387" stroke="url(#linearGradient-4)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M94.28571428571429,343.61202370043213 C131.42857142857144,343.61202370043213 131.42857142857144,176.16684343399498 168.57142857142858,176.16684343399498" stroke-width="1" stroke="url(#linearGradient-5)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,0.5 C89.28571428571429,0.5 89.28571428571429,203.16684343399498 168.57142857142858,203.16684343399498" stroke-width="1" stroke="url(#linearGradient-6)"/>
+        <path d="M10,0.5 C89.28571428571429,0.5 89.28571428571429,203.16684343399498 168.57142857142858,203.16684343399498" stroke="url(#linearGradient-6)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,61.5 C89.28571428571429,61.5 89.28571428571429,322.09458474983387 168.57142857142858,322.09458474983387" stroke-width="1" stroke="url(#linearGradient-7)"/>
+        <path d="M10,61.5 C89.28571428571429,61.5 89.28571428571429,322.09458474983387 168.57142857142858,322.09458474983387" stroke="url(#linearGradient-7)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M10,0.5 C47.142857142857146,0.5 47.142857142857146,191.29729237491694 84.28571428571429,191.29729237491694" stroke-width="1" stroke="url(#linearGradient-8)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,0.5 C47.142857142857146,0.5 47.142857142857146,192.29729237491694 84.28571428571429,192.29729237491694" stroke="url(#linearGradient-9)" stroke-width="1"/>
+        <path d="M10,0.5 C47.142857142857146,0.5 47.142857142857146,192.29729237491694 84.28571428571429,192.29729237491694" stroke-width="1" stroke="url(#linearGradient-9)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M94.28571428571429,191.29729237491694 C131.42857142857144,191.29729237491694 131.42857142857144,323.09458474983387 168.57142857142858,323.09458474983387" stroke-width="1" stroke="url(#linearGradient-10)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M347.14285714285717,314.1075786607503 C468.57142857142856,314.1075786607503 468.57142857142856,217.5 590,217.5" stroke="url(#linearGradient-11)" stroke-width="1"/>
+        <path d="M347.14285714285717,314.1075786607503 C468.57142857142856,314.1075786607503 468.57142857142856,217.5 590,217.5" stroke-width="1" stroke="url(#linearGradient-11)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M347.14285714285717,315.1075786607503 C468.57142857142856,315.1075786607503 468.57142857142856,373.5 590,373.5" stroke="url(#linearGradient-12)" stroke-width="1"/>
@@ -465,7 +465,7 @@ marker path {
         <path d="M347.14285714285717,316.1075786607503 C468.57142857142856,316.1075786607503 468.57142857142856,399.5 590,399.5" stroke-width="1" stroke="url(#linearGradient-13)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M347.14285714285717,276.5893535061836 C468.57142857142856,276.5893535061836 468.57142857142856,243.5 590,243.5" stroke-width="1" stroke="url(#linearGradient-14)"/>
+        <path d="M347.14285714285717,276.5893535061836 C468.57142857142856,276.5893535061836 468.57142857142856,243.5 590,243.5" stroke="url(#linearGradient-14)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M347.14285714285717,277.5893535061836 C468.57142857142856,277.5893535061836 468.57142857142856,400.5 590,400.5" stroke="url(#linearGradient-15)" stroke-width="1"/>
@@ -480,37 +480,37 @@ marker path {
         <path d="M347.14285714285717,280.5893535061836 C468.57142857142856,280.5893535061836 468.57142857142856,61.5 590,61.5" stroke="url(#linearGradient-18)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M347.14285714285717,281.5893535061836 C468.57142857142856,281.5893535061836 468.57142857142856,269.5 590,269.5" stroke-width="1" stroke="url(#linearGradient-19)"/>
+        <path d="M347.14285714285717,281.5893535061836 C468.57142857142856,281.5893535061836 468.57142857142856,269.5 590,269.5" stroke="url(#linearGradient-19)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M347.14285714285717,282.5893535061836 C468.57142857142856,282.5893535061836 468.57142857142856,374.5 590,374.5" stroke-width="1" stroke="url(#linearGradient-20)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M347.14285714285717,283.5893535061836 C468.57142857142856,283.5893535061836 468.57142857142856,192.5 590,192.5" stroke="url(#linearGradient-21)" stroke-width="1"/>
+        <path d="M347.14285714285717,283.5893535061836 C468.57142857142856,283.5893535061836 468.57142857142856,192.5 590,192.5" stroke-width="1" stroke="url(#linearGradient-21)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M347.14285714285717,284.5893535061836 C468.57142857142856,284.5893535061836 468.57142857142856,295.5 590,295.5" stroke="url(#linearGradient-22)" stroke-width="1"/>
+        <path d="M347.14285714285717,284.5893535061836 C468.57142857142856,284.5893535061836 468.57142857142856,295.5 590,295.5" stroke-width="1" stroke="url(#linearGradient-22)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M347.14285714285717,285.5893535061836 C468.57142857142856,285.5893535061836 468.57142857142856,321.5 590,321.5" stroke-width="1" stroke="url(#linearGradient-23)"/>
+        <path d="M347.14285714285717,285.5893535061836 C468.57142857142856,285.5893535061836 468.57142857142856,321.5 590,321.5" stroke="url(#linearGradient-23)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M347.14285714285717,286.5893535061836 C468.57142857142856,286.5893535061836 468.57142857142856,347.5 590,347.5" stroke-width="1" stroke="url(#linearGradient-24)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,0.5 C47.142857142857146,0.5 47.142857142857146,144.8334217169975 84.28571428571429,144.8334217169975" stroke-width="1" stroke="url(#linearGradient-25)"/>
+        <path d="M10,0.5 C47.142857142857146,0.5 47.142857142857146,144.8334217169975 84.28571428571429,144.8334217169975" stroke="url(#linearGradient-25)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,9.500000000000028 C47.142857142857146,9.500000000000028 47.142857142857146,145.8334217169975 84.28571428571429,145.8334217169975" stroke="url(#linearGradient-26)" stroke-width="1"/>
+        <path d="M10,9.500000000000028 C47.142857142857146,9.500000000000028 47.142857142857146,145.8334217169975 84.28571428571429,145.8334217169975" stroke-width="1" stroke="url(#linearGradient-26)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M178.57142857142858,176.16684343399498 C384.2857142857143,176.16684343399498 384.2857142857143,375.5 590,375.5" stroke="url(#linearGradient-27)" stroke-width="1"/>
+        <path d="M178.57142857142858,176.16684343399498 C384.2857142857143,176.16684343399498 384.2857142857143,375.5 590,375.5" stroke-width="1" stroke="url(#linearGradient-27)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M178.57142857142858,177.16684343399498 C384.2857142857143,177.16684343399498 384.2857142857143,193.5 590,193.5" stroke-width="1" stroke="url(#linearGradient-28)"/>
+        <path d="M178.57142857142858,177.16684343399498 C384.2857142857143,177.16684343399498 384.2857142857143,193.5 590,193.5" stroke="url(#linearGradient-28)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M178.57142857142858,178.16684343399498 C215.71428571428572,178.16684343399498 215.71428571428572,245.55598415110927 252.8571428571429,245.55598415110927" stroke-width="1" stroke="url(#linearGradient-29)"/>
+        <path d="M178.57142857142858,178.16684343399498 C215.71428571428572,178.16684343399498 215.71428571428572,245.55598415110927 252.8571428571429,245.55598415110927" stroke="url(#linearGradient-29)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M178.57142857142858,179.16684343399498 C384.2857142857143,179.16684343399498 384.2857142857143,270.5 590,270.5" stroke-width="1" stroke="url(#linearGradient-30)"/>
@@ -519,52 +519,52 @@ marker path {
         <path d="M178.57142857142858,180.16684343399498 C384.2857142857143,180.16684343399498 384.2857142857143,219.5 590,219.5" stroke-width="1" stroke="url(#linearGradient-31)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,87.5 C173.57142857142858,87.5 173.57142857142858,276.5893535061836 337.14285714285717,276.5893535061836" stroke="url(#linearGradient-32)" stroke-width="1"/>
+        <path d="M10,87.5 C173.57142857142858,87.5 173.57142857142858,276.5893535061836 337.14285714285717,276.5893535061836" stroke-width="1" stroke="url(#linearGradient-32)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M431.42857142857144,232.26250967242714 C468.5714285714286,232.26250967242714 468.5714285714286,174 505.7142857142858,174" stroke="url(#linearGradient-33)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M431.42857142857144,233.26250967242714 C510.7142857142857,233.26250967242714 510.7142857142857,194.5 590,194.5" stroke="url(#linearGradient-34)" stroke-width="1"/>
+        <path d="M431.42857142857144,233.26250967242714 C510.7142857142857,233.26250967242714 510.7142857142857,194.5 590,194.5" stroke-width="1" stroke="url(#linearGradient-34)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M515.7142857142858,174 C552.8571428571429,174 552.8571428571429,62.5 590,62.5" stroke="url(#linearGradient-35)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,113.5 C173.57142857142858,113.5 173.57142857142858,277.5893535061836 337.14285714285717,277.5893535061836" stroke-width="1" stroke="url(#linearGradient-36)"/>
+        <path d="M10,113.5 C173.57142857142858,113.5 173.57142857142858,277.5893535061836 337.14285714285717,277.5893535061836" stroke="url(#linearGradient-36)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M178.57142857142858,202.16684343399498 C384.2857142857143,202.16684343399498 384.2857142857143,220.5 590,220.5" stroke-width="1" stroke="url(#linearGradient-37)"/>
+        <path d="M178.57142857142858,202.16684343399498 C384.2857142857143,202.16684343399498 384.2857142857143,220.5 590,220.5" stroke="url(#linearGradient-37)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M178.57142857142858,203.16684343399498 C384.2857142857143,203.16684343399498 384.2857142857143,87.5 590,87.5" stroke="url(#linearGradient-38)" stroke-width="1"/>
+        <path d="M178.57142857142858,203.16684343399498 C384.2857142857143,203.16684343399498 384.2857142857143,87.5 590,87.5" stroke-width="1" stroke="url(#linearGradient-38)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M178.57142857142858,204.16684343399498 C384.2857142857143,204.16684343399498 384.2857142857143,63.5 590,63.5" stroke-width="1" stroke="url(#linearGradient-39)"/>
+        <path d="M178.57142857142858,204.16684343399498 C384.2857142857143,204.16684343399498 384.2857142857143,63.5 590,63.5" stroke="url(#linearGradient-39)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M178.57142857142858,205.16684343399498 C384.2857142857143,205.16684343399498 384.2857142857143,113.5 590,113.5" stroke="url(#linearGradient-40)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M178.57142857142858,206.16684343399498 C384.2857142857143,206.16684343399498 384.2857142857143,139.5 590,139.5" stroke="url(#linearGradient-41)" stroke-width="1"/>
+        <path d="M178.57142857142858,206.16684343399498 C384.2857142857143,206.16684343399498 384.2857142857143,139.5 590,139.5" stroke-width="1" stroke="url(#linearGradient-41)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M178.57142857142858,207.16684343399498 C384.2857142857143,207.16684343399498 384.2857142857143,271.5 590,271.5" stroke-width="1" stroke="url(#linearGradient-42)"/>
+        <path d="M178.57142857142858,207.16684343399498 C384.2857142857143,207.16684343399498 384.2857142857143,271.5 590,271.5" stroke="url(#linearGradient-42)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M178.57142857142858,208.16684343399498 C384.2857142857143,208.16684343399498 384.2857142857143,165.5 590,165.5" stroke="url(#linearGradient-43)" stroke-width="1"/>
+        <path d="M178.57142857142858,208.16684343399498 C384.2857142857143,208.16684343399498 384.2857142857143,165.5 590,165.5" stroke-width="1" stroke="url(#linearGradient-43)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M178.57142857142858,209.16684343399498 C384.2857142857143,209.16684343399498 384.2857142857143,296.5 590,296.5" stroke="url(#linearGradient-44)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,217.5 C47.142857142857146,217.5 47.142857142857146,341.61202370043213 84.28571428571429,341.61202370043213" stroke="url(#linearGradient-45)" stroke-width="1"/>
+        <path d="M10,217.5 C47.142857142857146,217.5 47.142857142857146,341.61202370043213 84.28571428571429,341.61202370043213" stroke-width="1" stroke="url(#linearGradient-45)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M94.28571428571429,144.8334217169975 C131.42857142857144,144.8334217169975 131.42857142857144,177.16684343399498 168.57142857142858,177.16684343399498" stroke="url(#linearGradient-46)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,139.5 C131.42857142857144,139.5 131.42857142857144,246.55598415110927 252.8571428571429,246.55598415110927" stroke-width="1" stroke="url(#linearGradient-47)"/>
+        <path d="M10,139.5 C131.42857142857144,139.5 131.42857142857144,246.55598415110927 252.8571428571429,246.55598415110927" stroke="url(#linearGradient-47)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M10,165.5 C47.142857142857146,165.5 47.142857142857146,222.8334217169975 84.28571428571429,222.8334217169975" stroke-width="1" stroke="url(#linearGradient-48)"/>
@@ -576,31 +576,31 @@ marker path {
         <path d="M94.28571428571429,222.8334217169975 C131.42857142857144,222.8334217169975 131.42857142857144,204.16684343399498 168.57142857142858,204.16684343399498" stroke-width="1" stroke="url(#linearGradient-50)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,243.5 C89.28571428571429,243.5 89.28571428571429,324.09458474983387 168.57142857142858,324.09458474983387" stroke="url(#linearGradient-51)" stroke-width="1"/>
+        <path d="M10,243.5 C89.28571428571429,243.5 89.28571428571429,324.09458474983387 168.57142857142858,324.09458474983387" stroke-width="1" stroke="url(#linearGradient-51)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,244.5 C47.142857142857146,244.5 47.142857142857146,342.61202370043213 84.28571428571429,342.61202370043213" stroke="url(#linearGradient-52)" stroke-width="1"/>
+        <path d="M10,244.5 C47.142857142857146,244.5 47.142857142857146,342.61202370043213 84.28571428571429,342.61202370043213" stroke-width="1" stroke="url(#linearGradient-52)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,347.5 C300,347.5 300,401.5 590,401.5" stroke="url(#linearGradient-53)" stroke-width="1"/>
+        <path d="M10,347.5 C300,347.5 300,401.5 590,401.5" stroke-width="1" stroke="url(#linearGradient-53)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,348.5 C300,348.5 300,376.5 590,376.5" stroke="url(#linearGradient-54)" stroke-width="1"/>
+        <path d="M10,348.5 C300,348.5 300,376.5 590,376.5" stroke-width="1" stroke="url(#linearGradient-54)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M94.28571428571429,312.04467675309184 C215.71428571428572,312.04467675309184 215.71428571428572,278.5893535061836 337.14285714285717,278.5893535061836" stroke="url(#linearGradient-55)" stroke-width="1"/>
+        <path d="M94.28571428571429,312.04467675309184 C215.71428571428572,312.04467675309184 215.71428571428572,278.5893535061836 337.14285714285717,278.5893535061836" stroke-width="1" stroke="url(#linearGradient-55)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M94.28571428571429,386.5 C342.14285714285717,386.5 342.14285714285717,402.5 590,402.5" stroke="url(#linearGradient-56)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,295.5 C47.142857142857146,295.5 47.142857142857146,386.5 84.28571428571429,386.5" stroke-width="1" stroke="url(#linearGradient-57)"/>
+        <path d="M10,295.5 C47.142857142857146,295.5 47.142857142857146,386.5 84.28571428571429,386.5" stroke="url(#linearGradient-57)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,296.5 C47.142857142857146,296.5 47.142857142857146,312.04467675309184 84.28571428571429,312.04467675309184" stroke="url(#linearGradient-58)" stroke-width="1"/>
+        <path d="M10,296.5 C47.142857142857146,296.5 47.142857142857146,312.04467675309184 84.28571428571429,312.04467675309184" stroke-width="1" stroke="url(#linearGradient-58)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M178.57142857142858,321.09458474983387 C384.2857142857143,321.09458474983387 384.2857142857143,272.5 590,272.5" stroke="url(#linearGradient-59)" stroke-width="1"/>
+        <path d="M178.57142857142858,321.09458474983387 C384.2857142857143,321.09458474983387 384.2857142857143,272.5 590,272.5" stroke-width="1" stroke="url(#linearGradient-59)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M178.57142857142858,322.09458474983387 C215.71428571428572,322.09458474983387 215.71428571428572,247.55598415110927 252.8571428571429,247.55598415110927" stroke="url(#linearGradient-60)" stroke-width="1"/>
@@ -609,10 +609,10 @@ marker path {
         <path d="M178.57142857142858,323.09458474983387 C384.2857142857143,323.09458474983387 384.2857142857143,221.5 590,221.5" stroke-width="1" stroke="url(#linearGradient-61)"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M262.8571428571429,245.55598415110927 C300,245.55598415110927 300,279.5893535061836 337.14285714285717,279.5893535061836" stroke-width="1" stroke="url(#linearGradient-62)"/>
+        <path d="M262.8571428571429,245.55598415110927 C300,245.55598415110927 300,279.5893535061836 337.14285714285717,279.5893535061836" stroke="url(#linearGradient-62)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M262.8571428571429,246.55598415110927 C426.42857142857144,246.55598415110927 426.42857142857144,195.5 590,195.5" stroke-width="1" stroke="url(#linearGradient-63)"/>
+        <path d="M262.8571428571429,246.55598415110927 C426.42857142857144,246.55598415110927 426.42857142857144,195.5 590,195.5" stroke="url(#linearGradient-63)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M262.8571428571429,247.55598415110927 C300,247.55598415110927 300,314.1075786607503 337.14285714285717,314.1075786607503" stroke="url(#linearGradient-64)" stroke-width="1"/>
@@ -624,7 +624,7 @@ marker path {
         <path d="M10,399.5 C47.142857142857146,399.5 47.142857142857146,343.61202370043213 84.28571428571429,343.61202370043213" stroke="url(#linearGradient-66)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,321.5 C173.57142857142858,321.5 173.57142857142858,281.5893535061836 337.14285714285717,281.5893535061836" stroke-width="1" stroke="url(#linearGradient-67)"/>
+        <path d="M10,321.5 C173.57142857142858,321.5 173.57142857142858,281.5893535061836 337.14285714285717,281.5893535061836" stroke="url(#linearGradient-67)" stroke-width="1"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M10,373.5 C173.57142857142858,373.5 173.57142857142858,282.5893535061836 337.14285714285717,282.5893535061836" stroke="url(#linearGradient-68)" stroke-width="1"/>

--- a/docs/images/sankey_quoted.svg
+++ b/docs/images/sankey_quoted.svg
@@ -116,23 +116,23 @@ marker path {
 
     </g>
     <g class="nodes">
-      <g class="node" transform="translate(0,0)" y="0" id="node-1" x="0">
-        <rect x="0" y="0" width="10" height="89.52453337620767" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" id="node-1" transform="translate(0,0)" y="0" x="0">
+        <rect x="0" y="0" width="10" height="89.52453337620767" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" id="node-3" y="114.52453337620769" x="0" transform="translate(0,114.52453337620769)">
-        <rect x="0" y="0" width="10" height="202.91119166289081" class="sankey-node" fill="#e15759"/>
+      <g class="node" id="node-3" transform="translate(0,114.52453337620769)" x="0" y="114.52453337620769">
+        <rect x="0" y="0" width="10" height="202.91119166289081" class="sankey-node" style="fill: #e15759"/>
       </g>
-      <g class="node" id="node-5" transform="translate(0,342.4357250390985)" y="342.4357250390985" x="0">
-        <rect x="0" y="0" width="10" height="57.564274960901514" class="sankey-node" fill="#59a14f"/>
+      <g class="node" x="0" y="342.4357250390985" id="node-5" transform="translate(0,342.4357250390985)">
+        <rect x="0" y="0" width="10" height="57.564274960901514" class="sankey-node" style="fill: #59a14f"/>
       </g>
       <g class="node" x="590" id="node-2" y="0" transform="translate(590,0)">
-        <rect x="0" y="0" width="10" height="89.52453337620767" class="sankey-node" fill="#f28e2c"/>
+        <rect x="0" y="0" width="10" height="89.52453337620767" class="sankey-node" style="fill: #f28e2c"/>
       </g>
-      <g class="node" y="114.52453337620769" id="node-4" x="590" transform="translate(590,114.52453337620769)">
-        <rect x="0" y="0" width="10" height="202.91119166289081" class="sankey-node" fill="#76b7b2"/>
+      <g class="node" id="node-4" transform="translate(590,114.52453337620769)" x="590" y="114.52453337620769">
+        <rect x="0" y="0" width="10" height="202.91119166289081" class="sankey-node" style="fill: #76b7b2"/>
       </g>
-      <g class="node" x="590" id="node-6" y="342.4357250390985" transform="translate(590,342.4357250390985)">
-        <rect x="0" y="0" width="10" height="57.564274960901514" class="sankey-node" fill="#edc949"/>
+      <g class="node" id="node-6" y="342.4357250390985" transform="translate(590,342.4357250390985)" x="590">
+        <rect x="0" y="0" width="10" height="57.564274960901514" class="sankey-node" style="fill: #edc949"/>
       </g>
     </g>
     <g class="node-labels" font-size="14">
@@ -151,13 +151,13 @@ marker path {
     </g>
     <g class="links" fill="none" stroke-opacity="0.5">
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,44.762266688103836 C300,44.762266688103836 300,44.762266688103836 590,44.762266688103836" stroke-width="89.52453337620767" stroke="url(#linearGradient-1)"/>
+        <path d="M10,44.762266688103836 C300,44.762266688103836 300,44.762266688103836 590,44.762266688103836" stroke="url(#linearGradient-1)" stroke-width="89.52453337620767"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
         <path d="M10,215.98012920765308 C300,215.98012920765308 300,215.98012920765308 590,215.98012920765308" stroke="url(#linearGradient-2)" stroke-width="202.9111916628908"/>
       </g>
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,371.21786251954927 C300,371.21786251954927 300,371.21786251954927 590,371.21786251954927" stroke-width="57.56427496090153" stroke="url(#linearGradient-3)"/>
+        <path d="M10,371.21786251954927 C300,371.21786251954927 300,371.21786251954927 590,371.21786251954927" stroke="url(#linearGradient-3)" stroke-width="57.56427496090153"/>
       </g>
     </g>
   </g>

--- a/docs/images/sankey_simple.svg
+++ b/docs/images/sankey_simple.svg
@@ -114,11 +114,11 @@ marker path {
 
     </g>
     <g class="nodes">
-      <g class="node" id="node-1" y="0" x="0" transform="translate(0,0)">
-        <rect x="0" y="0" width="10" height="400" class="sankey-node" fill="#4e79a7"/>
+      <g class="node" id="node-1" x="0" transform="translate(0,0)" y="0">
+        <rect x="0" y="0" width="10" height="400" class="sankey-node" style="fill: #4e79a7"/>
       </g>
-      <g class="node" y="0" transform="translate(590,0)" x="590" id="node-2">
-        <rect x="0" y="0" width="10" height="400" class="sankey-node" fill="#f28e2c"/>
+      <g class="node" transform="translate(590,0)" id="node-2" x="590" y="0">
+        <rect x="0" y="0" width="10" height="400" class="sankey-node" style="fill: #f28e2c"/>
       </g>
     </g>
     <g class="node-labels" font-size="14">
@@ -129,7 +129,7 @@ marker path {
     </g>
     <g class="links" fill="none" stroke-opacity="0.5">
       <g class="link" style="mix-blend-mode: multiply">
-        <path d="M10,200 C300,200 300,200 590,200" stroke-width="400" stroke="url(#linearGradient-1)"/>
+        <path d="M10,200 C300,200 300,200 590,200" stroke="url(#linearGradient-1)" stroke-width="400"/>
       </g>
     </g>
   </g>

--- a/src/render/sankey.rs
+++ b/src/render/sankey.rs
@@ -592,6 +592,9 @@ fn render_nodes(nodes: &[LayoutNode], config: &RenderConfig) -> SvgElement {
         let color = &colors[node.index % colors.len()];
 
         // Rect uses local coordinates (0,0) since group has the transform
+        // Use inline style for fill color instead of presentation attribute
+        // because CSS rules like ".node rect { fill: #ECECFF }" override
+        // presentation attributes but not inline styles
         let rect = SvgElement::Rect {
             x: 0.0,
             y: 0.0,
@@ -599,8 +602,9 @@ fn render_nodes(nodes: &[LayoutNode], config: &RenderConfig) -> SvgElement {
             height: node.y1 - node.y0,
             rx: None,
             ry: None,
-            attrs: Attrs::new().with_fill(color).with_class("sankey-node"),
-        };
+            attrs: Attrs::new().with_class("sankey-node"),
+        }
+        .with_style(&format!("fill: {}", color));
 
         // Group has transform for positioning, x/y are data attributes for tests
         let node_group = SvgElement::Group {
@@ -827,5 +831,36 @@ mod tests {
         assert!(result.contains("stroke-width="));
         // Links should have fill="none"
         assert!(result.contains("fill=\"none\""));
+    }
+
+    #[test]
+    fn test_node_colors_use_inline_style() {
+        // Node colors must use inline style (style="fill: #color") instead of
+        // presentation attributes (fill="#color") because CSS rules like
+        // ".node rect { fill: #ECECFF }" override presentation attributes but
+        // not inline styles. This ensures sankey node colors are visible.
+        let mut db = SankeyDb::new();
+        db.add_link("A", "B", 10.0);
+
+        let config = RenderConfig::default();
+        let result = render_sankey(&db, &config).unwrap();
+
+        // Sankey nodes should use inline style for fill, not presentation attribute
+        // The default theme colors start with #4e79a7 and #f28e2c
+        assert!(
+            result.contains(r#"style="fill: #"#),
+            "Sankey nodes should use inline style for fill color. Got: {}",
+            result
+        );
+
+        // Should NOT have presentation attribute fill on rect inside node
+        // (which would be overridden by CSS .node rect rules)
+        // Check that we don't have patterns like: <rect ... fill="#4e79a7" ... class="sankey-node">
+        let has_presentation_fill =
+            result.contains("fill=\"#4e79a7\"") || result.contains("fill=\"#f28e2c\"");
+        assert!(
+            !has_presentation_fill,
+            "Sankey nodes should NOT use presentation attribute fill (gets overridden by CSS)"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Fixed CSS specificity issue where generic `.node rect { fill: #ECECFF }` was overriding sankey node colors
- Changed from SVG presentation attributes to inline styles for node fill colors (inline styles have highest CSS specificity)
- Added regression test to prevent future CSS override issues

## Results
Visual similarity scores improved significantly:
- sankey: 87% → **99%**
- sankey_simple: 31% → **98%**
- sankey_chain: -8% → **96%**
- sankey_quoted: 84% → **99%**
- sankey_commas: 69% → **96%**
- sankey_double_quotes: 69% → **96%**

## Test plan
- [x] Added test `test_node_colors_use_inline_style` that verifies:
  - Sankey nodes use inline style for fill color
  - No presentation attribute fill that would be CSS-overridable
- [x] All existing tests pass
- [x] Ran `cargo clippy --features all-formats -- -D warnings` with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)