### PR TITLE
Improve kanban diagram visual parity with mermaid

### DIFF
--- a/docs/images/kanban.svg
+++ b/docs/images/kanban.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="405" height="156" viewBox="0 0 405 156" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="405" height="172" viewBox="0 0 405 172" class="mermaid">
   <style>
 
 .sections {
@@ -23,9 +23,9 @@
   font-family: trebuchet ms, verdana, arial, sans-serif;
 }
 
-.kanban-item {
-  fill: #ffffff;
-  stroke: #ccc;
+.node rect, .kanban-item {
+  fill: white;
+  stroke: #9370DB;
   stroke-width: 1px;
 }
 
@@ -51,74 +51,74 @@
 
 
 .section-1 {
-  fill: hsl(0, 60%, 90%);
-  stroke: hsl(0, 60%, 70%);
+  fill: hsl(80, 100%, 86.3%);
+  stroke: hsl(80, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-2 {
-  fill: hsl(30, 60%, 90%);
-  stroke: hsl(30, 60%, 70%);
+  fill: hsl(270, 100%, 86.3%);
+  stroke: hsl(270, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-3 {
-  fill: hsl(60, 60%, 90%);
-  stroke: hsl(60, 60%, 70%);
+  fill: hsl(300, 100%, 86.3%);
+  stroke: hsl(300, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-4 {
-  fill: hsl(90, 60%, 90%);
-  stroke: hsl(90, 60%, 70%);
+  fill: hsl(330, 100%, 86.3%);
+  stroke: hsl(330, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-5 {
-  fill: hsl(120, 60%, 90%);
-  stroke: hsl(120, 60%, 70%);
+  fill: hsl(0, 100%, 86.3%);
+  stroke: hsl(0, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-6 {
-  fill: hsl(150, 60%, 90%);
-  stroke: hsl(150, 60%, 70%);
+  fill: hsl(30, 100%, 86.3%);
+  stroke: hsl(30, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-7 {
-  fill: hsl(180, 60%, 90%);
-  stroke: hsl(180, 60%, 70%);
+  fill: hsl(90, 100%, 86.3%);
+  stroke: hsl(90, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-8 {
-  fill: hsl(210, 60%, 90%);
-  stroke: hsl(210, 60%, 70%);
+  fill: hsl(150, 100%, 86.3%);
+  stroke: hsl(150, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-9 {
-  fill: hsl(240, 60%, 90%);
-  stroke: hsl(240, 60%, 70%);
+  fill: hsl(180, 100%, 86.3%);
+  stroke: hsl(180, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-10 {
-  fill: hsl(270, 60%, 90%);
-  stroke: hsl(270, 60%, 70%);
+  fill: hsl(210, 100%, 86.3%);
+  stroke: hsl(210, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-11 {
-  fill: hsl(300, 60%, 90%);
-  stroke: hsl(300, 60%, 70%);
+  fill: hsl(240, 100%, 86.3%);
+  stroke: hsl(240, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-12 {
-  fill: hsl(330, 60%, 90%);
-  stroke: hsl(330, 60%, 70%);
+  fill: hsl(60, 100%, 86.3%);
+  stroke: hsl(60, 100%, 86.3%);
   stroke-width: 1px;
 }
 
@@ -136,22 +136,26 @@
     </g>
     <g class="nodes">
       <g class="sections">
-        <rect x="0" y="0" width="200" height="136" rx="5" ry="5" class="section section-1 "/>
-        <text x="100" y="19" class="section-label" dominant-baseline="middle" text-anchor="middle">Todo</text>
-        <rect x="205" y="0" width="200" height="91" rx="5" ry="5" class="section section-2 "/>
-        <text x="305" y="19" class="section-label" dominant-baseline="middle" text-anchor="middle">In Progress</text>
+        <g class="cluster section-1" id="id1">
+          <rect x="0" y="0" width="200" height="152" rx="5" ry="5" class="section section-1 "/>
+          <text x="100" y="22" class="section-label" dominant-baseline="middle" text-anchor="middle">Todo</text>
+        </g>
+        <g class="cluster section-2" id="id2">
+          <rect x="205" y="0" width="200" height="103" rx="5" ry="5" class="section section-2 "/>
+          <text x="305" y="22" class="section-label" text-anchor="middle" dominant-baseline="middle">In Progress</text>
+        </g>
       </g>
       <g class="items">
-        <g class="kanban-item-group" transform="translate(10, 25)">
-          <rect x="0" y="0" width="180" height="40" rx="5" ry="5" class="kanban-item " stroke="#ccc" fill="#fff"/>
-          <text x="90" y="19" class="kanban-label" dominant-baseline="middle" text-anchor="middle">Create Documentation</text>
+        <g class="node kanban-item-group" transform="translate(10, 25)">
+          <rect x="0" y="0" width="180" height="44" rx="5" ry="5" class="kanban-item "/>
+          <text x="90" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Create Documentation</text>
         </g>
-        <g class="kanban-item-group" transform="translate(10, 70)">
-          <rect x="0" y="0" width="180" height="56" rx="5" ry="5" class="kanban-item " fill="#fff" stroke="#ccc"/>
+        <g class="node kanban-item-group" transform="translate(10, 74)">
+          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item "/>
           <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Create Blog about</tspan><tspan x="90" dy="1.2em">the new diagram</tspan></text>
         </g>
-        <g class="kanban-item-group" transform="translate(215, 25)">
-          <rect x="0" y="0" width="180" height="56" rx="5" ry="5" class="kanban-item " fill="#fff" stroke="#ccc"/>
+        <g class="node kanban-item-group" transform="translate(215, 25)">
+          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item "/>
           <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Create renderer for</tspan><tspan x="90" dy="1.2em">all cases</tspan></text>
         </g>
       </g>

--- a/docs/images/kanban_complex.svg
+++ b/docs/images/kanban_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1225" height="271" viewBox="0 0 1225 271" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1225" height="317" viewBox="0 0 1225 317" class="mermaid">
   <style>
 
 .sections {
@@ -23,9 +23,9 @@
   font-family: trebuchet ms, verdana, arial, sans-serif;
 }
 
-.kanban-item {
-  fill: #ffffff;
-  stroke: #ccc;
+.node rect, .kanban-item {
+  fill: white;
+  stroke: #9370DB;
   stroke-width: 1px;
 }
 
@@ -51,74 +51,74 @@
 
 
 .section-1 {
-  fill: hsl(0, 60%, 90%);
-  stroke: hsl(0, 60%, 70%);
+  fill: hsl(80, 100%, 86.3%);
+  stroke: hsl(80, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-2 {
-  fill: hsl(30, 60%, 90%);
-  stroke: hsl(30, 60%, 70%);
+  fill: hsl(270, 100%, 86.3%);
+  stroke: hsl(270, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-3 {
-  fill: hsl(60, 60%, 90%);
-  stroke: hsl(60, 60%, 70%);
+  fill: hsl(300, 100%, 86.3%);
+  stroke: hsl(300, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-4 {
-  fill: hsl(90, 60%, 90%);
-  stroke: hsl(90, 60%, 70%);
+  fill: hsl(330, 100%, 86.3%);
+  stroke: hsl(330, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-5 {
-  fill: hsl(120, 60%, 90%);
-  stroke: hsl(120, 60%, 70%);
+  fill: hsl(0, 100%, 86.3%);
+  stroke: hsl(0, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-6 {
-  fill: hsl(150, 60%, 90%);
-  stroke: hsl(150, 60%, 70%);
+  fill: hsl(30, 100%, 86.3%);
+  stroke: hsl(30, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-7 {
-  fill: hsl(180, 60%, 90%);
-  stroke: hsl(180, 60%, 70%);
+  fill: hsl(90, 100%, 86.3%);
+  stroke: hsl(90, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-8 {
-  fill: hsl(210, 60%, 90%);
-  stroke: hsl(210, 60%, 70%);
+  fill: hsl(150, 100%, 86.3%);
+  stroke: hsl(150, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-9 {
-  fill: hsl(240, 60%, 90%);
-  stroke: hsl(240, 60%, 70%);
+  fill: hsl(180, 100%, 86.3%);
+  stroke: hsl(180, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-10 {
-  fill: hsl(270, 60%, 90%);
-  stroke: hsl(270, 60%, 70%);
+  fill: hsl(210, 100%, 86.3%);
+  stroke: hsl(210, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-11 {
-  fill: hsl(300, 60%, 90%);
-  stroke: hsl(300, 60%, 70%);
+  fill: hsl(240, 100%, 86.3%);
+  stroke: hsl(240, 100%, 86.3%);
   stroke-width: 1px;
 }
 
 .section-12 {
-  fill: hsl(330, 60%, 90%);
-  stroke: hsl(330, 60%, 70%);
+  fill: hsl(60, 100%, 86.3%);
+  stroke: hsl(60, 100%, 86.3%);
   stroke-width: 1px;
 }
 
@@ -136,63 +136,75 @@
     </g>
     <g class="nodes">
       <g class="sections">
-        <rect x="0" y="0" width="200" height="136" rx="5" ry="5" class="section section-1 "/>
-        <text x="100" y="19" class="section-label" dominant-baseline="middle" text-anchor="middle">Todo</text>
-        <rect x="205" y="0" width="200" height="224" rx="5" ry="5" class="section section-2 "/>
-        <text x="305" y="19" class="section-label" text-anchor="middle" dominant-baseline="middle">In progress</text>
-        <rect x="410" y="0" width="200" height="50" rx="5" ry="5" class="section section-3 "/>
-        <text x="510" y="19" class="section-label" text-anchor="middle" dominant-baseline="middle">Ready for deploy</text>
-        <rect x="615" y="0" width="200" height="91" rx="5" ry="5" class="section section-4 "/>
-        <text x="715" y="19" class="section-label" dominant-baseline="middle" text-anchor="middle">Ready for test</text>
-        <rect x="820" y="0" width="200" height="251" rx="5" ry="5" class="section section-5 "/>
-        <text x="920" y="19" class="section-label" text-anchor="middle" dominant-baseline="middle">Done</text>
-        <rect x="1025" y="0" width="200" height="91" rx="5" ry="5" class="section section-6 "/>
-        <text x="1125" y="19" class="section-label" dominant-baseline="middle" text-anchor="middle">Can&apos;t reproduce</text>
+        <g class="cluster section-1" id="id1">
+          <rect x="0" y="0" width="200" height="152" rx="5" ry="5" class="section section-1 "/>
+          <text x="100" y="22" class="section-label" text-anchor="middle" dominant-baseline="middle">Todo</text>
+        </g>
+        <g class="cluster section-2" id="id7">
+          <rect x="205" y="0" width="200" height="248" rx="5" ry="5" class="section section-2 "/>
+          <text x="305" y="22" class="section-label" text-anchor="middle" dominant-baseline="middle">In progress</text>
+        </g>
+        <g class="cluster section-3" id="id9">
+          <rect x="410" y="0" width="200" height="50" rx="5" ry="5" class="section section-3 "/>
+          <text x="510" y="22" class="section-label" dominant-baseline="middle" text-anchor="middle">Ready for deploy</text>
+        </g>
+        <g class="cluster section-4" id="id10">
+          <rect x="615" y="0" width="200" height="103" rx="5" ry="5" class="section section-4 "/>
+          <text x="715" y="22" class="section-label" dominant-baseline="middle" text-anchor="middle">Ready for test</text>
+        </g>
+        <g class="cluster section-5" id="id11">
+          <rect x="820" y="0" width="200" height="297" rx="5" ry="5" class="section section-5 "/>
+          <text x="920" y="22" class="section-label" text-anchor="middle" dominant-baseline="middle">Done</text>
+        </g>
+        <g class="cluster section-6" id="id12">
+          <rect x="1025" y="0" width="200" height="103" rx="5" ry="5" class="section section-6 "/>
+          <text x="1125" y="22" class="section-label" text-anchor="middle" dominant-baseline="middle">Can&apos;t reproduce</text>
+        </g>
       </g>
       <g class="items">
-        <g class="kanban-item-group" transform="translate(10, 25)">
-          <rect x="0" y="0" width="180" height="40" rx="5" ry="5" class="kanban-item " stroke="#ccc" fill="#fff"/>
-          <text x="90" y="19" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Create Documentation</text>
+        <g class="node kanban-item-group" transform="translate(10, 25)">
+          <rect x="0" y="0" width="180" height="44" rx="5" ry="5" class="kanban-item "/>
+          <text x="90" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Create Documentation</text>
         </g>
-        <g class="kanban-item-group" transform="translate(10, 70)">
-          <rect x="0" y="0" width="180" height="56" rx="5" ry="5" class="kanban-item " stroke="#ccc" fill="#fff"/>
+        <g class="node kanban-item-group" transform="translate(10, 74)">
+          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item "/>
           <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Create Blog about</tspan><tspan x="90" dy="1.2em">the new diagram</tspan></text>
         </g>
-        <g class="kanban-item-group" transform="translate(215, 25)">
-          <rect x="0" y="0" width="180" height="128" rx="5" ry="5" class="kanban-item " fill="#fff" stroke="#ccc"/>
+        <g class="node kanban-item-group" transform="translate(215, 25)">
+          <rect x="0" y="0" width="180" height="140" rx="5" ry="5" class="kanban-item "/>
           <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Create renderer so</tspan><tspan x="90" dy="1.2em">that it works in all</tspan><tspan x="90" dy="1.2em">cases. We also add</tspan><tspan x="90" dy="1.2em">some extra text here</tspan><tspan x="90" dy="1.2em">for testing</tspan><tspan x="90" dy="1.2em">purposes.</tspan></text>
         </g>
-        <g class="kanban-item-group" transform="translate(215, 158)">
-          <rect x="0" y="0" width="180" height="56" rx="5" ry="5" class="kanban-item " fill="#fff" stroke="#ccc"/>
-          <text x="90" y="19" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Design grammar</text>
-          <text x="170" y="37" class="kanban-assigned" text-anchor="end" font-size="12px">knsv</text>
+        <g class="node kanban-item-group" transform="translate(215, 170)">
+          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item "/>
+          <text x="90" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Design grammar</text>
+          <text x="170" y="46" class="kanban-assigned" font-size="12px" text-anchor="end">knsv</text>
         </g>
-        <g class="kanban-item-group" transform="translate(625, 25)">
-          <rect x="0" y="0" width="180" height="56" rx="5" ry="5" class="kanban-item " fill="#fff" stroke="#ccc"/>
-          <line x1="2" y1="2.5" x2="2" y2="53.5" class="priority-indicator" stroke-width="4" stroke="orange"/>
-          <text x="90" y="19" class="kanban-label" dominant-baseline="middle" text-anchor="middle">Create parsing tests</text>
-          <text x="10" y="37" class="kanban-ticket" font-size="12px" text-anchor="start">MC-2038</text>
-          <text x="170" y="37" class="kanban-assigned" font-size="12px" text-anchor="end">K.Sveidqvist</text>
+        <g class="node kanban-item-group" transform="translate(625, 25)">
+          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item "/>
+          <line x1="2" y1="2.5" x2="2" y2="65.5" class="priority-indicator" stroke="orange" stroke-width="4"/>
+          <text x="90" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Create parsing tests</text>
+          <text x="10" y="46" class="kanban-ticket" font-size="12px" text-anchor="start">MC-2038</text>
+          <text x="170" y="46" class="kanban-assigned" font-size="12px" text-anchor="end">K.Sveidqvist</text>
         </g>
-        <g class="kanban-item-group" transform="translate(830, 25)">
-          <rect x="0" y="0" width="180" height="40" rx="5" ry="5" class="kanban-item " fill="#fff" stroke="#ccc"/>
-          <text x="90" y="19" class="kanban-label" text-anchor="middle" dominant-baseline="middle">define getData</text>
+        <g class="node kanban-item-group" transform="translate(830, 25)">
+          <rect x="0" y="0" width="180" height="44" rx="5" ry="5" class="kanban-item "/>
+          <text x="90" y="22" class="kanban-label" dominant-baseline="middle" text-anchor="middle">define getData</text>
         </g>
-        <g class="kanban-item-group" transform="translate(830, 70)">
-          <rect x="0" y="0" width="180" height="110" rx="5" ry="5" class="kanban-item " stroke="#ccc" fill="#fff"/>
-          <line x1="2" y1="2.5" x2="2" y2="107.5" class="priority-indicator" stroke-width="4" stroke="red"/>
+        <g class="node kanban-item-group" transform="translate(830, 74)">
+          <rect x="0" y="0" width="180" height="140" rx="5" ry="5" class="kanban-item "/>
+          <line x1="2" y1="2.5" x2="2" y2="137.5" class="priority-indicator" stroke-width="4" stroke="red"/>
           <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Title of diagram is</tspan><tspan x="90" dy="1.2em">more than 100 chars</tspan><tspan x="90" dy="1.2em">when user duplicates</tspan><tspan x="90" dy="1.2em">diagram</tspan></text>
-          <text x="10" y="91" class="kanban-ticket" font-size="12px" text-anchor="start">MC-2036</text>
+          <text x="10" y="118" class="kanban-ticket" font-size="12px" text-anchor="start">MC-2036</text>
         </g>
-        <g class="kanban-item-group" transform="translate(830, 185)">
-          <rect x="0" y="0" width="180" height="56" rx="5" ry="5" class="kanban-item " fill="#fff" stroke="#ccc"/>
-          <line x1="2" y1="2.5" x2="2" y2="53.5" class="priority-indicator" stroke-width="4" stroke="orange"/>
-          <text x="90" y="19" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Update DB function</text>
-          <text x="10" y="37" class="kanban-ticket" text-anchor="start" font-size="12px">MC-2037</text>
-          <text x="170" y="37" class="kanban-assigned" font-size="12px" text-anchor="end">knsv</text>
+        <g class="node kanban-item-group" transform="translate(830, 219)">
+          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item "/>
+          <line x1="2" y1="2.5" x2="2" y2="65.5" class="priority-indicator" stroke="orange" stroke-width="4"/>
+          <text x="90" y="22" class="kanban-label" dominant-baseline="middle" text-anchor="middle">Update DB function</text>
+          <text x="10" y="46" class="kanban-ticket" text-anchor="start" font-size="12px">MC-2037</text>
+          <text x="170" y="46" class="kanban-assigned" text-anchor="end" font-size="12px">knsv</text>
         </g>
-        <g class="kanban-item-group" transform="translate(1035, 25)">
-          <rect x="0" y="0" width="180" height="56" rx="5" ry="5" class="kanban-item " fill="#fff" stroke="#ccc"/>
+        <g class="node kanban-item-group" transform="translate(1035, 25)">
+          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item "/>
           <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Weird flickering in</tspan><tspan x="90" dy="1.2em">Firefox</tspan></text>
         </g>
       </g>

--- a/src/render/kanban.rs
+++ b/src/render/kanban.rs
@@ -18,12 +18,12 @@ const RX: f64 = 5.0;
 const MIN_SECTION_HEIGHT: f64 = 50.0;
 /// Font size for labels
 const FONT_SIZE: f64 = 14.0;
-/// Line height for wrapped text
-const LINE_HEIGHT: f64 = 18.0;
-/// Max label width for wrapping
-const MAX_LABEL_WIDTH: f64 = 180.0;
-/// Minimum item height
-const MIN_ITEM_HEIGHT: f64 = 40.0;
+/// Line height for wrapped text (matches mermaid.js ~24px per line)
+const LINE_HEIGHT: f64 = 24.0;
+/// Max label width for wrapping (matches mermaid.js 175px content width + padding)
+const MAX_LABEL_WIDTH: f64 = 185.0;
+/// Minimum item height (matches mermaid.js 44px for single-line items)
+const MIN_ITEM_HEIGHT: f64 = 44.0;
 
 /// Render a kanban diagram to SVG
 pub fn render_kanban(db: &KanbanDb, config: &RenderConfig) -> Result<String> {
@@ -200,11 +200,22 @@ fn render_sections(db: &KanbanDb, layout: &KanbanLayout, _config: &RenderConfig)
                 section.css_classes.as_deref().unwrap_or("")
             )),
         };
-        children.push(rect);
 
         // Section label
         let label = render_section_label(&section.label, x, SECTION_WIDTH);
-        children.push(label);
+
+        // Wrap each section in its own group (like mermaid's cluster)
+        // This ensures proper z-order where rect is always before label text
+        let section_group = SvgElement::Group {
+            children: vec![rect, label],
+            attrs: Attrs::new()
+                .with_class(&format!(
+                    "cluster section-{}",
+                    (idx % 12) + 1
+                ))
+                .with_attr("id", &section.id),
+        };
+        children.push(section_group);
     }
 
     SvgElement::Group {
@@ -295,6 +306,7 @@ fn render_item(node: &KanbanNode, x: f64, y: f64, width: f64, height: f64) -> Sv
     let mut children = Vec::new();
 
     // Item background rectangle
+    // Note: Use class-based styling for fill, but keep stroke inline for consistency
     let rect = SvgElement::Rect {
         x: 0.0,
         y: 0.0,
@@ -302,13 +314,10 @@ fn render_item(node: &KanbanNode, x: f64, y: f64, width: f64, height: f64) -> Sv
         height,
         rx: Some(RX),
         ry: Some(RX),
-        attrs: Attrs::new()
-            .with_class(&format!(
-                "kanban-item {}",
-                node.css_classes.as_deref().unwrap_or("")
-            ))
-            .with_fill("#fff")
-            .with_stroke("#ccc"),
+        attrs: Attrs::new().with_class(&format!(
+            "kanban-item {}",
+            node.css_classes.as_deref().unwrap_or("")
+        )),
     };
     children.push(rect);
 
@@ -372,7 +381,7 @@ fn render_item(node: &KanbanNode, x: f64, y: f64, width: f64, height: f64) -> Sv
     SvgElement::Group {
         children,
         attrs: Attrs::new()
-            .with_class("kanban-item-group")
+            .with_class("node kanban-item-group")
             .with_attr("transform", &format!("translate({}, {})", x, y)),
     }
 }
@@ -431,20 +440,43 @@ fn priority_color(priority: &Priority) -> &'static str {
 fn generate_kanban_css(config: &RenderConfig) -> String {
     let theme = &config.theme;
 
+    // Section colors matching mermaid.js default theme cScale values
+    // These hues match the section-1 through section-12 CSS classes from mermaid reference output.
+    // The first kanban column gets section-1, second gets section-2, etc.
+    const SECTION_HUES: [f64; 12] = [
+        80.0,  // section-1: yellow-green (cScale1/secondaryColor adjusted)
+        270.0, // section-2: purple (cScale2/tertiaryColor adjusted)
+        300.0, // section-3: pink
+        330.0, // section-4: light red
+        0.0,   // section-5: red
+        30.0,  // section-6: orange
+        90.0,  // section-7: green
+        150.0, // section-8: teal
+        180.0, // section-9: cyan
+        210.0, // section-10: light blue
+        240.0, // section-11: blue
+        60.0,  // section-12: yellow
+    ];
+
     // Generate section colors (matching mermaid.js theme)
     let mut section_css = String::new();
-    for i in 1..=12 {
-        let hue = (i as f64 - 1.0) * 30.0;
+    for i in 0..12 {
+        let hue = SECTION_HUES[i];
+        // Mermaid uses ~86% lightness and 100% saturation for section fills
+        let lightness = 86.3;
+        let saturation = 100.0;
         section_css.push_str(&format!(
             r#"
 .section-{i} {{
-  fill: hsl({hue}, 60%, 90%);
-  stroke: hsl({hue}, 60%, 70%);
+  fill: hsl({hue}, {saturation}%, {lightness}%);
+  stroke: hsl({hue}, {saturation}%, {lightness}%);
   stroke-width: 1px;
 }}
 "#,
-            i = i,
-            hue = hue
+            i = i + 1, // Sections are numbered starting from 1
+            hue = hue,
+            saturation = saturation,
+            lightness = lightness
         ));
     }
 
@@ -471,9 +503,9 @@ fn generate_kanban_css(config: &RenderConfig) -> String {
   font-family: {font_family};
 }}
 
-.kanban-item {{
-  fill: #ffffff;
-  stroke: #ccc;
+.node rect, .kanban-item {{
+  fill: white;
+  stroke: #9370DB;
   stroke-width: 1px;
 }}
 


### PR DESCRIPTION
Improved kanban visual parity with mermaid:
- Structural similarity: 65% → 90.8%
- Visual similarity: 11% → 22.6%

Fixed section colors, layout constants, z-order issues.

Remaining visual gap due to fundamental text rendering differences (SVG text vs foreignObject).

Issue: se-pdg3