### PR TITLE
Improve pie chart visual parity with mermaid

### DIFF
--- a/docs/images/example_pie_netflix.svg
+++ b/docs/images/example_pie_netflix.svg
@@ -124,15 +124,15 @@ marker path {
     <g class="nodes">
 
     </g>
-    <circle cx="210" cy="245" r="186" class="pieOuterCircle" stroke="black" fill="none" stroke-width="2"/>
-    <path d="M 210 245 L 210 60 A 185 185 0 1 1 101.25972832589245 95.33185604063473 Z" class="pieCircle" fill="hsl(240, 100%, 96.27450980392157%)" stroke-width="2" stroke="black" opacity="0.7"/>
-    <path d="M 210 245 L 101.25972832589245 95.33185604063473 A 185 185 0 0 1 209.99999999999997 60 Z" class="pieCircle" opacity="0.7" stroke="black" fill="hsl(60, 100%, 93.52941176470588%)" stroke-width="2"/>
-    <text x="210" y="25" class="pie-title" text-anchor="middle" font-size="20" font-weight="bold">NETFLIX</text>
-    <text x="252.87610796952396" y="376.9590916359525" class="slice" dominant-baseline="middle" font-size="17" text-anchor="middle">90%</text>
-    <text x="167.12389203047604" y="113.04090836404745" class="slice" font-size="17" dominant-baseline="middle" text-anchor="middle">10%</text>
+    <circle cx="210" cy="245" r="186" class="pieOuterCircle" stroke="black" stroke-width="2" fill="none"/>
+    <path d="M 210 245 L 210 60 A 185 185 0 1 1 101.25972832589245 95.33185604063473 Z" class="pieCircle" stroke-width="2" fill="#ececff" opacity="0.7" stroke="black"/>
+    <path d="M 210 245 L 101.25972832589245 95.33185604063473 A 185 185 0 0 1 209.99999999999997 60 Z" class="pieCircle" opacity="0.7" stroke="black" stroke-width="2" fill="#ffffde"/>
+    <text x="210" y="25" class="pie-title" font-size="20" text-anchor="middle" font-weight="bold">NETFLIX</text>
+    <text x="252.87610796952396" y="376.9590916359525" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">90%</text>
+    <text x="167.12389203047604" y="113.04090836404745" class="slice" text-anchor="middle" font-size="17" dominant-baseline="middle">10%</text>
     <g class="legend">
-      <rect x="430" y="175" width="18" height="18" class="legend" fill="hsl(240, 100%, 96.27450980392157%)" stroke="hsl(240, 100%, 96.27450980392157%)"/>
-      <rect x="430" y="197" width="18" height="18" class="legend" fill="hsl(60, 100%, 93.52941176470588%)" stroke="hsl(60, 100%, 93.52941176470588%)"/>
+      <rect x="430" y="175" width="18" height="18" class="legend" fill="#ececff" stroke="#ececff"/>
+      <rect x="430" y="197" width="18" height="18" class="legend" stroke="#ffffde" fill="#ffffde"/>
       <text x="452" y="189" class="legend" font-size="17">Time spent looking for movie</text>
       <text x="452" y="211" class="legend" font-size="17">Time spent watching it</text>
     </g>

--- a/docs/images/example_pie_voldemort.svg
+++ b/docs/images/example_pie_voldemort.svg
@@ -124,18 +124,18 @@ marker path {
     <g class="nodes">
 
     </g>
-    <circle cx="210" cy="245" r="186" class="pieOuterCircle" fill="none" stroke="black" stroke-width="2"/>
-    <path d="M 210 245 L 210 60 A 185 185 0 1 1 101.25972832589245 95.33185604063473 Z" class="pieCircle" stroke="black" stroke-width="2" fill="hsl(0, 0%, 58.03921568627452%)" opacity="0.7"/>
-    <path d="M 210 245 L 101.25972832589245 95.33185604063473 A 185 185 0 0 1 163.99237087450177 65.81211519120328 Z" class="pieCircle" stroke="black" opacity="0.7" fill="hsl(60, 100%, 93.52941176470588%)" stroke-width="2"/>
-    <path d="M 210 245 L 163.99237087450177 65.81211519120328 A 185 185 0 0 1 209.99999999999997 60 Z" class="pieCircle" fill="hsl(240, 100%, 96.27450980392157%)" stroke="black" opacity="0.7" stroke-width="2"/>
-    <text x="210" y="25" class="pie-title" font-size="20" text-anchor="middle" font-weight="bold">What Voldemort doesn&apos;t have?</text>
-    <text x="252.87610796952396" y="376.9590916359525" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">90%</text>
-    <text x="150.92312329534613" y="119.45524647033982" class="slice" font-size="17" dominant-baseline="middle" text-anchor="middle">6%</text>
-    <text x="192.61001384295275" y="107.3440851926162" class="slice" font-size="17" text-anchor="middle" dominant-baseline="middle">4%</text>
+    <circle cx="210" cy="245" r="186" class="pieOuterCircle" fill="none" stroke-width="2" stroke="black"/>
+    <path d="M 210 245 L 210 60 A 185 185 0 1 1 101.25972832589245 95.33185604063473 Z" class="pieCircle" stroke-width="2" opacity="0.7" fill="#ececff" stroke="black"/>
+    <path d="M 210 245 L 101.25972832589245 95.33185604063473 A 185 185 0 0 1 163.99237087450177 65.81211519120328 Z" class="pieCircle" fill="#ffffde" stroke="black" stroke-width="2" opacity="0.7"/>
+    <path d="M 210 245 L 163.99237087450177 65.81211519120328 A 185 185 0 0 1 209.99999999999997 60 Z" class="pieCircle" opacity="0.7" stroke="black" stroke-width="2" fill="hsl(80, 100%, 56.2745098039%)"/>
+    <text x="210" y="25" class="pie-title" text-anchor="middle" font-size="20" font-weight="bold">What Voldemort doesn&apos;t have?</text>
+    <text x="252.87610796952396" y="376.9590916359525" class="slice" font-size="17" dominant-baseline="middle" text-anchor="middle">90%</text>
+    <text x="150.92312329534613" y="119.45524647033982" class="slice" text-anchor="middle" font-size="17" dominant-baseline="middle">6%</text>
+    <text x="192.61001384295275" y="107.3440851926162" class="slice" dominant-baseline="middle" text-anchor="middle" font-size="17">4%</text>
     <g class="legend">
-      <rect x="430" y="175" width="18" height="18" class="legend" fill="hsl(240, 100%, 96.27450980392157%)" stroke="hsl(240, 100%, 96.27450980392157%)"/>
-      <rect x="430" y="197" width="18" height="18" class="legend" fill="hsl(60, 100%, 93.52941176470588%)" stroke="hsl(60, 100%, 93.52941176470588%)"/>
-      <rect x="430" y="219" width="18" height="18" class="legend" stroke="hsl(0, 0%, 58.03921568627452%)" fill="hsl(0, 0%, 58.03921568627452%)"/>
+      <rect x="430" y="175" width="18" height="18" class="legend" stroke="hsl(80, 100%, 56.2745098039%)" fill="hsl(80, 100%, 56.2745098039%)"/>
+      <rect x="430" y="197" width="18" height="18" class="legend" stroke="#ffffde" fill="#ffffde"/>
+      <rect x="430" y="219" width="18" height="18" class="legend" fill="#ececff" stroke="#ececff"/>
       <text x="452" y="189" class="legend" font-size="17">FRIENDS</text>
       <text x="452" y="211" class="legend" font-size="17">FAMILY</text>
       <text x="452" y="233" class="legend" font-size="17">NOSE</text>

--- a/docs/images/pie.svg
+++ b/docs/images/pie.svg
@@ -124,21 +124,21 @@ marker path {
     <g class="nodes">
 
     </g>
-    <circle cx="210" cy="245" r="186" class="pieOuterCircle" stroke-width="2" stroke="black" fill="none"/>
-    <path d="M 210 245 L 210 60 A 185 185 0 0 1 318.74027167410753 394.66814395936524 Z" class="pieCircle" stroke-width="2" fill="hsl(240, 100%, 96.27450980392157%)" stroke="black" opacity="0.7"/>
-    <path d="M 210 245 L 318.74027167410753 394.66814395936524 A 185 185 0 0 1 60.33185604063473 353.74027167410753 Z" class="pieCircle" opacity="0.7" stroke-width="2" stroke="black" fill="hsl(60, 100%, 93.52941176470588%)"/>
-    <path d="M 210 245 L 60.33185604063473 353.74027167410753 A 185 185 0 0 1 60.33185604063473 136.2597283258925 Z" class="pieCircle" stroke="black" stroke-width="2" fill="hsl(240, 100%, 86.27450980392157%)" opacity="0.7"/>
-    <path d="M 210 245 L 60.33185604063473 136.2597283258925 A 185 185 0 0 1 209.99999999999997 60 Z" class="pieCircle" stroke="black" fill="hsl(0, 0%, 58.03921568627452%)" opacity="0.7" stroke-width="2"/>
-    <text x="210" y="25" class="pie-title" font-size="20" font-weight="bold" text-anchor="middle">Project Distribution</text>
+    <circle cx="210" cy="245" r="186" class="pieOuterCircle" stroke-width="2" fill="none" stroke="black"/>
+    <path d="M 210 245 L 210 60 A 185 185 0 0 1 318.74027167410753 394.66814395936524 Z" class="pieCircle" stroke-width="2" stroke="black" fill="#ececff" opacity="0.7"/>
+    <path d="M 210 245 L 318.74027167410753 394.66814395936524 A 185 185 0 0 1 60.33185604063473 353.74027167410753 Z" class="pieCircle" stroke-width="2" opacity="0.7" stroke="black" fill="#ffffde"/>
+    <path d="M 210 245 L 60.33185604063473 353.74027167410753 A 185 185 0 0 1 60.33185604063473 136.2597283258925 Z" class="pieCircle" fill="hsl(80, 100%, 56.2745098039%)" stroke-width="2" opacity="0.7" stroke="black"/>
+    <path d="M 210 245 L 60.33185604063473 136.2597283258925 A 185 185 0 0 1 209.99999999999997 60 Z" class="pieCircle" fill="hsl(240, 100%, 86.2745098039%)" stroke="black" stroke-width="2" opacity="0.7"/>
+    <text x="210" y="25" class="pie-title" text-anchor="middle" font-size="20" font-weight="bold">Project Distribution</text>
     <text x="341.9590916359525" y="202.12389203047604" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">40%</text>
-    <text x="188.29471797566796" y="382.04175725757534" class="slice" font-size="17" dominant-baseline="middle" text-anchor="middle">25%</text>
-    <text x="71.25" y="245.00000000000003" class="slice" dominant-baseline="middle" font-size="17" text-anchor="middle">20%</text>
-    <text x="147.00881816113787" y="121.37284476886397" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">15%</text>
+    <text x="188.29471797566796" y="382.04175725757534" class="slice" text-anchor="middle" font-size="17" dominant-baseline="middle">25%</text>
+    <text x="71.25" y="245.00000000000003" class="slice" dominant-baseline="middle" text-anchor="middle" font-size="17">20%</text>
+    <text x="147.00881816113787" y="121.37284476886397" class="slice" dominant-baseline="middle" font-size="17" text-anchor="middle">15%</text>
     <g class="legend">
-      <rect x="430" y="175" width="18" height="18" class="legend" fill="hsl(240, 100%, 96.27450980392157%)" stroke="hsl(240, 100%, 96.27450980392157%)"/>
-      <rect x="430" y="197" width="18" height="18" class="legend" fill="hsl(60, 100%, 93.52941176470588%)" stroke="hsl(60, 100%, 93.52941176470588%)"/>
-      <rect x="430" y="219" width="18" height="18" class="legend" fill="hsl(0, 0%, 58.03921568627452%)" stroke="hsl(0, 0%, 58.03921568627452%)"/>
-      <rect x="430" y="241" width="18" height="18" class="legend" fill="hsl(240, 100%, 86.27450980392157%)" stroke="hsl(240, 100%, 86.27450980392157%)"/>
+      <rect x="430" y="175" width="18" height="18" class="legend" fill="#ececff" stroke="#ececff"/>
+      <rect x="430" y="197" width="18" height="18" class="legend" fill="#ffffde" stroke="#ffffde"/>
+      <rect x="430" y="219" width="18" height="18" class="legend" stroke="hsl(240, 100%, 86.2745098039%)" fill="hsl(240, 100%, 86.2745098039%)"/>
+      <rect x="430" y="241" width="18" height="18" class="legend" fill="hsl(80, 100%, 56.2745098039%)" stroke="hsl(80, 100%, 56.2745098039%)"/>
       <text x="452" y="189" class="legend" font-size="17">Development</text>
       <text x="452" y="211" class="legend" font-size="17">Testing</text>
       <text x="452" y="233" class="legend" font-size="17">Documentation</text>

--- a/docs/images/pie_complex.svg
+++ b/docs/images/pie_complex.svg
@@ -124,33 +124,33 @@ marker path {
     <g class="nodes">
 
     </g>
-    <circle cx="210" cy="245" r="186" class="pieOuterCircle" fill="none" stroke-width="2" stroke="black"/>
-    <path d="M 210 245 L 210 60 A 185 185 0 0 1 359.66814395936524 353.74027167410753 Z" class="pieCircle" stroke-width="2" stroke="black" opacity="0.7" fill="hsl(240, 100%, 96.27450980392157%)"/>
-    <path d="M 210 245 L 359.66814395936524 353.74027167410753 A 185 185 0 0 1 131.23083106046155 412.39300470621356 Z" class="pieCircle" fill="hsl(0, 0%, 58.03921568627452%)" stroke="black" stroke-width="2" opacity="0.7"/>
-    <path d="M 210 245 L 131.23083106046155 412.39300470621356 A 185 185 0 0 1 25 245.00000000000003 Z" class="pieCircle" stroke-width="2" opacity="0.7" fill="hsl(60, 100%, 93.52941176470588%)" stroke="black"/>
-    <path d="M 210 245 L 25 245.00000000000003 A 185 185 0 0 1 47.88326419188522 155.87557029118273 Z" class="pieCircle" opacity="0.7" stroke-width="2" fill="hsl(240, 100%, 86.27450980392157%)" stroke="black"/>
-    <path d="M 210 245 L 47.88326419188522 155.87557029118273 A 185 185 0 0 1 92.07656189649231 102.45505008647908 Z" class="pieCircle" stroke-width="2" fill="hsl(60, 100%, 63.52941176470588%)" opacity="0.7" stroke="black"/>
-    <path d="M 210 245 L 92.07656189649231 102.45505008647908 A 185 185 0 0 1 141.89695775333445 72.99135011067355 Z" class="pieCircle" opacity="0.7" stroke-width="2" fill="hsl(0, 0%, 78.03921568627452%)" stroke="black"/>
-    <path d="M 210 245 L 141.89695775333445 72.99135011067355 A 185 185 0 0 1 186.81335179060366 61.458780256821626 Z" class="pieCircle" stroke-width="2" opacity="0.7" fill="hsl(300, 100%, 76.27450980392156%)" stroke="black"/>
-    <path d="M 210 245 L 186.81335179060366 61.458780256821626 A 185 185 0 0 1 209.99999999999997 60 Z" class="pieCircle" stroke-width="2" stroke="black" opacity="0.7" fill="hsl(180, 100%, 56.27450980392157%)"/>
-    <text x="210" y="25" class="pie-title" text-anchor="middle" font-size="20" font-weight="bold">Cloud Infrastructure Costs</text>
-    <text x="333.62715523113604" y="182.00881816113787" class="slice" font-size="17" text-anchor="middle" dominant-baseline="middle">35%</text>
+    <circle cx="210" cy="245" r="186" class="pieOuterCircle" fill="none" stroke="black" stroke-width="2"/>
+    <path d="M 210 245 L 210 60 A 185 185 0 0 1 359.66814395936524 353.74027167410753 Z" class="pieCircle" stroke-width="2" stroke="black" opacity="0.7" fill="#ececff"/>
+    <path d="M 210 245 L 359.66814395936524 353.74027167410753 A 185 185 0 0 1 131.23083106046155 412.39300470621356 Z" class="pieCircle" fill="#ffffde" stroke="black" opacity="0.7" stroke-width="2"/>
+    <path d="M 210 245 L 131.23083106046155 412.39300470621356 A 185 185 0 0 1 25 245.00000000000003 Z" class="pieCircle" stroke-width="2" stroke="black" opacity="0.7" fill="hsl(80, 100%, 56.2745098039%)"/>
+    <path d="M 210 245 L 25 245.00000000000003 A 185 185 0 0 1 47.88326419188522 155.87557029118273 Z" class="pieCircle" fill="hsl(240, 100%, 86.2745098039%)" opacity="0.7" stroke-width="2" stroke="black"/>
+    <path d="M 210 245 L 47.88326419188522 155.87557029118273 A 185 185 0 0 1 92.07656189649231 102.45505008647908 Z" class="pieCircle" fill="hsl(60, 100%, 63.5294117647%)" stroke="black" stroke-width="2" opacity="0.7"/>
+    <path d="M 210 245 L 92.07656189649231 102.45505008647908 A 185 185 0 0 1 141.89695775333445 72.99135011067355 Z" class="pieCircle" fill="hsl(80, 100%, 76.2745098039%)" stroke-width="2" opacity="0.7" stroke="black"/>
+    <path d="M 210 245 L 141.89695775333445 72.99135011067355 A 185 185 0 0 1 186.81335179060366 61.458780256821626 Z" class="pieCircle" fill="hsl(300, 100%, 76.2745098039%)" opacity="0.7" stroke="black" stroke-width="2"/>
+    <path d="M 210 245 L 186.81335179060366 61.458780256821626 A 185 185 0 0 1 209.99999999999997 60 Z" class="pieCircle" stroke-width="2" fill="hsl(180, 100%, 56.2745098039%)" opacity="0.7" stroke="black"/>
+    <text x="210" y="25" class="pie-title" text-anchor="middle" font-weight="bold" font-size="20">Cloud Infrastructure Costs</text>
+    <text x="333.62715523113604" y="182.00881816113787" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">35%</text>
     <text x="244.5057218441236" y="379.39091360659756" class="slice" font-size="17" dominant-baseline="middle" text-anchor="middle">22%</text>
-    <text x="92.84950033659541" y="319.3459678033358" class="slice" dominant-baseline="middle" text-anchor="middle" font-size="17">18%</text>
-    <text x="75.60908639340244" y="210.49427815587643" class="slice" dominant-baseline="middle" font-size="17" text-anchor="middle">8%</text>
-    <text x="103.0912875648592" y="156.55742142236937" class="slice" dominant-baseline="middle" font-size="17" text-anchor="middle">6%</text>
-    <text x="139.3705035646359" y="125.57204375320286" class="slice" font-size="17" text-anchor="middle" dominant-baseline="middle">5%</text>
-    <text x="175.49427815587632" y="110.60908639340246" class="slice" dominant-baseline="middle" text-anchor="middle" font-size="17">4%</text>
-    <text x="201.28781541530768" y="106.52379143057732" class="slice" font-size="17" text-anchor="middle" dominant-baseline="middle">2%</text>
+    <text x="92.84950033659541" y="319.3459678033358" class="slice" text-anchor="middle" font-size="17" dominant-baseline="middle">18%</text>
+    <text x="75.60908639340244" y="210.49427815587643" class="slice" font-size="17" text-anchor="middle" dominant-baseline="middle">8%</text>
+    <text x="103.0912875648592" y="156.55742142236937" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">6%</text>
+    <text x="139.3705035646359" y="125.57204375320286" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">5%</text>
+    <text x="175.49427815587632" y="110.60908639340246" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">4%</text>
+    <text x="201.28781541530768" y="106.52379143057732" class="slice" dominant-baseline="middle" font-size="17" text-anchor="middle">2%</text>
     <g class="legend">
-      <rect x="430" y="175" width="18" height="18" class="legend" fill="hsl(240, 100%, 96.27450980392157%)" stroke="hsl(240, 100%, 96.27450980392157%)"/>
-      <rect x="430" y="197" width="18" height="18" class="legend" stroke="hsl(60, 100%, 93.52941176470588%)" fill="hsl(60, 100%, 93.52941176470588%)"/>
-      <rect x="430" y="219" width="18" height="18" class="legend" stroke="hsl(0, 0%, 58.03921568627452%)" fill="hsl(0, 0%, 58.03921568627452%)"/>
-      <rect x="430" y="241" width="18" height="18" class="legend" stroke="hsl(240, 100%, 86.27450980392157%)" fill="hsl(240, 100%, 86.27450980392157%)"/>
-      <rect x="430" y="263" width="18" height="18" class="legend" stroke="hsl(60, 100%, 63.52941176470588%)" fill="hsl(60, 100%, 63.52941176470588%)"/>
-      <rect x="430" y="285" width="18" height="18" class="legend" fill="hsl(0, 0%, 78.03921568627452%)" stroke="hsl(0, 0%, 78.03921568627452%)"/>
-      <rect x="430" y="307" width="18" height="18" class="legend" fill="hsl(300, 100%, 76.27450980392156%)" stroke="hsl(300, 100%, 76.27450980392156%)"/>
-      <rect x="430" y="329" width="18" height="18" class="legend" stroke="hsl(180, 100%, 56.27450980392157%)" fill="hsl(180, 100%, 56.27450980392157%)"/>
+      <rect x="430" y="175" width="18" height="18" class="legend" stroke="#ececff" fill="#ececff"/>
+      <rect x="430" y="197" width="18" height="18" class="legend" stroke="hsl(80, 100%, 56.2745098039%)" fill="hsl(80, 100%, 56.2745098039%)"/>
+      <rect x="430" y="219" width="18" height="18" class="legend" fill="#ffffde" stroke="#ffffde"/>
+      <rect x="430" y="241" width="18" height="18" class="legend" stroke="hsl(240, 100%, 86.2745098039%)" fill="hsl(240, 100%, 86.2745098039%)"/>
+      <rect x="430" y="263" width="18" height="18" class="legend" fill="hsl(60, 100%, 63.5294117647%)" stroke="hsl(60, 100%, 63.5294117647%)"/>
+      <rect x="430" y="285" width="18" height="18" class="legend" stroke="hsl(80, 100%, 76.2745098039%)" fill="hsl(80, 100%, 76.2745098039%)"/>
+      <rect x="430" y="307" width="18" height="18" class="legend" stroke="hsl(300, 100%, 76.2745098039%)" fill="hsl(300, 100%, 76.2745098039%)"/>
+      <rect x="430" y="329" width="18" height="18" class="legend" fill="hsl(180, 100%, 56.2745098039%)" stroke="hsl(180, 100%, 56.2745098039%)"/>
       <text x="452" y="189" class="legend" font-size="17">Compute (EC2/GKE) [35]</text>
       <text x="452" y="211" class="legend" font-size="17">Storage (S3/GCS) [18]</text>
       <text x="452" y="233" class="legend" font-size="17">Database (RDS) [22]</text>

--- a/src/render/pie.rs
+++ b/src/render/pie.rs
@@ -50,20 +50,22 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
         return Ok(doc.to_string());
     }
 
-    // Mermaid.js assigns colors based on ORIGINAL input order, but renders slices
-    // sorted by value descending. Legend stays in original order.
+    // Mermaid.js uses D3's scaleOrdinal which assigns colors in the order labels
+    // are first encountered. Since mermaid processes arcs in value-descending order,
+    // colors are assigned by sorted order, not original input order.
 
-    // Step 1: Create color mapping based on original order
+    // Step 1: Get sections and sort by value descending (like mermaid)
     let sections_vec: Vec<_> = sections.to_vec();
-    let label_to_color_index: std::collections::HashMap<_, _> = sections_vec
+    let mut sorted_for_rendering: Vec<_> = sections_vec.clone();
+    sorted_for_rendering.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Step 2: Create color mapping based on SORTED order (not input order!)
+    // D3 scaleOrdinal assigns colors as labels are first seen - in sorted order
+    let label_to_color_index: std::collections::HashMap<_, _> = sorted_for_rendering
         .iter()
         .enumerate()
         .map(|(i, (label, _))| (label.clone(), i))
         .collect();
-
-    // Step 2: Sort by value descending for slice rendering
-    let mut sorted_for_rendering: Vec<_> = sections_vec.clone();
-    sorted_for_rendering.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
     // Pie colors from theme
     let colors: Vec<&str> = config.theme.pie_colors.iter().map(|s| s.as_str()).collect();
@@ -196,12 +198,13 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
     }
 
     // Build legend items in ORIGINAL input order (not sorted)
-    // Include the raw value for showData display
+    // But use colors based on sorted order (looked up from label_to_color_index)
     let legend_items: Vec<(String, String, f64, f64)> = sections_vec
         .iter()
-        .enumerate()
-        .map(|(i, (label, value))| {
-            let color = colors[i % colors.len()];
+        .map(|(label, value)| {
+            // Look up the color index from sorted order, not input order
+            let color_index = label_to_color_index.get(label).copied().unwrap_or(0);
+            let color = colors[color_index % colors.len()];
             let percentage = *value / total;
             (color.to_string(), label.clone(), percentage, *value)
         })

--- a/src/render/svg/color.rs
+++ b/src/render/svg/color.rs
@@ -276,6 +276,37 @@ pub fn adjust(color: &Color, h: f64, s: f64, l: f64) -> Color {
     result
 }
 
+/// Adjust a color's HSL values and return the result as an HSL string directly.
+/// This avoids the precision loss from converting HSL → RGB → HSL.
+/// Output format matches mermaid.js: hsl(h, s%, l%) with specific precision.
+pub fn adjust_to_hsl_string(color: &Color, h: f64, s: f64, l: f64) -> String {
+    let (ch, cs, cl) = color.to_hsl();
+    let new_h = ((ch + h) % 360.0 + 360.0) % 360.0; // Normalize hue
+    let new_s = (cs + s).clamp(0.0, 100.0);
+    let new_l = (cl + l).clamp(0.0, 100.0);
+
+    // Format matching mermaid.js precision (10-digit precision for percentages)
+    format!(
+        "hsl({}, {}%, {}%)",
+        new_h.round() as i32,
+        format_mermaid_pct(new_s),
+        format_mermaid_pct(new_l)
+    )
+}
+
+/// Format percentage value matching mermaid.js output precision
+fn format_mermaid_pct(value: f64) -> String {
+    // Mermaid.js uses 10 significant digits after decimal
+    // Check if value is close to a whole number
+    let rounded = value.round();
+    if (value - rounded).abs() < 0.0001 {
+        format!("{}", rounded as i32)
+    } else {
+        // Match mermaid's precision: up to 10 decimal places
+        format!("{:.10}", value).trim_end_matches('0').trim_end_matches('.').to_string()
+    }
+}
+
 /// Darken a color by reducing lightness
 /// Amount is in percentage points (0-100)
 pub fn darken(color: &Color, amount: f64) -> Color {

--- a/src/render/svg/theme.rs
+++ b/src/render/svg/theme.rs
@@ -1,6 +1,6 @@
 //! Theme configuration for SVG rendering
 
-use super::color::{adjust, Color};
+use super::color::{adjust, adjust_to_hsl_string, Color};
 
 /// Compute journey fillType colors dynamically from theme base colors.
 /// This matches mermaid.js theme-default.js journey color calculation.
@@ -30,25 +30,60 @@ fn compute_journey_fill_types(primary: &str, secondary: &str) -> Vec<String> {
 
 /// Compute pie chart colors dynamically from theme base colors.
 /// This matches mermaid.js theme-default.js pie color calculation.
-fn compute_pie_colors(primary: &str, secondary: &str, tertiary: &str) -> Vec<String> {
+///
+/// In mermaid.js:
+/// - tertiaryColor = adjust(primaryColor, { h: -160 }) - NOT a hardcoded value
+/// - pie1 = primaryColor (kept in original hex format)
+/// - pie2 = secondaryColor (kept in original hex format)
+/// - pie3+ = computed colors (output as HSL to match mermaid)
+fn compute_pie_colors(primary: &str, secondary: &str) -> Vec<String> {
     let primary_color = Color::from_hex(primary).unwrap_or_else(|| Color::rgb(236, 236, 255));
     let secondary_color = Color::from_hex(secondary).unwrap_or_else(|| Color::rgb(255, 255, 222));
-    let tertiary_color = Color::from_hex(tertiary).unwrap_or_else(|| Color::rgb(250, 250, 250));
+    // tertiaryColor is derived from primaryColor by hue shift, not a hardcoded value!
+    // mermaid.js: this.tertiaryColor = adjust(this.primaryColor, { h: -160 });
+    // Note: We compute tertiary's HSL directly to avoid precision loss
+    let (primary_h, primary_s, primary_l) = primary_color.to_hsl();
+    let tertiary_h = ((primary_h - 160.0) % 360.0 + 360.0) % 360.0;
+    let tertiary_s = primary_s;
+    let tertiary_l = primary_l;
 
+    // Use adjust_to_hsl_string to avoid RGB roundtrip precision loss
     vec![
-        primary_color.to_hsl_string(),   // pie1 = primaryColor
-        secondary_color.to_hsl_string(), // pie2 = secondaryColor
-        adjust(&tertiary_color, 0.0, 0.0, -40.0).to_hsl_string(), // pie3 = adjust(tertiaryColor, { l: -40 })
-        adjust(&primary_color, 0.0, 0.0, -10.0).to_hsl_string(), // pie4 = adjust(primaryColor, { l: -10 })
-        adjust(&secondary_color, 0.0, 0.0, -30.0).to_hsl_string(), // pie5 = adjust(secondaryColor, { l: -30 })
-        adjust(&tertiary_color, 0.0, 0.0, -20.0).to_hsl_string(), // pie6 = adjust(tertiaryColor, { l: -20 })
-        adjust(&primary_color, 60.0, 0.0, -20.0).to_hsl_string(), // pie7 = adjust(primaryColor, { h: +60, l: -20 })
-        adjust(&primary_color, -60.0, 0.0, -40.0).to_hsl_string(), // pie8 = adjust(primaryColor, { h: -60, l: -40 })
-        adjust(&primary_color, 120.0, 0.0, -40.0).to_hsl_string(), // pie9 = adjust(primaryColor, { h: 120, l: -40 })
-        adjust(&primary_color, 60.0, 0.0, -40.0).to_hsl_string(), // pie10 = adjust(primaryColor, { h: +60, l: -40 })
-        adjust(&primary_color, -90.0, 0.0, -40.0).to_hsl_string(), // pie11 = adjust(primaryColor, { h: -90, l: -40 })
-        adjust(&primary_color, 120.0, 0.0, -30.0).to_hsl_string(), // pie12 = adjust(primaryColor, { h: 120, l: -30 })
+        primary.to_lowercase(),   // pie1 = primaryColor (keep original hex format like mermaid)
+        secondary.to_lowercase(), // pie2 = secondaryColor (keep original hex format like mermaid)
+        // pie3 = adjust(tertiaryColor, { l: -40 })
+        format!(
+            "hsl({}, {}%, {}%)",
+            tertiary_h.round() as i32,
+            format_hsl_pct(tertiary_s),
+            format_hsl_pct((tertiary_l - 40.0).clamp(0.0, 100.0))
+        ),
+        adjust_to_hsl_string(&primary_color, 0.0, 0.0, -10.0), // pie4 = adjust(primaryColor, { l: -10 })
+        adjust_to_hsl_string(&secondary_color, 0.0, 0.0, -30.0), // pie5 = adjust(secondaryColor, { l: -30 })
+        // pie6 = adjust(tertiaryColor, { l: -20 })
+        format!(
+            "hsl({}, {}%, {}%)",
+            tertiary_h.round() as i32,
+            format_hsl_pct(tertiary_s),
+            format_hsl_pct((tertiary_l - 20.0).clamp(0.0, 100.0))
+        ),
+        adjust_to_hsl_string(&primary_color, 60.0, 0.0, -20.0), // pie7 = adjust(primaryColor, { h: +60, l: -20 })
+        adjust_to_hsl_string(&primary_color, -60.0, 0.0, -40.0), // pie8 = adjust(primaryColor, { h: -60, l: -40 })
+        adjust_to_hsl_string(&primary_color, 120.0, 0.0, -40.0), // pie9 = adjust(primaryColor, { h: 120, l: -40 })
+        adjust_to_hsl_string(&primary_color, 60.0, 0.0, -40.0), // pie10 = adjust(primaryColor, { h: +60, l: -40 })
+        adjust_to_hsl_string(&primary_color, -90.0, 0.0, -40.0), // pie11 = adjust(primaryColor, { h: -90, l: -40 })
+        adjust_to_hsl_string(&primary_color, 120.0, 0.0, -30.0), // pie12 = adjust(primaryColor, { h: 120, l: -30 })
     ]
+}
+
+/// Helper to format HSL percentage matching mermaid's precision
+fn format_hsl_pct(value: f64) -> String {
+    let rounded = value.round();
+    if (value - rounded).abs() < 0.0001 {
+        format!("{}", rounded as i32)
+    } else {
+        format!("{:.10}", value).trim_end_matches('0').trim_end_matches('.').to_string()
+    }
 }
 
 /// Color theme for diagram rendering
@@ -223,7 +258,7 @@ impl Default for Theme {
             font_family: "trebuchet ms, verdana, arial, sans-serif".to_string(),
             font_size: "16px".to_string(),
             // Pie chart - dynamically computed from theme colors (matches mermaid.js)
-            pie_colors: compute_pie_colors("#ECECFF", "#ffffde", "#fafafa"),
+            pie_colors: compute_pie_colors("#ECECFF", "#ffffde"),
             pie_stroke_color: "black".to_string(),
             pie_outer_stroke_color: "black".to_string(),
             pie_opacity: "0.7".to_string(),
@@ -332,7 +367,7 @@ impl Theme {
             font_family: "trebuchet ms, verdana, arial, sans-serif".to_string(),
             font_size: "16px".to_string(),
             // Pie chart - dynamically computed from dark theme colors
-            pie_colors: compute_pie_colors("#1f2020", "#8a8a8a", "#333333"),
+            pie_colors: compute_pie_colors("#1f2020", "#8a8a8a"),
             pie_stroke_color: "#81B1DB".to_string(),
             pie_outer_stroke_color: "#81B1DB".to_string(),
             pie_opacity: "0.7".to_string(),
@@ -438,7 +473,7 @@ impl Theme {
             font_family: "trebuchet ms, verdana, arial, sans-serif".to_string(),
             font_size: "16px".to_string(),
             // Pie chart - dynamically computed from neutral theme colors
-            pie_colors: compute_pie_colors("#f0f0f0", "#e0e0e0", "#fafafa"),
+            pie_colors: compute_pie_colors("#f0f0f0", "#e0e0e0"),
             pie_stroke_color: "#333333".to_string(),
             pie_outer_stroke_color: "#333333".to_string(),
             pie_opacity: "0.7".to_string(),
@@ -545,7 +580,7 @@ impl Theme {
             font_family: "trebuchet ms, verdana, arial, sans-serif".to_string(),
             font_size: "16px".to_string(),
             // Pie chart - dynamically computed from forest theme colors
-            pie_colors: compute_pie_colors("#cde498", "#cdffb2", "#e0f2c8"),
+            pie_colors: compute_pie_colors("#cde498", "#cdffb2"),
             pie_stroke_color: "black".to_string(),
             pie_outer_stroke_color: "black".to_string(),
             pie_opacity: "0.7".to_string(),
@@ -1726,5 +1761,70 @@ mod tests {
         let theme = Theme::from_directive(&config);
         // Should fall back to default theme
         assert_eq!(theme.primary_color, "#ECECFF");
+    }
+
+    #[test]
+    fn test_pie_colors_match_mermaid_default_theme() {
+        // This test ensures pie colors match mermaid.js default theme exactly.
+        // Bug: tertiaryColor was #fafafa (gray) instead of derived from primaryColor,
+        // causing pie3 and pie6 to be gray instead of having proper hue.
+        //
+        // In mermaid.js theme-default.js:
+        // - primaryColor = '#ECECFF' (light purple, hsl(240, 100%, 96%))
+        // - secondaryColor = '#ffffde' (light yellow, hsl(60, 100%, 93%))
+        // - tertiaryColor = adjust(primaryColor, { h: -160 }) = hsl(80, 100%, 96%)
+        //
+        // Pie colors:
+        // - pie1 = primaryColor = #ECECFF
+        // - pie2 = secondaryColor = #ffffde
+        // - pie3 = adjust(tertiaryColor, { l: -40 }) = hsl(80, 100%, 56%)
+        // - pie4 = adjust(primaryColor, { l: -10 }) = hsl(240, 100%, 86%)
+        // - etc.
+        let theme = Theme::default();
+
+        // Verify no pie color has 0% saturation (would indicate bug with grayscale tertiary)
+        for (i, color_str) in theme.pie_colors.iter().enumerate() {
+            // Parse the HSL string to check saturation
+            if color_str.starts_with("hsl(") {
+                let inner = &color_str[4..color_str.len() - 1];
+                let parts: Vec<&str> = inner.split(',').collect();
+                if parts.len() >= 2 {
+                    let saturation = parts[1].trim().trim_end_matches('%').parse::<f64>().unwrap_or(100.0);
+                    assert!(
+                        saturation > 0.0,
+                        "pie{} has 0% saturation (gray): {} - tertiaryColor may not be derived correctly",
+                        i + 1,
+                        color_str
+                    );
+                }
+            }
+        }
+
+        // pie1 should be primaryColor (light purple)
+        // pie2 should be secondaryColor (light yellow)
+        let pie1 = &theme.pie_colors[0];
+        let pie2 = &theme.pie_colors[1];
+
+        // Parse pie1 to verify it's the purple color (hue ~240)
+        if pie1.starts_with("hsl(") {
+            let inner = &pie1[4..pie1.len() - 1];
+            let hue: f64 = inner.split(',').next().unwrap().trim().parse().unwrap_or(0.0);
+            assert!(
+                (hue - 240.0).abs() < 5.0,
+                "pie1 should have hue ~240 (purple), got {}",
+                hue
+            );
+        }
+
+        // Parse pie2 to verify it's the yellow color (hue ~60)
+        if pie2.starts_with("hsl(") {
+            let inner = &pie2[4..pie2.len() - 1];
+            let hue: f64 = inner.split(',').next().unwrap().trim().parse().unwrap_or(0.0);
+            assert!(
+                (hue - 60.0).abs() < 5.0,
+                "pie2 should have hue ~60 (yellow), got {}",
+                hue
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixed pie chart visual parity with mermaid. Three key fixes:
1) tertiaryColor now derived from primaryColor
2) color assignment uses value-sorted order like D3
3) HSL precision matches mermaid output

All 5 pie charts now pass eval.

Issue: se-fqz8