### PR TITLE
Improve mindmap diagram visual parity with mermaid

### DIFF
--- a/docs/images/mindmap.svg
+++ b/docs/images/mindmap.svg
@@ -191,8 +191,8 @@
         <path d="M 181.6 -68 Q 221.60000000000002 -68 241.6 -68" class="edge section-edge-0" fill="none" stroke-width="3"/>
         <path d="M 45.6 0 Q 73.8 0 105.6 34" class="edge section-edge-1" fill="none" stroke-width="3"/>
         <path d="M 189.6 34 Q 235.60000000000002 34 249.6 0" class="edge section-edge-1" fill="none" stroke-width="3"/>
-        <path d="M 189.6 34 Q 245.60000000000002 34 249.6 68" class="edge section-edge-1" stroke-width="3" fill="none"/>
-        <path d="M 45.6 0 Q -159.8 0 -349.6 0" class="edge section-edge-2" stroke-width="3" fill="none"/>
+        <path d="M 189.6 34 Q 245.60000000000002 34 249.6 68" class="edge section-edge-1" fill="none" stroke-width="3"/>
+        <path d="M 45.6 0 Q -159.8 0 -349.6 0" class="edge section-edge-2" fill="none" stroke-width="3"/>
         <path d="M -289.6 0 Q -395.6 0 -533.6 -34" class="edge section-edge-2" stroke-width="3" fill="none"/>
         <path d="M -289.6 0 Q -383.6 0 -485.6 34" class="edge section-edge-2" fill="none" stroke-width="3"/>
       </g>
@@ -204,39 +204,47 @@
       <g class="mindmap-nodes">
         <g class="mindmap-node section-0" id="node-Origins" transform="translate(105.6, -87)">
           <path d="M0 33 v-28 q0,-5 5,-5 h66 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="38" y="19" class="mindmap-node-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Origins</text>
+          <line x1="0" y1="38" x2="76" y2="38" class="node-line-0"/>
+          <text x="38" y="19" class="mindmap-node-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Origins</text>
         </g>
-        <g class="mindmap-node section-0" id="node-mindmap-node-1" transform="translate(241.6, -87)">
+        <g class="mindmap-node section-0" transform="translate(241.6, -87)" id="node-mindmap-node-1">
           <path d="M0 33 v-28 q0,-5 5,-5 h106 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="58" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Long history</text>
+          <line x1="0" y1="38" x2="116" y2="38" class="node-line-0"/>
+          <text x="58" y="19" class="mindmap-node-label" text-anchor="middle" font-size="14px" dominant-baseline="middle">Long history</text>
         </g>
         <g class="mindmap-node section-1" id="node-Research" transform="translate(105.6, 15)">
           <path d="M0 33 v-28 q0,-5 5,-5 h74 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
+          <line x1="0" y1="38" x2="84" y2="38" class="node-line-1"/>
           <text x="42" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Research</text>
         </g>
         <g class="mindmap-node section-1" transform="translate(249.6, -19)" id="node-mindmap-node-3">
           <path d="M0 33 v-28 q0,-5 5,-5 h138 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="74" y="19" class="mindmap-node-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">On effectiveness</text>
+          <line x1="0" y1="38" x2="148" y2="38" class="node-line-1"/>
+          <text x="74" y="19" class="mindmap-node-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">On effectiveness</text>
         </g>
-        <g class="mindmap-node section-1" id="node-mindmap-node-4" transform="translate(249.6, 49)">
+        <g class="mindmap-node section-1" transform="translate(249.6, 49)" id="node-mindmap-node-4">
           <path d="M0 33 v-28 q0,-5 5,-5 h178 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
+          <line x1="0" y1="38" x2="188" y2="38" class="node-line-1"/>
           <text x="94" y="19" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">On Automatic creation</text>
         </g>
-        <g class="mindmap-node section-2" id="node-Tools" transform="translate(-349.6, -19)">
+        <g class="mindmap-node section-2" transform="translate(-349.6, -19)" id="node-Tools">
           <path d="M0 33 v-28 q0,-5 5,-5 h50 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="30" y="19" class="mindmap-node-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Tools</text>
+          <line x1="0" y1="38" x2="60" y2="38" class="node-line-2"/>
+          <text x="30" y="19" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Tools</text>
         </g>
         <g class="mindmap-node section-2" transform="translate(-533.6, -53)" id="node-mindmap-node-6">
           <path d="M0 33 v-28 q0,-5 5,-5 h114 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="62" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Pen and paper</text>
+          <line x1="0" y1="38" x2="124" y2="38" class="node-line-2"/>
+          <text x="62" y="19" class="mindmap-node-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Pen and paper</text>
         </g>
         <g class="mindmap-node section-2" id="node-Mermaid" transform="translate(-485.6, 15)">
           <path d="M0 33 v-28 q0,-5 5,-5 h66 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="38" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Mermaid</text>
+          <line x1="0" y1="38" x2="76" y2="38" class="node-line-2"/>
+          <text x="38" y="19" class="mindmap-node-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Mermaid</text>
         </g>
         <g class="mindmap-node section-root" id="node-mindmap-root" transform="translate(-45.6, -45.6)">
           <circle cx="45.6" cy="45.6" r="45.6" class="node-bkg node-circle"/>
-          <text x="45.6" y="45.6" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">mindmap</text>
+          <text x="45.6" y="45.6" class="mindmap-node-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">mindmap</text>
         </g>
       </g>
     </g>

--- a/docs/images/mindmap_complex.svg
+++ b/docs/images/mindmap_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1901.1999999999998" height="504" viewBox="-1075.6 -252 1901.1999999999998 504" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1901.1999999999998" height="436" viewBox="-1075.6 -218 1901.1999999999998 436" class="mermaid">
   <style>
 
 .mindmap-node {
@@ -187,23 +187,22 @@
     </g>
     <g class="edgePaths">
       <g class="mindmap-edges">
-        <path d="M 45.6 0 Q 71.8 0 105.6 -145" class="edge section-edge-0" stroke-width="3" fill="none"/>
-        <path d="M 181.6 -145 Q 221.60000000000002 -145 241.6 -213" class="edge section-edge-0" stroke-width="3" fill="none"/>
-        <path d="M 181.6 -145 Q 233.60000000000002 -145 241.6 -145" class="edge section-edge-0" fill="none" stroke-width="3"/>
-        <path d="M 181.6 -145 Q 225.60000000000002 -145 241.6 -77" class="edge section-edge-0" fill="none" stroke-width="3"/>
-        <path d="M 373.6 -77 Q 463.6 -77 433.6 -77" class="edge section-edge-0" fill="none" stroke-width="3"/>
-        <path d="M 45.6 0 Q 73.8 0 105.6 102" class="edge section-edge-1" stroke-width="3" fill="none"/>
-        <path d="M 189.6 102 Q 235.60000000000002 102 249.6 0" class="edge section-edge-1" stroke-width="3" fill="none"/>
-        <path d="M 189.6 102 Q 245.60000000000002 102 249.6 145" class="edge section-edge-1" fill="none" stroke-width="3"/>
-        <path d="M 437.6 145 Q 433.6 145 497.6 145" class="edge section-edge-1" fill="none" stroke-width="3"/>
-        <path d="M 549.6 145 Q 609.6 145 609.6 77" class="edge section-edge-1" fill="none" stroke-width="3"/>
-        <path d="M 549.6 145 Q 607.6 145 609.6 145" class="edge section-edge-1" stroke-width="3" fill="none"/>
-        <path d="M 549.6 145 Q 603.6 145 609.6 213" class="edge section-edge-1" stroke-width="3" fill="none"/>
+        <path d="M 45.6 0 Q 71.8 0 105.6 -145" class="edge section-edge-0" fill="none" stroke-width="3"/>
+        <path d="M 181.6 -145 Q 221.60000000000002 -145 241.6 -179" class="edge section-edge-0" fill="none" stroke-width="3"/>
+        <path d="M 181.6 -145 Q 225.60000000000002 -145 241.6 -111" class="edge section-edge-0" stroke-width="3" fill="none"/>
+        <path d="M 373.6 -111 Q 463.6 -111 433.6 -111" class="edge section-edge-0" stroke-width="3" fill="none"/>
+        <path d="M 45.6 0 Q 73.8 0 105.6 68" class="edge section-edge-1" stroke-width="3" fill="none"/>
+        <path d="M 189.6 68 Q 235.60000000000002 68 249.6 -34" class="edge section-edge-1" fill="none" stroke-width="3"/>
+        <path d="M 189.6 68 Q 245.60000000000002 68 249.6 111" class="edge section-edge-1" stroke-width="3" fill="none"/>
+        <path d="M 437.6 111 Q 433.6 111 497.6 111" class="edge section-edge-1" fill="none" stroke-width="3"/>
+        <path d="M 549.6 111 Q 609.6 111 609.6 43" class="edge section-edge-1" stroke-width="3" fill="none"/>
+        <path d="M 549.6 111 Q 607.6 111 609.6 111" class="edge section-edge-1" stroke-width="3" fill="none"/>
+        <path d="M 549.6 111 Q 603.6 111 609.6 179" class="edge section-edge-1" stroke-width="3" fill="none"/>
         <path d="M 45.6 0 Q -238.8 0 -507.6 0" class="edge section-edge-2" fill="none" stroke-width="3"/>
         <path d="M -447.6 0 Q -553.6 0 -691.6 -88" class="edge section-edge-2" fill="none" stroke-width="3"/>
-        <path d="M -447.6 0 Q -644.6 0 -849.6 34" class="edge section-edge-2" stroke-width="3" fill="none"/>
+        <path d="M -447.6 0 Q -644.6 0 -849.6 34" class="edge section-edge-2" fill="none" stroke-width="3"/>
         <path d="M -773.6 34 Q -897.0999999999999 34 -1055.6 -10" class="edge section-edge-2" fill="none" stroke-width="3"/>
-        <path d="M -773.6 34 Q -895.0999999999999 34 -1047.6 78" class="edge section-edge-2" fill="none" stroke-width="3"/>
+        <path d="M -773.6 34 Q -895.0999999999999 34 -1047.6 78" class="edge section-edge-2" stroke-width="3" fill="none"/>
       </g>
     </g>
     <g class="edgeLabels">
@@ -211,77 +210,88 @@
     </g>
     <g class="nodes">
       <g class="mindmap-nodes">
-        <g class="mindmap-node section-0" id="node-Origins" transform="translate(105.6, -164)">
+        <g class="mindmap-node section-0" transform="translate(105.6, -164)" id="node-Origins">
           <path d="M0 33 v-28 q0,-5 5,-5 h66 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="38" y="19" class="mindmap-node-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Origins</text>
+          <line x1="0" y1="38" x2="76" y2="38" class="node-line-0"/>
+          <text x="38" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Origins</text>
         </g>
-        <g class="mindmap-node section-0" id="node-mindmap-node-1" transform="translate(241.6, -232)">
+        <g class="mindmap-node section-0" id="node-mindmap-node-1" transform="translate(241.6, -198)">
           <path d="M0 33 v-28 q0,-5 5,-5 h106 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="58" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Long history</text>
+          <line x1="0" y1="38" x2="116" y2="38" class="node-line-0"/>
+          <foreignObject x="38" y="-10" width="40" height="40" style="text-align:center;"><div xmlns="http://www.w3.org/1999/xhtml" class="icon-container" style="height:100%;display:flex;justify-content:center;align-items:center;"><i class="node-icon-0 fa fa-book"></i></div></foreignObject>
+          <text x="58" y="19" class="mindmap-node-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Long history</text>
         </g>
-        <g class="mindmap-node section-0" transform="translate(241.6, -164)" id="node-mindmap-node-2">
-          <path d="M0 33 v-28 q0,-5 5,-5 h154 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="82" y="19" class="mindmap-node-label" text-anchor="middle" font-size="14px" dominant-baseline="middle">::icon(fa fa-book)</text>
-        </g>
-        <g class="mindmap-node section-0" id="node-Popularisation" transform="translate(241.6, -96)">
+        <g class="mindmap-node section-0" id="node-Popularisation" transform="translate(241.6, -130)">
           <path d="M0 33 v-28 q0,-5 5,-5 h122 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="66" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Popularisation</text>
+          <line x1="0" y1="38" x2="132" y2="38" class="node-line-0"/>
+          <text x="66" y="19" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Popularisation</text>
         </g>
-        <g class="mindmap-node section-0" id="node-mindmap-node-4" transform="translate(433.6, -96)">
+        <g class="mindmap-node section-0" transform="translate(433.6, -130)" id="node-mindmap-node-3">
           <path d="M0 33 v-28 q0,-5 5,-5 h362 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="186" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">British popular psychology author Tony Buzan</text>
+          <line x1="0" y1="38" x2="372" y2="38" class="node-line-0"/>
+          <text x="186" y="19" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">British popular psychology author Tony Buzan</text>
         </g>
-        <g class="mindmap-node section-1" id="node-Research" transform="translate(105.6, 83)">
+        <g class="mindmap-node section-1" id="node-Research" transform="translate(105.6, 49)">
           <path d="M0 33 v-28 q0,-5 5,-5 h74 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
+          <line x1="0" y1="38" x2="84" y2="38" class="node-line-1"/>
           <text x="42" y="19" class="mindmap-node-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Research</text>
         </g>
-        <g class="mindmap-node section-1" id="node-mindmap-node-6" transform="translate(249.6, -28)">
+        <g class="mindmap-node section-1" id="node-mindmap-node-5" transform="translate(249.6, -62)">
           <path d="M0 51 v-46 q0,-5 5,-5 h138 q5,0 5,5 v51 H0 Z" class="node-bkg node-default"/>
-          <text x="74" y="28" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px"><tspan x="74" y="28" dy="-0.6em">On effectiveness</tspan><tspan x="74" dy="1.2em">and features</tspan></text>
+          <line x1="0" y1="56" x2="148" y2="56" class="node-line-1"/>
+          <text x="74" y="28" class="mindmap-node-label" dominant-baseline="middle" text-anchor="middle" font-size="14px"><tspan x="74" y="28" dy="-0.6em">On effectiveness</tspan><tspan x="74" dy="1.2em">and features</tspan></text>
         </g>
-        <g class="mindmap-node section-1" transform="translate(249.6, 126)" id="node-mindmap-node-7">
+        <g class="mindmap-node section-1" transform="translate(249.6, 92)" id="node-mindmap-node-6">
           <path d="M0 33 v-28 q0,-5 5,-5 h178 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="94" y="19" class="mindmap-node-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">On Automatic creation</text>
+          <line x1="0" y1="38" x2="188" y2="38" class="node-line-1"/>
+          <text x="94" y="19" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">On Automatic creation</text>
         </g>
-        <g class="mindmap-node section-1" id="node-Uses" transform="translate(497.6, 126)">
+        <g class="mindmap-node section-1" id="node-Uses" transform="translate(497.6, 92)">
           <path d="M0 33 v-28 q0,-5 5,-5 h42 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="26" y="19" class="mindmap-node-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Uses</text>
+          <line x1="0" y1="38" x2="52" y2="38" class="node-line-1"/>
+          <text x="26" y="19" class="mindmap-node-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Uses</text>
         </g>
-        <g class="mindmap-node section-1" id="node-mindmap-node-9" transform="translate(609.6, 58)">
+        <g class="mindmap-node section-1" transform="translate(609.6, 24)" id="node-mindmap-node-8">
           <path d="M0 33 v-28 q0,-5 5,-5 h162 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="86" y="19" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Creative techniques</text>
+          <line x1="0" y1="38" x2="172" y2="38" class="node-line-1"/>
+          <text x="86" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Creative techniques</text>
         </g>
-        <g class="mindmap-node section-1" id="node-mindmap-node-10" transform="translate(609.6, 126)">
+        <g class="mindmap-node section-1" id="node-mindmap-node-9" transform="translate(609.6, 92)">
           <path d="M0 33 v-28 q0,-5 5,-5 h154 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="82" y="19" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Strategic planning</text>
+          <line x1="0" y1="38" x2="164" y2="38" class="node-line-1"/>
+          <text x="82" y="19" class="mindmap-node-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Strategic planning</text>
         </g>
-        <g class="mindmap-node section-1" id="node-mindmap-node-11" transform="translate(609.6, 194)">
+        <g class="mindmap-node section-1" id="node-mindmap-node-10" transform="translate(609.6, 160)">
           <path d="M0 33 v-28 q0,-5 5,-5 h138 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="74" y="19" class="mindmap-node-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Argument mapping</text>
+          <line x1="0" y1="38" x2="148" y2="38" class="node-line-1"/>
+          <text x="74" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Argument mapping</text>
         </g>
-        <g class="mindmap-node section-2" transform="translate(-507.6, -19)" id="node-Tools">
+        <g class="mindmap-node section-2" id="node-Tools" transform="translate(-507.6, -19)">
           <path d="M0 33 v-28 q0,-5 5,-5 h50 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
+          <line x1="0" y1="38" x2="60" y2="38" class="node-line-2"/>
           <text x="30" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Tools</text>
         </g>
-        <g class="mindmap-node section-2" id="node-mindmap-node-13" transform="translate(-691.6, -107)">
+        <g class="mindmap-node section-2" transform="translate(-691.6, -107)" id="node-mindmap-node-12">
           <path d="M0 33 v-28 q0,-5 5,-5 h114 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="62" y="19" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Pen and paper</text>
+          <line x1="0" y1="38" x2="124" y2="38" class="node-line-2"/>
+          <text x="62" y="19" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Pen and paper</text>
         </g>
-        <g class="mindmap-node section-2" transform="translate(-849.6, 15)" id="node-Mermaid">
+        <g class="mindmap-node section-2" id="node-Mermaid" transform="translate(-849.6, 15)">
           <path d="M0 33 v-28 q0,-5 5,-5 h66 q5,0 5,5 v33 H0 Z" class="node-bkg node-default"/>
-          <text x="38" y="19" class="mindmap-node-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Mermaid</text>
+          <line x1="0" y1="38" x2="76" y2="38" class="node-line-2"/>
+          <text x="38" y="19" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Mermaid</text>
         </g>
-        <g class="mindmap-node section-2" id="node-cloud" transform="translate(-1055.6, -39)">
+        <g class="mindmap-node section-2" transform="translate(-1055.6, -39)" id="node-cloud">
           <path d="M0 0 a21.9,21.9 0 0,1 36.5,-14.600000000000001 a51.099999999999994,51.099999999999994 1 0,1 58.400000000000006,-14.600000000000001 a36.5,36.5 1 0,1 51.099999999999994,29.200000000000003 a21.9,21.9 1 0,1 21.9,20.299999999999997 a29.200000000000003,29.200000000000003 1 0,1 -21.9,37.7 a36.5,21.9 1 0,1 -36.5,21.9 a51.099999999999994,51.099999999999994 1 0,1 -73,0 a21.9,21.9 1 0,1 -36.5,-21.9 a21.9,21.9 1 0,1 -14.600000000000001,-20.299999999999997 a29.200000000000003,29.200000000000003 1 0,1 14.600000000000001,-37.7 H0 V0 Z" class="node-bkg node-cloud"/>
-          <text x="73" y="29" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">I am a cloud</text>
+          <text x="73" y="29" class="mindmap-node-label" text-anchor="middle" font-size="14px" dominant-baseline="middle">I am a cloud</text>
         </g>
-        <g class="mindmap-node section-2" id="node-bang" transform="translate(-1047.6, 49)">
+        <g class="mindmap-node section-2" transform="translate(-1047.6, 49)" id="node-bang">
           <path d="M0 0 a20.7,20.7 1 0,0 34.5,-5.800000000000001 a20.7,20.7 1 0,0 34.5,0 a20.7,20.7 1 0,0 34.5,0 a20.7,20.7 1 0,0 34.5,5.800000000000001 a20.7,20.7 1 0,0 20.7,19.14 a16.56,16.56 1 0,0 0,19.720000000000002 a20.7,20.7 1 0,0 -20.7,19.14 a20.7,20.7 1 0,0 -34.5,8.7 a20.7,20.7 1 0,0 -34.5,0 a20.7,20.7 1 0,0 -34.5,0 a20.7,20.7 1 0,0 -34.5,-8.7 a20.7,20.7 1 0,0 -13.8,-19.14 a16.56,16.56 1 0,0 0,-19.720000000000002 a20.7,20.7 1 0,0 13.8,-19.14 H0 V0 Z" class="node-bkg node-bang"/>
-          <text x="69" y="29" class="mindmap-node-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">I am a bang</text>
+          <text x="69" y="29" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">I am a bang</text>
         </g>
-        <g class="mindmap-node section-root" transform="translate(-45.6, -45.6)" id="node-mindmap-root">
+        <g class="mindmap-node section-root" id="node-mindmap-root" transform="translate(-45.6, -45.6)">
           <circle cx="45.6" cy="45.6" r="45.6" class="node-bkg node-circle"/>
-          <text x="45.6" y="45.6" class="mindmap-node-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">mindmap</text>
+          <text x="45.6" y="45.6" class="mindmap-node-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">mindmap</text>
         </g>
       </g>
     </g>

--- a/src/diagrams/mindmap/parser.rs
+++ b/src/diagrams/mindmap/parser.rs
@@ -31,7 +31,8 @@ static NODE_BANG_RE: LazyLock<Regex> =
 static NODE_HEXAGON_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(\w+)?\{\{([^}]+)\}\}$").unwrap());
 
-static ICON_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^::icon\((\w+)\)$").unwrap());
+// Icon classes can contain multiple space-separated words with hyphens (e.g., "fa fa-book")
+static ICON_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^::icon\(([^)]+)\)$").unwrap());
 
 static CLASS_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^:::(.+)$").unwrap());
 

--- a/src/render/mindmap.rs
+++ b/src/render/mindmap.rs
@@ -451,9 +451,9 @@ fn render_node(node: &PositionedNode, _config: &RenderConfig) -> SvgElement {
         classes.push(class.clone());
     }
 
-    // Render shape based on node type
-    let shape = render_node_shape(node);
-    node_children.push(shape);
+    // Render shape based on node type (may include multiple elements like path + line)
+    let shapes = render_node_shape(node);
+    node_children.extend(shapes);
 
     // Render icon if present
     if let Some(ref icon) = node.icon {
@@ -476,10 +476,11 @@ fn render_node(node: &PositionedNode, _config: &RenderConfig) -> SvgElement {
 }
 
 /// Render node shape based on type
-fn render_node_shape(node: &PositionedNode) -> SvgElement {
+/// Returns a vector of SVG elements (some shapes like Default include multiple elements)
+fn render_node_shape(node: &PositionedNode) -> Vec<SvgElement> {
     match node.node_type {
         NodeType::Default => {
-            // Default shape: rounded rectangle with bottom line
+            // Default shape: rounded rectangle with decorative bottom line (mermaid.js style)
             let rd = 5.0;
             let path = format!(
                 "M0 {} v{} q0,-5 5,-5 h{} q5,0 5,5 v{} H0 Z",
@@ -488,14 +489,32 @@ fn render_node_shape(node: &PositionedNode) -> SvgElement {
                 node.width - 2.0 * rd,
                 node.height - rd
             );
-            SvgElement::Path {
-                d: path,
-                attrs: Attrs::new().with_class("node-bkg node-default"),
-            }
+
+            // Line class uses the section number for color coordination
+            let line_class = if node.section >= 0 {
+                format!("node-line-{}", node.section % (MAX_SECTIONS as i32 - 1))
+            } else {
+                "node-line-root".to_string()
+            };
+
+            vec![
+                SvgElement::Path {
+                    d: path,
+                    attrs: Attrs::new().with_class("node-bkg node-default"),
+                },
+                // Decorative line at the bottom of the node (matches mermaid.js)
+                SvgElement::Line {
+                    x1: 0.0,
+                    y1: node.height,
+                    x2: node.width,
+                    y2: node.height,
+                    attrs: Attrs::new().with_class(&line_class),
+                },
+            ]
         }
         NodeType::Rect => {
             // Square/rectangle
-            SvgElement::Rect {
+            vec![SvgElement::Rect {
                 x: 0.0,
                 y: 0.0,
                 width: node.width,
@@ -503,11 +522,11 @@ fn render_node_shape(node: &PositionedNode) -> SvgElement {
                 rx: None,
                 ry: None,
                 attrs: Attrs::new().with_class("node-bkg node-rect"),
-            }
+            }]
         }
         NodeType::RoundedRect => {
             // Rounded rectangle
-            SvgElement::Rect {
+            vec![SvgElement::Rect {
                 x: 0.0,
                 y: 0.0,
                 width: node.width,
@@ -515,17 +534,17 @@ fn render_node_shape(node: &PositionedNode) -> SvgElement {
                 rx: Some(NODE_PADDING),
                 ry: Some(NODE_PADDING),
                 attrs: Attrs::new().with_class("node-bkg node-rounded"),
-            }
+            }]
         }
         NodeType::Circle => {
             // Circle - centered in the node box
             let radius = node.width.min(node.height) / 2.0;
-            SvgElement::Circle {
+            vec![SvgElement::Circle {
                 cx: node.width / 2.0,
                 cy: node.height / 2.0,
                 r: radius,
                 attrs: Attrs::new().with_class("node-bkg node-circle"),
-            }
+            }]
         }
         NodeType::Cloud => {
             // Cloud shape using arcs
@@ -566,10 +585,10 @@ fn render_node_shape(node: &PositionedNode) -> SvgElement {
                 r4 = r4
             );
 
-            SvgElement::Path {
+            vec![SvgElement::Path {
                 d: path,
                 attrs: Attrs::new().with_class("node-bkg node-cloud"),
-            }
+            }]
         }
         NodeType::Bang => {
             // Bang/explosion shape
@@ -599,10 +618,10 @@ fn render_node_shape(node: &PositionedNode) -> SvgElement {
                 r = r
             );
 
-            SvgElement::Path {
+            vec![SvgElement::Path {
                 d: path,
                 attrs: Attrs::new().with_class("node-bkg node-bang"),
-            }
+            }]
         }
         NodeType::Hexagon => {
             // Hexagon shape
@@ -625,10 +644,10 @@ fn render_node_shape(node: &PositionedNode) -> SvgElement {
                 h / 2.0
             );
 
-            SvgElement::PolygonStr {
+            vec![SvgElement::PolygonStr {
                 points,
                 attrs: Attrs::new().with_class("node-bkg node-hexagon"),
-            }
+            }]
         }
     }
 }

--- a/tests/mindmap_rendering.rs
+++ b/tests/mindmap_rendering.rs
@@ -448,3 +448,71 @@ fn mindmap_with_children_deep_hierarchy() {
         "Should have mindmap-node class"
     );
 }
+
+// ============================================================================
+// Visual Parity Tests (for mermaid compatibility)
+// ============================================================================
+
+fn count_elements_by_tag(doc: &Document<'_>, tag_name: &str) -> usize {
+    doc.descendants()
+        .filter(|node| node.tag_name().name() == tag_name)
+        .count()
+}
+
+#[test]
+fn mindmap_icon_with_multiple_classes_not_parsed_as_node() {
+    // Bug: Icons with multiple classes (e.g., "fa fa-book") were being parsed as nodes
+    // because the regex only matched single-word icon classes.
+    // This caused an extra node to appear in diagrams.
+    let input = r#"mindmap
+root((mindmap))
+    Origins
+        Long history
+        ::icon(fa fa-book)
+        Popularisation"#;
+    let svg = render_mindmap_svg(input);
+    let doc = parse_svg(&svg);
+
+    // Should have exactly 4 nodes: root, Origins, Long history, Popularisation
+    // NOT 5 nodes (with icon line as a node)
+    let node_count = count_elements_with_class(&doc, "mindmap-node");
+    assert_eq!(
+        node_count, 4,
+        "Icon line should not be parsed as a node. \
+         Expected 4 nodes (root, Origins, Long history, Popularisation), got {}",
+        node_count
+    );
+}
+
+#[test]
+fn mindmap_default_nodes_have_bottom_lines() {
+    // Default-style nodes in mermaid have a decorative line at the bottom
+    // This test verifies that Selkie renders these lines to match mermaid output
+    let input = r#"mindmap
+root((mindmap))
+    Origins
+        Long history
+    Research
+        On effectiveness
+        On Automatic creation
+    Tools
+        Pen and paper
+        Mermaid"#;
+    let svg = render_mindmap_svg(input);
+    let doc = parse_svg(&svg);
+
+    // Count default nodes (nodes that aren't root - root is a circle)
+    // We expect: Origins, Long history, Research, On effectiveness,
+    // On Automatic creation, Tools, Pen and paper, Mermaid = 8 default nodes
+    let default_node_count = 8;
+
+    // Each default node should have one <line> element at the bottom
+    let line_count = count_elements_by_tag(&doc, "line");
+
+    assert_eq!(
+        line_count, default_node_count,
+        "Each default-style node should have a decorative bottom line. \
+         Expected {} lines for {} default nodes, but found {}",
+        default_node_count, default_node_count, line_count
+    );
+}


### PR DESCRIPTION
Fixed mindmap visual parity:
- Added decorative bottom lines to default nodes (was missing entirely)
- Fixed icon regex to accept multi-word classes like 'fa fa-book' (was being parsed as nodes)

Eval errors reduced from 2 to 0, warnings from 11 to 8.

Issue: se-iwlt