### PR TITLE
feat(sequence): improve visual parity with mermaid.js

### DIFF
--- a/docs/images/example_sequence_basic.svg
+++ b/docs/images/example_sequence_basic.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="650" height="502" viewBox="0 0 650 502" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="690" height="478" viewBox="-50 -10 690 478" class="mermaid">
   <style>
 
 .mermaid {
@@ -211,60 +211,60 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
   </defs>
   <g class="root">
     <g class="clusters">
-      <line x1="125" y1="75" x2="125" y2="427" class="actor-line" stroke-width="0.5px"/>
-      <line x1="325" y1="75" x2="325" y2="427" class="actor-line" stroke-width="0.5px"/>
-      <line x1="525" y1="75" x2="525" y2="427" class="actor-line" stroke-width="0.5px"/>
+      <line x1="75" y1="65" x2="75" y2="393" class="actor-line" stroke-width="0.5px"/>
+      <line x1="295" y1="65" x2="295" y2="393" class="actor-line" stroke-width="0.5px"/>
+      <line x1="515" y1="65" x2="515" y2="393" class="actor-line" stroke-width="0.5px"/>
     </g>
     <g class="edgePaths">
-      <line x1="125" y1="119" x2="325" y2="119" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="325" y1="163" x2="525" y2="163" class="message-line" stroke-width="1.5" stroke-dasharray="5,5" marker-end="url(#arrow-filled)"/>
-      <line x1="325" y1="207" x2="125" y2="207" class="message-line" marker-end="url(#arrow-cross)" stroke-dasharray="5,5" stroke-width="1.5"/>
-      <line x1="325" y1="251" x2="525" y2="251" class="message-line" marker-end="url(#arrow-cross)" stroke-width="1.5"/>
-      <line x1="325" y1="339" x2="125" y2="339" class="message-line" stroke-width="1.5" stroke-dasharray="5,5"/>
-      <line x1="125" y1="383" x2="525" y2="383" class="message-line" stroke-width="1.5"/>
+      <line x1="75" y1="109" x2="295" y2="109" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="295" y1="153" x2="515" y2="153" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="5,5" stroke-width="1.5"/>
+      <line x1="295" y1="197" x2="75" y2="197" class="message-line" stroke-width="1.5" stroke-dasharray="5,5" marker-end="url(#arrow-cross)"/>
+      <line x1="295" y1="241" x2="515" y2="241" class="message-line" marker-end="url(#arrow-cross)" stroke-width="1.5"/>
+      <line x1="295" y1="329" x2="75" y2="329" class="message-line" stroke-width="1.5" stroke-dasharray="5,5"/>
+      <line x1="75" y1="373" x2="515" y2="373" class="message-line" stroke-width="1.5"/>
     </g>
     <g class="edgeLabels">
-      <text x="225" y="109" class="message-label" text-anchor="middle" font-size="16">Hello Bob, how are you?</text>
-      <text x="425" y="153" class="message-label" text-anchor="middle" font-size="16">How about you John?</text>
-      <text x="225" y="197" class="message-label" font-size="16" text-anchor="middle">I am good thanks!</text>
-      <text x="425" y="241" class="message-label" text-anchor="middle" font-size="16">I am good thanks!</text>
-      <text x="225" y="329" class="message-label" font-size="16" text-anchor="middle">Checking with John...</text>
-      <text x="325" y="373" class="message-label" text-anchor="middle" font-size="16">Yes... John, how are you?</text>
+      <text x="185" y="99" class="message-label" font-size="16" text-anchor="middle">Hello Bob, how are you?</text>
+      <text x="405" y="143" class="message-label" text-anchor="middle" font-size="16">How about you John?</text>
+      <text x="185" y="187" class="message-label" text-anchor="middle" font-size="16">I am good thanks!</text>
+      <text x="405" y="231" class="message-label" font-size="16" text-anchor="middle">I am good thanks!</text>
+      <text x="185" y="319" class="message-label" text-anchor="middle" font-size="16">Checking with John...</text>
+      <text x="295" y="363" class="message-label" text-anchor="middle" font-size="16">Yes... John, how are you?</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="50" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="125" y="42.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Alice</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="75" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="250" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="325" y="42.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Bob</text>
+      <rect x="220" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="295" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Bob</text>
     </g>
     <g class="actor">
-      <rect x="450" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="525" y="42.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">John</text>
+      <rect x="440" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="515" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">John</text>
     </g>
     <g class="note">
-      <path d="M 545 247 L 637 247 L 645 255 L 645 343 L 545 343 Z" class="note note-box" stroke="#666" fill="#EDF2AE" stroke-width="1"/>
-      <path d="M 637 247 L 637 255 L 645 255" class="note" stroke-width="1" fill="none"/>
-      <text x="595" y="273" class="note-text" text-anchor="middle" font-size="16">Bob thinks a long</text>
-      <text x="595" y="292" class="note-text" text-anchor="middle" font-size="16">long time, so long</text>
-      <text x="595" y="311" class="note-text" text-anchor="middle" font-size="16">that the text does</text>
-      <text x="595" y="330" class="note-text" font-size="16" text-anchor="middle">not fit on a row.</text>
+      <path d="M 535 237 L 627 237 L 635 245 L 635 333 L 535 333 Z" class="note note-box" fill="#EDF2AE" stroke="#666" stroke-width="1"/>
+      <path d="M 627 237 L 627 245 L 635 245" class="note" fill="none" stroke-width="1"/>
+      <text x="585" y="263" class="note-text" font-size="16" text-anchor="middle">Bob thinks a long</text>
+      <text x="585" y="282" class="note-text" font-size="16" text-anchor="middle">long time, so long</text>
+      <text x="585" y="301" class="note-text" text-anchor="middle" font-size="16">that the text does</text>
+      <text x="585" y="320" class="note-text" text-anchor="middle" font-size="16">not fit on a row.</text>
     </g>
     <g class="actor">
-      <rect x="50" y="427" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="125" y="459.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
+      <rect x="0" y="393" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="75" y="425.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="250" y="427" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="325" y="459.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Bob</text>
+      <rect x="220" y="393" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="295" y="425.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Bob</text>
     </g>
     <g class="actor">
-      <rect x="450" y="427" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="525" y="459.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">John</text>
+      <rect x="440" y="393" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="515" y="425.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">John</text>
     </g>
   </g>
 </svg>

--- a/docs/images/example_sequence_blogging.svg
+++ b/docs/images/example_sequence_blogging.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1050" height="898" viewBox="0 0 1050 898" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1274" height="874" viewBox="-50 -10 1274 874" class="mermaid">
   <style>
 
 .mermaid {
@@ -211,102 +211,102 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
   </defs>
   <g class="root">
     <g class="clusters">
-      <line x1="40" y1="383" x2="610" y2="383" class="loopLine" stroke-dasharray="3,3"/>
-      <line x1="250" y1="735" x2="1000" y2="735" class="loopLine" stroke-dasharray="3,3"/>
-      <rect x="50" y="581" width="950" height="220" rx="3" ry="3" class="loopLine" fill="none"/>
-      <rect x="40" y="273" width="970" height="528" rx="3" ry="3" class="loopLine" fill="none"/>
-      <line x1="125" y1="75" x2="125" y2="823" class="actor-line" stroke-width="0.5px"/>
-      <line x1="325" y1="75" x2="325" y2="823" class="actor-line" stroke-width="0.5px"/>
-      <line x1="525" y1="75" x2="525" y2="823" class="actor-line" stroke-width="0.5px"/>
-      <line x1="725" y1="75" x2="725" y2="823" class="actor-line" stroke-width="0.5px"/>
-      <line x1="925" y1="75" x2="925" y2="823" class="actor-line" stroke-width="0.5px"/>
-      <rect x="520" y="163" width="10" height="264" rx="1" ry="1" class="activation"/>
-      <rect x="320" y="515" width="10" height="264" rx="1" ry="1" class="activation"/>
+      <line x1="-10" y1="373" x2="672" y2="373" class="loopLine" stroke-dasharray="3,3"/>
+      <line x1="256" y1="725" x2="1174" y2="725" class="loopLine" stroke-dasharray="3,3"/>
+      <rect x="0" y="571" width="1174" height="220" rx="3" ry="3" class="loopLine" fill="none"/>
+      <rect x="-10" y="263" width="1194" height="528" rx="3" ry="3" class="loopLine" fill="none"/>
+      <line x1="75" y1="65" x2="75" y2="789" class="actor-line" stroke-width="0.5px"/>
+      <line x1="331" y1="65" x2="331" y2="789" class="actor-line" stroke-width="0.5px"/>
+      <line x1="587" y1="65" x2="587" y2="789" class="actor-line" stroke-width="0.5px"/>
+      <line x1="843" y1="65" x2="843" y2="789" class="actor-line" stroke-width="0.5px"/>
+      <line x1="1099" y1="65" x2="1099" y2="789" class="actor-line" stroke-width="0.5px"/>
+      <rect x="582" y="153" width="10" height="264" rx="1" ry="1" class="activation"/>
+      <rect x="326" y="505" width="10" height="264" rx="1" ry="1" class="activation"/>
     </g>
     <g class="edgePaths">
-      <line x1="125" y1="163" x2="525" y2="163" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="525" y1="207" x2="925" y2="207" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="925" y1="251" x2="525" y2="251" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="525" y1="339" x2="125" y2="339" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="525" y1="427" x2="125" y2="427" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="125" y1="515" x2="325" y2="515" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="325" y1="559" x2="925" y2="559" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <path d="M 325 647 L 365 647 L 365 677 L 325 677" class="message-line" fill="none" marker-end="url(#arrow-filled)" stroke-dasharray="5,5" stroke-width="1.5"/>
-      <path d="M 325 691 L 365 691 L 365 721 L 325 721" class="message-line" stroke-width="1.5" fill="none" marker-end="url(#arrow-filled)" stroke-dasharray="5,5"/>
-      <line x1="325" y1="779" x2="125" y2="779" class="message-line" stroke-dasharray="5,5" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="75" y1="153" x2="587" y2="153" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="587" y1="197" x2="1099" y2="197" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="1099" y1="241" x2="587" y2="241" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="587" y1="329" x2="75" y2="329" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="587" y1="417" x2="75" y2="417" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="75" y1="505" x2="331" y2="505" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="331" y1="549" x2="1099" y2="549" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <path d="M 331 637 L 371 637 L 371 667 L 331 667" class="message-line" stroke-width="1.5" stroke-dasharray="5,5" fill="none" marker-end="url(#arrow-filled)"/>
+      <path d="M 331 681 L 371 681 L 371 711 L 331 711" class="message-line" stroke-width="1.5" fill="none" marker-end="url(#arrow-filled)" stroke-dasharray="5,5"/>
+      <line x1="331" y1="769" x2="75" y2="769" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="5,5"/>
     </g>
     <g class="edgeLabels">
-      <text x="325" y="153" class="message-label" text-anchor="middle" font-size="16">Logs in using credentials</text>
-      <text x="725" y="197" class="message-label" text-anchor="middle" font-size="16">Query stored accounts</text>
-      <text x="725" y="241" class="message-label" text-anchor="middle" font-size="16">Respond with query result</text>
-      <text x="325" y="329" class="message-label" font-size="16" text-anchor="middle">Invalid credentials</text>
-      <text x="325" y="401" class="loopText" font-size="16" text-anchor="middle">[Credentials found]</text>
-      <text x="325" y="417" class="message-label" text-anchor="middle" font-size="16">Successfully logged in</text>
-      <text x="225" y="505" class="message-label" text-anchor="middle" font-size="16">Submit new post</text>
-      <text x="625" y="549" class="message-label" text-anchor="middle" font-size="16">Store post data</text>
-      <text x="370" y="662" class="message-label" font-size="16" text-anchor="start">Send mail to blog subscribers</text>
-      <text x="370" y="706" class="message-label" font-size="16" text-anchor="start">Store in-site notifications</text>
-      <text x="625" y="753" class="loopText" font-size="16" text-anchor="middle">[Response]</text>
-      <text x="225" y="769" class="message-label" text-anchor="middle" font-size="16">Successfully posted</text>
-      <polygon points="60,581 110,581 110,594 102,601 60,601" class="labelBox"/>
-      <text x="85" y="594" class="labelText" font-size="16" text-anchor="middle">par</text>
-      <text x="525" y="599" class="loopText" text-anchor="middle" font-size="16">[Notifications]</text>
-      <polygon points="50,273 100,273 100,286 92,293 50,293" class="labelBox"/>
-      <text x="75" y="286" class="labelText" text-anchor="middle" font-size="16">alt</text>
-      <text x="525" y="291" class="loopText" text-anchor="middle" font-size="16">[Credentials not found]</text>
+      <text x="331" y="143" class="message-label" font-size="16" text-anchor="middle">Logs in using credentials</text>
+      <text x="843" y="187" class="message-label" font-size="16" text-anchor="middle">Query stored accounts</text>
+      <text x="843" y="231" class="message-label" text-anchor="middle" font-size="16">Respond with query result</text>
+      <text x="331" y="319" class="message-label" text-anchor="middle" font-size="16">Invalid credentials</text>
+      <text x="331" y="391" class="loopText" font-size="16" text-anchor="middle">[Credentials found]</text>
+      <text x="331" y="407" class="message-label" text-anchor="middle" font-size="16">Successfully logged in</text>
+      <text x="203" y="495" class="message-label" font-size="16" text-anchor="middle">Submit new post</text>
+      <text x="715" y="539" class="message-label" font-size="16" text-anchor="middle">Store post data</text>
+      <text x="376" y="652" class="message-label" text-anchor="start" font-size="16">Send mail to blog subscribers</text>
+      <text x="376" y="696" class="message-label" text-anchor="start" font-size="16">Store in-site notifications</text>
+      <text x="715" y="743" class="loopText" text-anchor="middle" font-size="16">[Response]</text>
+      <text x="203" y="759" class="message-label" font-size="16" text-anchor="middle">Successfully posted</text>
+      <polygon points="10,571 60,571 60,584 52,591 10,591" class="labelBox"/>
+      <text x="35" y="584" class="labelText" text-anchor="middle" font-size="16">par</text>
+      <text x="587" y="589" class="loopText" text-anchor="middle" font-size="16">[Notifications]</text>
+      <polygon points="0,263 50,263 50,276 42,283 0,283" class="labelBox"/>
+      <text x="25" y="276" class="labelText" font-size="16" text-anchor="middle">alt</text>
+      <text x="587" y="281" class="loopText" font-size="16" text-anchor="middle">[Credentials not found]</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="50" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="125" y="42.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Web Browser</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="75" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Web Browser</text>
     </g>
     <g class="actor">
-      <rect x="250" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="325" y="42.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Blog Service</text>
+      <rect x="256" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="331" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Blog Service</text>
     </g>
     <g class="actor">
-      <rect x="450" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="525" y="42.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Account Service</text>
+      <rect x="512" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="587" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Account Service</text>
     </g>
     <g class="actor">
-      <rect x="650" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="725" y="42.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Mail Service</text>
+      <rect x="768" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="843" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Mail Service</text>
     </g>
     <g class="actor">
-      <rect x="850" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="925" y="42.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Storage</text>
+      <rect x="1024" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="1099" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Storage</text>
     </g>
     <g class="note">
-      <path d="M 115 99 L 927 99 L 935 107 L 935 139 L 115 139 Z" class="note note-box" stroke="#666" stroke-width="1" fill="#EDF2AE"/>
-      <path d="M 927 99 L 927 107 L 935 107" class="note" fill="none" stroke-width="1"/>
-      <text x="525" y="125" class="note-text" font-size="16" text-anchor="middle">The user must be logged in to submit blog posts</text>
+      <path d="M 65 89 L 1101 89 L 1109 97 L 1109 129 L 65 129 Z" class="note note-box" stroke-width="1" fill="#EDF2AE" stroke="#666"/>
+      <path d="M 1101 89 L 1101 97 L 1109 97" class="note" fill="none" stroke-width="1"/>
+      <text x="587" y="115" class="note-text" font-size="16" text-anchor="middle">The user must be logged in to submit blog posts</text>
     </g>
     <g class="note">
-      <path d="M 115 451 L 927 451 L 935 459 L 935 491 L 115 491 Z" class="note note-box" stroke-width="1" fill="#EDF2AE" stroke="#666"/>
-      <path d="M 927 451 L 927 459 L 935 459" class="note" fill="none" stroke-width="1"/>
-      <text x="525" y="477" class="note-text" text-anchor="middle" font-size="16">When the user is authenticated, they can now submit new posts</text>
+      <path d="M 65 441 L 1101 441 L 1109 449 L 1109 481 L 65 481 Z" class="note note-box" stroke-width="1" fill="#EDF2AE" stroke="#666"/>
+      <path d="M 1101 441 L 1101 449 L 1109 449" class="note" stroke-width="1" fill="none"/>
+      <text x="587" y="467" class="note-text" text-anchor="middle" font-size="16">When the user is authenticated, they can now submit new posts</text>
     </g>
     <g class="actor">
-      <rect x="50" y="823" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="125" y="855.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Web Browser</text>
+      <rect x="0" y="789" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="75" y="821.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Web Browser</text>
     </g>
     <g class="actor">
-      <rect x="250" y="823" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="325" y="855.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Blog Service</text>
+      <rect x="256" y="789" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="331" y="821.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Blog Service</text>
     </g>
     <g class="actor">
-      <rect x="450" y="823" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="525" y="855.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Account Service</text>
+      <rect x="512" y="789" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="587" y="821.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Account Service</text>
     </g>
     <g class="actor">
-      <rect x="650" y="823" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="725" y="855.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Mail Service</text>
+      <rect x="768" y="789" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="843" y="821.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Mail Service</text>
     </g>
     <g class="actor">
-      <rect x="850" y="823" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="925" y="855.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Storage</text>
+      <rect x="1024" y="789" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="1099" y="821.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Storage</text>
     </g>
   </g>
 </svg>

--- a/docs/images/example_sequence_loops.svg
+++ b/docs/images/example_sequence_loops.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="450" height="546" viewBox="0 0 450 546" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="479" height="522" viewBox="-50 -10 479 522" class="mermaid">
   <style>
 
 .mermaid {
@@ -211,53 +211,53 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
   </defs>
   <g class="root">
     <g class="clusters">
-      <line x1="50" y1="295" x2="400" y2="295" class="loopLine" stroke-dasharray="3,3"/>
-      <rect x="50" y="185" width="350" height="176" rx="3" ry="3" class="loopLine" fill="none"/>
-      <rect x="50" y="361" width="350" height="88" rx="3" ry="3" class="loopLine" fill="none"/>
-      <rect x="40" y="97" width="370" height="352" rx="3" ry="3" class="loopLine" fill="none"/>
-      <line x1="125" y1="75" x2="125" y2="471" class="actor-line" stroke-width="0.5px"/>
-      <line x1="325" y1="75" x2="325" y2="471" class="actor-line" stroke-width="0.5px"/>
+      <line x1="0" y1="285" x2="379" y2="285" class="loopLine" stroke-dasharray="3,3"/>
+      <rect x="0" y="175" width="379" height="176" rx="3" ry="3" class="loopLine" fill="none"/>
+      <rect x="0" y="351" width="379" height="88" rx="3" ry="3" class="loopLine" fill="none"/>
+      <rect x="-10" y="87" width="399" height="352" rx="3" ry="3" class="loopLine" fill="none"/>
+      <line x1="75" y1="65" x2="75" y2="437" class="actor-line" stroke-width="0.5px"/>
+      <line x1="304" y1="65" x2="304" y2="437" class="actor-line" stroke-width="0.5px"/>
     </g>
     <g class="edgePaths">
-      <line x1="125" y1="163" x2="325" y2="163" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="325" y1="251" x2="125" y2="251" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="325" y1="339" x2="125" y2="339" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="325" y1="427" x2="125" y2="427" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="75" y1="153" x2="304" y2="153" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="304" y1="241" x2="75" y2="241" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="304" y1="329" x2="75" y2="329" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="304" y1="417" x2="75" y2="417" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
     </g>
     <g class="edgeLabels">
-      <text x="225" y="153" class="message-label" font-size="16" text-anchor="middle">Hello Bob, how are you?</text>
-      <text x="225" y="241" class="message-label" font-size="16" text-anchor="middle">Not so good :(</text>
-      <text x="225" y="313" class="loopText" text-anchor="middle" font-size="16">[is well]</text>
-      <text x="225" y="329" class="message-label" font-size="16" text-anchor="middle">Feeling fresh like a daisy</text>
-      <polygon points="60,185 110,185 110,198 102,205 60,205" class="labelBox"/>
-      <text x="85" y="198" class="labelText" text-anchor="middle" font-size="16">alt</text>
-      <text x="225" y="203" class="loopText" font-size="16" text-anchor="middle">[is sick]</text>
-      <text x="225" y="417" class="message-label" font-size="16" text-anchor="middle">Thanks for asking</text>
-      <polygon points="60,361 110,361 110,374 102,381 60,381" class="labelBox"/>
-      <text x="85" y="374" class="labelText" text-anchor="middle" font-size="16">opt</text>
-      <text x="225" y="379" class="loopText" font-size="16" text-anchor="middle">[Extra response]</text>
-      <polygon points="50,97 100,97 100,110 92,117 50,117" class="labelBox"/>
-      <text x="75" y="110" class="labelText" font-size="16" text-anchor="middle">loop</text>
-      <text x="225" y="115" class="loopText" text-anchor="middle" font-size="16">[Daily query]</text>
+      <text x="189.5" y="143" class="message-label" font-size="16" text-anchor="middle">Hello Bob, how are you?</text>
+      <text x="189.5" y="231" class="message-label" text-anchor="middle" font-size="16">Not so good :(</text>
+      <text x="189.5" y="303" class="loopText" font-size="16" text-anchor="middle">[is well]</text>
+      <text x="189.5" y="319" class="message-label" font-size="16" text-anchor="middle">Feeling fresh like a daisy</text>
+      <polygon points="10,175 60,175 60,188 52,195 10,195" class="labelBox"/>
+      <text x="35" y="188" class="labelText" font-size="16" text-anchor="middle">alt</text>
+      <text x="189.5" y="193" class="loopText" text-anchor="middle" font-size="16">[is sick]</text>
+      <text x="189.5" y="407" class="message-label" font-size="16" text-anchor="middle">Thanks for asking</text>
+      <polygon points="10,351 60,351 60,364 52,371 10,371" class="labelBox"/>
+      <text x="35" y="364" class="labelText" font-size="16" text-anchor="middle">opt</text>
+      <text x="189.5" y="369" class="loopText" font-size="16" text-anchor="middle">[Extra response]</text>
+      <polygon points="0,87 50,87 50,100 42,107 0,107" class="labelBox"/>
+      <text x="25" y="100" class="labelText" text-anchor="middle" font-size="16">loop</text>
+      <text x="189.5" y="105" class="loopText" font-size="16" text-anchor="middle">[Daily query]</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="50" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="125" y="42.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Alice</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="75" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="250" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="325" y="42.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Bob</text>
+      <rect x="229" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="304" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Bob</text>
     </g>
     <g class="actor">
-      <rect x="50" y="471" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="125" y="503.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Alice</text>
+      <rect x="0" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="75" y="469.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Alice</text>
     </g>
     <g class="actor">
-      <rect x="250" y="471" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="325" y="503.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Bob</text>
+      <rect x="229" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="304" y="469.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Bob</text>
     </g>
   </g>
 </svg>

--- a/docs/images/example_sequence_self_loop.svg
+++ b/docs/images/example_sequence_self_loop.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="650" height="502" viewBox="0 0 650 502" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="672" height="478" viewBox="-50 -10 672 478" class="mermaid">
   <style>
 
 .mermaid {
@@ -211,60 +211,60 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
   </defs>
   <g class="root">
     <g class="clusters">
-      <rect x="440" y="141" width="170" height="88" rx="3" ry="3" class="loopLine" fill="none"/>
-      <line x1="125" y1="75" x2="125" y2="427" class="actor-line" stroke-width="0.5px"/>
-      <line x1="325" y1="75" x2="325" y2="427" class="actor-line" stroke-width="0.5px"/>
-      <line x1="525" y1="75" x2="525" y2="427" class="actor-line" stroke-width="0.5px"/>
+      <rect x="412" y="131" width="170" height="88" rx="3" ry="3" class="loopLine" fill="none"/>
+      <line x1="75" y1="65" x2="75" y2="393" class="actor-line" stroke-width="0.5px"/>
+      <line x1="286" y1="65" x2="286" y2="393" class="actor-line" stroke-width="0.5px"/>
+      <line x1="497" y1="65" x2="497" y2="393" class="actor-line" stroke-width="0.5px"/>
     </g>
     <g class="edgePaths">
-      <line x1="125" y1="119" x2="525" y2="119" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <path d="M 525 207 L 565 207 L 565 237 L 525 237" class="message-line" fill="none" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="525" y1="295" x2="125" y2="295" class="message-line" stroke-dasharray="5,5" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="525" y1="339" x2="325" y2="339" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="325" y1="383" x2="525" y2="383" class="message-line" stroke-dasharray="5,5" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="75" y1="109" x2="497" y2="109" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <path d="M 497 197 L 537 197 L 537 227 L 497 227" class="message-line" stroke-width="1.5" fill="none" marker-end="url(#arrow-filled)"/>
+      <line x1="497" y1="285" x2="75" y2="285" class="message-line" stroke-dasharray="5,5" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="497" y1="329" x2="286" y2="329" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="286" y1="373" x2="497" y2="373" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="5,5"/>
     </g>
     <g class="edgeLabels">
-      <text x="325" y="109" class="message-label" text-anchor="middle" font-size="16">Hello John, how are you?</text>
-      <text x="570" y="222" class="message-label" text-anchor="start" font-size="16">Fight against hypochondria</text>
-      <polygon points="450,141 500,141 500,154 492,161 450,161" class="labelBox"/>
-      <text x="475" y="154" class="labelText" font-size="16" text-anchor="middle">loop</text>
-      <text x="525" y="159" class="loopText" font-size="16" text-anchor="middle">[HealthCheck]</text>
-      <text x="325" y="285" class="message-label" text-anchor="middle" font-size="16">Great!</text>
-      <text x="425" y="329" class="message-label" text-anchor="middle" font-size="16">How about you?</text>
-      <text x="425" y="373" class="message-label" text-anchor="middle" font-size="16">Jolly good!</text>
+      <text x="286" y="99" class="message-label" text-anchor="middle" font-size="16">Hello John, how are you?</text>
+      <text x="542" y="212" class="message-label" font-size="16" text-anchor="start">Fight against hypochondria</text>
+      <polygon points="422,131 472,131 472,144 464,151 422,151" class="labelBox"/>
+      <text x="447" y="144" class="labelText" text-anchor="middle" font-size="16">loop</text>
+      <text x="497" y="149" class="loopText" text-anchor="middle" font-size="16">[HealthCheck]</text>
+      <text x="286" y="275" class="message-label" text-anchor="middle" font-size="16">Great!</text>
+      <text x="391.5" y="319" class="message-label" text-anchor="middle" font-size="16">How about you?</text>
+      <text x="391.5" y="363" class="message-label" font-size="16" text-anchor="middle">Jolly good!</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="50" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="125" y="42.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Alice</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="75" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Alice</text>
     </g>
     <g class="actor">
-      <rect x="250" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="325" y="42.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Bob</text>
+      <rect x="211" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="286" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Bob</text>
     </g>
     <g class="actor">
-      <rect x="450" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="525" y="42.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">John</text>
+      <rect x="422" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="497" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">John</text>
     </g>
     <g class="note">
-      <path d="M 545 222 L 637 222 L 645 230 L 645 280 L 545 280 Z" class="note note-box" fill="#EDF2AE" stroke-width="1" stroke="#666"/>
-      <path d="M 637 222 L 637 230 L 645 230" class="note" fill="none" stroke-width="1"/>
-      <text x="595" y="248" class="note-text" font-size="16" text-anchor="middle">Rational thoughts</text>
-      <text x="595" y="267" class="note-text" text-anchor="middle" font-size="16">prevail...</text>
+      <path d="M 517 212 L 609 212 L 617 220 L 617 270 L 517 270 Z" class="note note-box" stroke="#666" fill="#EDF2AE" stroke-width="1"/>
+      <path d="M 609 212 L 609 220 L 617 220" class="note" fill="none" stroke-width="1"/>
+      <text x="567" y="238" class="note-text" text-anchor="middle" font-size="16">Rational thoughts</text>
+      <text x="567" y="257" class="note-text" text-anchor="middle" font-size="16">prevail...</text>
     </g>
     <g class="actor">
-      <rect x="50" y="427" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="125" y="459.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Alice</text>
+      <rect x="0" y="393" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="75" y="425.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="250" y="427" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="325" y="459.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Bob</text>
+      <rect x="211" y="393" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="286" y="425.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Bob</text>
     </g>
     <g class="actor">
-      <rect x="450" y="427" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="525" y="459.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">John</text>
+      <rect x="422" y="393" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="497" y="425.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">John</text>
     </g>
   </g>
 </svg>

--- a/docs/images/sequence.svg
+++ b/docs/images/sequence.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="650" height="546" viewBox="0 0 650 546" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="650" height="522" viewBox="-50 -10 650 522" class="mermaid">
   <style>
 
 .mermaid {
@@ -211,63 +211,63 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
   </defs>
   <g class="root">
     <g class="clusters">
-      <line x1="125" y1="75" x2="125" y2="471" class="actor-line" stroke-width="0.5px"/>
-      <line x1="325" y1="75" x2="325" y2="471" class="actor-line" stroke-width="0.5px"/>
-      <line x1="525" y1="75" x2="525" y2="471" class="actor-line" stroke-width="0.5px"/>
-      <rect x="520" y="251" width="10" height="44" rx="1" ry="1" class="activation"/>
+      <line x1="75" y1="65" x2="75" y2="437" class="actor-line" stroke-width="0.5px"/>
+      <line x1="275" y1="65" x2="275" y2="437" class="actor-line" stroke-width="0.5px"/>
+      <line x1="475" y1="65" x2="475" y2="437" class="actor-line" stroke-width="0.5px"/>
+      <rect x="470" y="241" width="10" height="44" rx="1" ry="1" class="activation"/>
     </g>
     <g class="edgePaths">
-      <line x1="125" y1="119" x2="325" y2="119" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="325" y1="163" x2="125" y2="163" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="5,5"/>
-      <line x1="125" y1="251" x2="525" y2="251" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="525" y1="295" x2="125" y2="295" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="5,5"/>
-      <line x1="125" y1="339" x2="325" y2="339" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="325" y1="383" x2="125" y2="383" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="5,5" stroke-width="1.5"/>
+      <line x1="75" y1="109" x2="275" y2="109" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="275" y1="153" x2="75" y2="153" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="5,5"/>
+      <line x1="75" y1="241" x2="475" y2="241" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="475" y1="285" x2="75" y2="285" class="message-line" stroke-dasharray="5,5" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="75" y1="329" x2="275" y2="329" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="275" y1="373" x2="75" y2="373" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="5,5" stroke-width="1.5"/>
     </g>
     <g class="edgeLabels">
-      <text x="225" y="109" class="message-label" text-anchor="middle" font-size="16">Hello Bob!</text>
-      <text x="225" y="153" class="message-label" font-size="16" text-anchor="middle">Hi Alice!</text>
-      <text x="325" y="241" class="message-label" font-size="16" text-anchor="middle">Login request</text>
-      <text x="325" y="285" class="message-label" text-anchor="middle" font-size="16">Token</text>
-      <text x="225" y="329" class="message-label" text-anchor="middle" font-size="16">How are you?</text>
-      <text x="225" y="373" class="message-label" text-anchor="middle" font-size="16">I&apos;m good, thanks!</text>
+      <text x="175" y="99" class="message-label" text-anchor="middle" font-size="16">Hello Bob!</text>
+      <text x="175" y="143" class="message-label" text-anchor="middle" font-size="16">Hi Alice!</text>
+      <text x="275" y="231" class="message-label" text-anchor="middle" font-size="16">Login request</text>
+      <text x="275" y="275" class="message-label" font-size="16" text-anchor="middle">Token</text>
+      <text x="175" y="319" class="message-label" text-anchor="middle" font-size="16">How are you?</text>
+      <text x="175" y="363" class="message-label" text-anchor="middle" font-size="16">I&apos;m good, thanks!</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="50" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="125" y="42.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="75" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Alice</text>
     </g>
     <g class="actor">
-      <rect x="250" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="325" y="42.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Bob</text>
+      <rect x="200" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="275" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Bob</text>
     </g>
     <g class="actor">
-      <rect x="450" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="525" y="42.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Server</text>
+      <rect x="400" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="475" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Server</text>
     </g>
     <g class="note">
-      <path d="M 115 187 L 327 187 L 335 195 L 335 227 L 115 227 Z" class="note note-box" stroke="#666" stroke-width="1" fill="#EDF2AE"/>
-      <path d="M 327 187 L 327 195 L 335 195" class="note" stroke-width="1" fill="none"/>
-      <text x="225" y="213" class="note-text" font-size="16" text-anchor="middle">Authentication</text>
+      <path d="M 65 177 L 277 177 L 285 185 L 285 217 L 65 217 Z" class="note note-box" stroke-width="1" fill="#EDF2AE" stroke="#666"/>
+      <path d="M 277 177 L 277 185 L 285 185" class="note" fill="none" stroke-width="1"/>
+      <text x="175" y="203" class="note-text" text-anchor="middle" font-size="16">Authentication</text>
     </g>
     <g class="note">
-      <path d="M 345 407 L 437 407 L 445 415 L 445 447 L 345 447 Z" class="note note-box" stroke="#666" stroke-width="1" fill="#EDF2AE"/>
-      <path d="M 437 407 L 437 415 L 445 415" class="note" stroke-width="1" fill="none"/>
-      <text x="395" y="433" class="note-text" text-anchor="middle" font-size="16">Bob thinks</text>
+      <path d="M 295 397 L 387 397 L 395 405 L 395 437 L 295 437 Z" class="note note-box" stroke-width="1" fill="#EDF2AE" stroke="#666"/>
+      <path d="M 387 397 L 387 405 L 395 405" class="note" fill="none" stroke-width="1"/>
+      <text x="345" y="423" class="note-text" font-size="16" text-anchor="middle">Bob thinks</text>
     </g>
     <g class="actor">
-      <rect x="50" y="471" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="125" y="503.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Alice</text>
+      <rect x="0" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="75" y="469.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="250" y="471" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="325" y="503.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Bob</text>
+      <rect x="200" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="275" y="469.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Bob</text>
     </g>
     <g class="actor">
-      <rect x="450" y="471" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="525" y="503.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Server</text>
+      <rect x="400" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="475" y="469.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Server</text>
     </g>
   </g>
 </svg>

--- a/docs/images/sequence_complex.svg
+++ b/docs/images/sequence_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1250" height="1294" viewBox="0 0 1250 1294" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1305" height="1270" viewBox="-50 -10 1305 1270" class="mermaid">
   <style>
 
 .mermaid {
@@ -211,170 +211,170 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
   </defs>
   <g class="root">
     <g class="clusters">
-      <line x1="40" y1="603" x2="610" y2="603" class="loopLine" stroke-dasharray="3,3"/>
-      <line x1="450" y1="823" x2="1200" y2="823" class="loopLine" stroke-dasharray="3,3"/>
-      <rect x="450" y="669" width="750" height="220" rx="3" ry="3" class="loopLine" fill="none"/>
-      <rect x="450" y="933" width="750" height="132" rx="3" ry="3" class="loopLine" fill="none"/>
-      <rect x="40" y="449" width="1170" height="748" rx="3" ry="3" class="loopLine" fill="none"/>
-      <line x1="125" y1="75" x2="125" y2="1219" class="actor-line" stroke-width="0.5px"/>
-      <line x1="325" y1="75" x2="325" y2="1219" class="actor-line" stroke-width="0.5px"/>
-      <line x1="525" y1="75" x2="525" y2="1219" class="actor-line" stroke-width="0.5px"/>
-      <line x1="725" y1="75" x2="725" y2="1219" class="actor-line" stroke-width="0.5px"/>
-      <line x1="925" y1="75" x2="925" y2="1219" class="actor-line" stroke-width="0.5px"/>
-      <line x1="1125" y1="75" x2="1125" y2="1219" class="actor-line" stroke-width="0.5px"/>
-      <rect x="720" y="295" width="10" height="132" rx="1" ry="1" class="activation"/>
-      <rect x="920" y="647" width="10" height="264" rx="1" ry="1" class="activation"/>
-      <rect x="520" y="207" width="10" height="924" rx="1" ry="1" class="activation"/>
-      <rect x="320" y="163" width="10" height="1012" rx="1" ry="1" class="activation"/>
+      <line x1="-10" y1="593" x2="582" y2="593" class="loopLine" stroke-dasharray="3,3"/>
+      <line x1="422" y1="813" x2="1205" y2="813" class="loopLine" stroke-dasharray="3,3"/>
+      <rect x="422" y="659" width="783" height="220" rx="3" ry="3" class="loopLine" fill="none"/>
+      <rect x="422" y="923" width="783" height="132" rx="3" ry="3" class="loopLine" fill="none"/>
+      <rect x="-10" y="439" width="1225" height="748" rx="3" ry="3" class="loopLine" fill="none"/>
+      <line x1="75" y1="65" x2="75" y2="1185" class="actor-line" stroke-width="0.5px"/>
+      <line x1="286" y1="65" x2="286" y2="1185" class="actor-line" stroke-width="0.5px"/>
+      <line x1="497" y1="65" x2="497" y2="1185" class="actor-line" stroke-width="0.5px"/>
+      <line x1="708" y1="65" x2="708" y2="1185" class="actor-line" stroke-width="0.5px"/>
+      <line x1="919" y1="65" x2="919" y2="1185" class="actor-line" stroke-width="0.5px"/>
+      <line x1="1130" y1="65" x2="1130" y2="1185" class="actor-line" stroke-width="0.5px"/>
+      <rect x="703" y="285" width="10" height="132" rx="1" ry="1" class="activation"/>
+      <rect x="914" y="637" width="10" height="264" rx="1" ry="1" class="activation"/>
+      <rect x="492" y="197" width="10" height="924" rx="1" ry="1" class="activation"/>
+      <rect x="281" y="153" width="10" height="1012" rx="1" ry="1" class="activation"/>
     </g>
     <g class="edgePaths">
-      <line x1="125" y1="163" x2="325" y2="163" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="125" cy="163" r="11" class="sequenceNumber-circle"/>
-      <line x1="325" y1="207" x2="525" y2="207" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="325" cy="207" r="11" class="sequenceNumber-circle"/>
-      <line x1="525" y1="295" x2="725" y2="295" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="525" cy="295" r="11" class="sequenceNumber-circle"/>
-      <line x1="725" y1="339" x2="925" y2="339" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <circle cx="725" cy="339" r="11" class="sequenceNumber-circle"/>
-      <line x1="925" y1="383" x2="725" y2="383" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="5,5" stroke-width="1.5"/>
-      <circle cx="925" cy="383" r="11" class="sequenceNumber-circle"/>
-      <line x1="725" y1="427" x2="525" y2="427" class="message-line" stroke-dasharray="5,5" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <circle cx="725" cy="427" r="11" class="sequenceNumber-circle"/>
-      <line x1="525" y1="515" x2="325" y2="515" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="5,5" stroke-width="1.5"/>
-      <circle cx="525" cy="515" r="11" class="sequenceNumber-circle"/>
-      <line x1="325" y1="559" x2="125" y2="559" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="5,5" stroke-width="1.5"/>
-      <circle cx="325" cy="559" r="11" class="sequenceNumber-circle"/>
-      <line x1="525" y1="647" x2="925" y2="647" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="525" cy="647" r="11" class="sequenceNumber-circle"/>
-      <line x1="525" y1="735" x2="1125" y2="735" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <circle cx="525" cy="735" r="11" class="sequenceNumber-circle"/>
-      <line x1="1125" y1="779" x2="525" y2="779" class="message-line" stroke-dasharray="5,5" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <circle cx="1125" cy="779" r="11" class="sequenceNumber-circle"/>
-      <path d="M 525 867 L 565 867 L 565 897 L 525 897" class="message-line" stroke-dasharray="5,5" fill="none" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <circle cx="525" cy="867" r="11" class="sequenceNumber-circle"/>
-      <line x1="925" y1="911" x2="525" y2="911" class="message-line" stroke-dasharray="5,5" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="925" cy="911" r="11" class="sequenceNumber-circle"/>
-      <line x1="525" y1="999" x2="1125" y2="999" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="525" cy="999" r="11" class="sequenceNumber-circle"/>
-      <line x1="1125" y1="1043" x2="525" y2="1043" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="5,5"/>
-      <circle cx="1125" cy="1043" r="11" class="sequenceNumber-circle"/>
-      <line x1="525" y1="1131" x2="325" y2="1131" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="5,5"/>
-      <circle cx="525" cy="1131" r="11" class="sequenceNumber-circle"/>
-      <line x1="325" y1="1175" x2="125" y2="1175" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="5,5"/>
-      <circle cx="325" cy="1175" r="11" class="sequenceNumber-circle"/>
+      <line x1="75" y1="153" x2="286" y2="153" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <circle cx="75" cy="153" r="11" class="sequenceNumber-circle"/>
+      <line x1="286" y1="197" x2="497" y2="197" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <circle cx="286" cy="197" r="11" class="sequenceNumber-circle"/>
+      <line x1="497" y1="285" x2="708" y2="285" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <circle cx="497" cy="285" r="11" class="sequenceNumber-circle"/>
+      <line x1="708" y1="329" x2="919" y2="329" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <circle cx="708" cy="329" r="11" class="sequenceNumber-circle"/>
+      <line x1="919" y1="373" x2="708" y2="373" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="5,5" stroke-width="1.5"/>
+      <circle cx="919" cy="373" r="11" class="sequenceNumber-circle"/>
+      <line x1="708" y1="417" x2="497" y2="417" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="5,5"/>
+      <circle cx="708" cy="417" r="11" class="sequenceNumber-circle"/>
+      <line x1="497" y1="505" x2="286" y2="505" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="5,5"/>
+      <circle cx="497" cy="505" r="11" class="sequenceNumber-circle"/>
+      <line x1="286" y1="549" x2="75" y2="549" class="message-line" stroke-dasharray="5,5" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <circle cx="286" cy="549" r="11" class="sequenceNumber-circle"/>
+      <line x1="497" y1="637" x2="919" y2="637" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <circle cx="497" cy="637" r="11" class="sequenceNumber-circle"/>
+      <line x1="497" y1="725" x2="1130" y2="725" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <circle cx="497" cy="725" r="11" class="sequenceNumber-circle"/>
+      <line x1="1130" y1="769" x2="497" y2="769" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="5,5"/>
+      <circle cx="1130" cy="769" r="11" class="sequenceNumber-circle"/>
+      <path d="M 497 857 L 537 857 L 537 887 L 497 887" class="message-line" stroke-width="1.5" stroke-dasharray="5,5" marker-end="url(#arrow-filled)" fill="none"/>
+      <circle cx="497" cy="857" r="11" class="sequenceNumber-circle"/>
+      <line x1="919" y1="901" x2="497" y2="901" class="message-line" stroke-dasharray="5,5" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <circle cx="919" cy="901" r="11" class="sequenceNumber-circle"/>
+      <line x1="497" y1="989" x2="1130" y2="989" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <circle cx="497" cy="989" r="11" class="sequenceNumber-circle"/>
+      <line x1="1130" y1="1033" x2="497" y2="1033" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="5,5"/>
+      <circle cx="1130" cy="1033" r="11" class="sequenceNumber-circle"/>
+      <line x1="497" y1="1121" x2="286" y2="1121" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="5,5"/>
+      <circle cx="497" cy="1121" r="11" class="sequenceNumber-circle"/>
+      <line x1="286" y1="1165" x2="75" y2="1165" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="5,5"/>
+      <circle cx="286" cy="1165" r="11" class="sequenceNumber-circle"/>
     </g>
     <g class="edgeLabels">
-      <text x="125" y="167" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">1</text>
-      <text x="225" y="153" class="message-label" text-anchor="middle" font-size="16">Click Checkout</text>
-      <text x="325" y="211" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">2</text>
-      <text x="425" y="197" class="message-label" font-size="16" text-anchor="middle">POST /checkout</text>
-      <text x="525" y="299" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">3</text>
-      <text x="625" y="285" class="message-label" font-size="16" text-anchor="middle">Verify session</text>
-      <text x="725" y="343" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">4</text>
-      <text x="825" y="329" class="message-label" font-size="16" text-anchor="middle">Query user</text>
-      <text x="925" y="387" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">5</text>
-      <text x="825" y="373" class="message-label" text-anchor="middle" font-size="16">User record</text>
-      <text x="725" y="431" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">6</text>
-      <text x="625" y="417" class="message-label" text-anchor="middle" font-size="16">Session valid</text>
-      <text x="525" y="519" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">7</text>
-      <text x="425" y="505" class="message-label" text-anchor="middle" font-size="16">Error: Empty cart</text>
-      <text x="325" y="563" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">8</text>
-      <text x="225" y="549" class="message-label" font-size="16" text-anchor="middle">Show error</text>
-      <text x="325" y="621" class="loopText" font-size="16" text-anchor="middle">[Cart Valid]</text>
-      <text x="525" y="651" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">9</text>
-      <text x="725" y="637" class="message-label" font-size="16" text-anchor="middle">Reserve inventory</text>
-      <text x="525" y="739" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">10</text>
-      <text x="825" y="725" class="message-label" font-size="16" text-anchor="middle">Queue payment job</text>
-      <text x="1125" y="783" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">11</text>
-      <text x="825" y="769" class="message-label" text-anchor="middle" font-size="16">Job queued</text>
-      <text x="825" y="841" class="loopText" text-anchor="middle" font-size="16">[Send Notifications]</text>
-      <text x="525" y="871" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">12</text>
-      <text x="570" y="882" class="message-label" font-size="16" text-anchor="start">Queue email confirmation</text>
-      <polygon points="460,669 510,669 510,682 502,689 460,689" class="labelBox"/>
-      <text x="485" y="682" class="labelText" text-anchor="middle" font-size="16">par</text>
-      <text x="825" y="687" class="loopText" font-size="16" text-anchor="middle">[Process Payment]</text>
-      <text x="925" y="915" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">13</text>
-      <text x="725" y="901" class="message-label" text-anchor="middle" font-size="16">Inventory reserved</text>
-      <text x="525" y="1003" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">14</text>
-      <text x="825" y="989" class="message-label" font-size="16" text-anchor="middle">Check payment status</text>
-      <text x="1125" y="1047" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">15</text>
-      <text x="825" y="1033" class="message-label" text-anchor="middle" font-size="16">Payment pending</text>
-      <polygon points="460,933 510,933 510,946 502,953 460,953" class="labelBox"/>
-      <text x="485" y="946" class="labelText" text-anchor="middle" font-size="16">loop</text>
-      <text x="825" y="951" class="loopText" font-size="16" text-anchor="middle">[Retry up to 3 times]</text>
-      <text x="525" y="1135" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">16</text>
-      <text x="425" y="1121" class="message-label" text-anchor="middle" font-size="16">Order confirmed</text>
-      <text x="325" y="1179" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">17</text>
-      <text x="225" y="1165" class="message-label" font-size="16" text-anchor="middle">Show confirmation</text>
-      <polygon points="50,449 100,449 100,462 92,469 50,469" class="labelBox"/>
-      <text x="75" y="462" class="labelText" font-size="16" text-anchor="middle">alt</text>
-      <text x="625" y="467" class="loopText" text-anchor="middle" font-size="16">[Cart Empty]</text>
+      <text x="75" y="157" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">1</text>
+      <text x="180.5" y="143" class="message-label" text-anchor="middle" font-size="16">Click Checkout</text>
+      <text x="286" y="201" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">2</text>
+      <text x="391.5" y="187" class="message-label" text-anchor="middle" font-size="16">POST /checkout</text>
+      <text x="497" y="289" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">3</text>
+      <text x="602.5" y="275" class="message-label" text-anchor="middle" font-size="16">Verify session</text>
+      <text x="708" y="333" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">4</text>
+      <text x="813.5" y="319" class="message-label" font-size="16" text-anchor="middle">Query user</text>
+      <text x="919" y="377" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">5</text>
+      <text x="813.5" y="363" class="message-label" font-size="16" text-anchor="middle">User record</text>
+      <text x="708" y="421" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">6</text>
+      <text x="602.5" y="407" class="message-label" text-anchor="middle" font-size="16">Session valid</text>
+      <text x="497" y="509" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">7</text>
+      <text x="391.5" y="495" class="message-label" text-anchor="middle" font-size="16">Error: Empty cart</text>
+      <text x="286" y="553" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">8</text>
+      <text x="180.5" y="539" class="message-label" text-anchor="middle" font-size="16">Show error</text>
+      <text x="286" y="611" class="loopText" text-anchor="middle" font-size="16">[Cart Valid]</text>
+      <text x="497" y="641" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">9</text>
+      <text x="708" y="627" class="message-label" text-anchor="middle" font-size="16">Reserve inventory</text>
+      <text x="497" y="729" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">10</text>
+      <text x="813.5" y="715" class="message-label" font-size="16" text-anchor="middle">Queue payment job</text>
+      <text x="1130" y="773" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">11</text>
+      <text x="813.5" y="759" class="message-label" font-size="16" text-anchor="middle">Job queued</text>
+      <text x="813.5" y="831" class="loopText" font-size="16" text-anchor="middle">[Send Notifications]</text>
+      <text x="497" y="861" class="sequenceNumber" font-family="sans-serif" font-size="12" text-anchor="middle">12</text>
+      <text x="542" y="872" class="message-label" font-size="16" text-anchor="start">Queue email confirmation</text>
+      <polygon points="432,659 482,659 482,672 474,679 432,679" class="labelBox"/>
+      <text x="457" y="672" class="labelText" text-anchor="middle" font-size="16">par</text>
+      <text x="813.5" y="677" class="loopText" text-anchor="middle" font-size="16">[Process Payment]</text>
+      <text x="919" y="905" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">13</text>
+      <text x="708" y="891" class="message-label" font-size="16" text-anchor="middle">Inventory reserved</text>
+      <text x="497" y="993" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">14</text>
+      <text x="813.5" y="979" class="message-label" font-size="16" text-anchor="middle">Check payment status</text>
+      <text x="1130" y="1037" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">15</text>
+      <text x="813.5" y="1023" class="message-label" text-anchor="middle" font-size="16">Payment pending</text>
+      <polygon points="432,923 482,923 482,936 474,943 432,943" class="labelBox"/>
+      <text x="457" y="936" class="labelText" font-size="16" text-anchor="middle">loop</text>
+      <text x="813.5" y="941" class="loopText" font-size="16" text-anchor="middle">[Retry up to 3 times]</text>
+      <text x="497" y="1125" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">16</text>
+      <text x="391.5" y="1111" class="message-label" text-anchor="middle" font-size="16">Order confirmed</text>
+      <text x="286" y="1169" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">17</text>
+      <text x="180.5" y="1155" class="message-label" text-anchor="middle" font-size="16">Show confirmation</text>
+      <polygon points="0,439 50,439 50,452 42,459 0,459" class="labelBox"/>
+      <text x="25" y="452" class="labelText" text-anchor="middle" font-size="16">alt</text>
+      <text x="602.5" y="457" class="loopText" text-anchor="middle" font-size="16">[Cart Empty]</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="50" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="125" y="42.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">User</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="75" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">User</text>
     </g>
     <g class="actor">
-      <rect x="250" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="325" y="42.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Browser</text>
+      <rect x="211" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="286" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Browser</text>
     </g>
     <g class="actor">
-      <rect x="450" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="525" y="42.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">API</text>
+      <rect x="422" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="497" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">API</text>
     </g>
     <g class="actor">
-      <rect x="650" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="725" y="42.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Auth</text>
+      <rect x="633" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="708" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Auth</text>
     </g>
     <g class="actor">
-      <rect x="850" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="925" y="42.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">DB</text>
+      <rect x="844" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="919" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">DB</text>
     </g>
     <g class="actor">
-      <rect x="1050" y="10" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="1125" y="42.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Queue</text>
+      <rect x="1055" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="1130" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Queue</text>
     </g>
     <g class="note">
-      <path d="M 115 99 L 1127 99 L 1135 107 L 1135 139 L 115 139 Z" class="note note-box" fill="#EDF2AE" stroke="#666" stroke-width="1"/>
-      <path d="M 1127 99 L 1127 107 L 1135 107" class="note" stroke-width="1" fill="none"/>
-      <text x="625" y="125" class="note-text" font-size="16" text-anchor="middle">E-Commerce Checkout Flow</text>
+      <path d="M 65 89 L 1132 89 L 1140 97 L 1140 129 L 65 129 Z" class="note note-box" stroke="#666" stroke-width="1" fill="#EDF2AE"/>
+      <path d="M 1132 89 L 1132 97 L 1140 97" class="note" fill="none" stroke-width="1"/>
+      <text x="602.5" y="115" class="note-text" text-anchor="middle" font-size="16">E-Commerce Checkout Flow</text>
     </g>
     <g class="note">
-      <path d="M 545 231 L 637 231 L 645 239 L 645 271 L 545 271 Z" class="note note-box" fill="#EDF2AE" stroke="#666" stroke-width="1"/>
-      <path d="M 637 231 L 637 239 L 645 239" class="note" stroke-width="1" fill="none"/>
-      <text x="595" y="257" class="note-text" text-anchor="middle" font-size="16">Validate cart items</text>
+      <path d="M 517 221 L 609 221 L 617 229 L 617 261 L 517 261 Z" class="note note-box" stroke="#666" fill="#EDF2AE" stroke-width="1"/>
+      <path d="M 609 221 L 609 229 L 617 229" class="note" fill="none" stroke-width="1"/>
+      <text x="567" y="247" class="note-text" font-size="16" text-anchor="middle">Validate cart items</text>
     </g>
     <g class="note">
-      <path d="M 515 1067 L 1127 1067 L 1135 1075 L 1135 1107 L 515 1107 Z" class="note note-box" stroke-width="1" fill="#EDF2AE" stroke="#666"/>
-      <path d="M 1127 1067 L 1127 1075 L 1135 1075" class="note" fill="none" stroke-width="1"/>
-      <text x="825" y="1093" class="note-text" text-anchor="middle" font-size="16">Payment confirmed</text>
+      <path d="M 487 1057 L 1132 1057 L 1140 1065 L 1140 1097 L 487 1097 Z" class="note note-box" stroke-width="1" stroke="#666" fill="#EDF2AE"/>
+      <path d="M 1132 1057 L 1132 1065 L 1140 1065" class="note" stroke-width="1" fill="none"/>
+      <text x="813.5" y="1083" class="note-text" text-anchor="middle" font-size="16">Payment confirmed</text>
     </g>
     <g class="actor">
-      <rect x="50" y="1219" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="125" y="1251.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">User</text>
+      <rect x="0" y="1185" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="75" y="1217.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">User</text>
     </g>
     <g class="actor">
-      <rect x="250" y="1219" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="325" y="1251.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Browser</text>
+      <rect x="211" y="1185" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="286" y="1217.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Browser</text>
     </g>
     <g class="actor">
-      <rect x="450" y="1219" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="525" y="1251.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">API</text>
+      <rect x="422" y="1185" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="497" y="1217.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">API</text>
     </g>
     <g class="actor">
-      <rect x="650" y="1219" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="725" y="1251.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Auth</text>
+      <rect x="633" y="1185" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="708" y="1217.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Auth</text>
     </g>
     <g class="actor">
-      <rect x="850" y="1219" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="925" y="1251.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">DB</text>
+      <rect x="844" y="1185" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="919" y="1217.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">DB</text>
     </g>
     <g class="actor">
-      <rect x="1050" y="1219" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="1125" y="1251.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Queue</text>
+      <rect x="1055" y="1185" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="1130" y="1217.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Queue</text>
     </g>
   </g>
 </svg>

--- a/src/render/sequence.rs
+++ b/src/render/sequence.rs
@@ -9,17 +9,34 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
     let mut doc = SvgDocument::new();
 
     // Layout constants (matching mermaid.js default theme)
-    let actor_spacing = 200.0;
+    let base_actor_spacing = 200.0;
     let actor_width = 150.0; // mermaid.js uses 150
     let actor_height = 65.0; // mermaid.js uses 65
     let message_spacing = 44.0; // mermaid.js uses ~44px
-    let margin_top = 10.0; // Small top margin (viewBox offset handles visual padding)
+    let margin_top = 0.0; // Actors start at y=0 (mermaid style - viewBox offset handles padding)
     let _margin_left = 0.0; // No left margin (handled by viewBox offset)
     let actor_box_padding = 0.0; // No padding - full width box
+    let diagram_margin_x = 50.0; // Mermaid.js default diagramMarginX
+    let diagram_margin_y = 10.0; // Mermaid.js default diagramMarginY
+    let char_width = 9.0; // Approximate character width in pixels for 16px font (trebuchet ms)
+    let wrap_padding = 10.0; // mermaid.js wrapPadding
+    let actor_margin = 50.0; // mermaid.js default actorMargin
 
     // Get actors in order
     let actors = db.get_actors_in_order();
     let messages = db.get_messages();
+
+    // Calculate dynamic actor spacing based on message text widths (mermaid.js style)
+    // Mermaid adjusts spacing to accommodate long message text
+    let actor_spacing = calculate_actor_spacing(
+        &actors,
+        messages,
+        base_actor_spacing,
+        actor_width,
+        char_width,
+        wrap_padding,
+        actor_margin,
+    );
 
     if actors.is_empty() {
         // Empty diagram
@@ -43,10 +60,7 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
     // Calculate dimensions (mimicking mermaid.js layout)
     // mermaid.js uses negative viewBox offset for visual padding
     let content_width = (actors.len() as f64 - 1.0) * actor_spacing + actor_width;
-
-    // Add visual padding via width/viewBox (mermaid.js style)
-    let width = content_width + 100.0; // Total viewBox width with padding
-                                       // Height will be set later after we know the actual content height
+    // Height will be set later after we know the actual content height
 
     // Add theme styles
     if config.embed_css {
@@ -69,10 +83,10 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
         0.0
     };
 
-    // Render title
+    // Render title (centered over content)
     if !db.diagram_title.is_empty() {
         let title_elem = SvgElement::Text {
-            x: width / 2.0,
+            x: content_width / 2.0,
             y: 25.0,
             content: db.diagram_title.clone(),
             attrs: Attrs::new()
@@ -84,9 +98,10 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
         doc.add_element(title_elem);
     }
 
-    // Calculate actor positions (with padding offset for visual alignment)
-    let padding_x = 50.0; // Horizontal padding offset
-    let padding_y = margin_top; // Vertical padding offset
+    // Calculate actor positions
+    // Content starts at (0,0) - visual padding achieved via negative viewBox offset (mermaid style)
+    let padding_x = 0.0; // Content coordinate origin
+    let padding_y = margin_top; // Content coordinate origin
 
     let actor_y = padding_y + title_offset;
     let lifeline_start_y = actor_y + actor_height;
@@ -363,7 +378,10 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
     }
 
     // Calculate final bottom actor position based on actual content
-    let bottom_actor_y = current_y;
+    // Mermaid uses boxMargin * 2 (~20px) between last content and bottom actors
+    // We subtract extra message_spacing and add boxMargin to match
+    let box_margin = 10.0; // mermaid.js default boxMargin
+    let bottom_actor_y = last_message_y.unwrap_or(current_y) + box_margin * 2.0;
     let lifeline_end_y = bottom_actor_y;
 
     // Render lifelines and bottom actors now that we know the final height
@@ -402,9 +420,17 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
         doc.add_cluster(activation);
     }
 
-    // Set final SVG dimensions
-    let height = bottom_actor_y + actor_height + margin_top;
-    doc.set_size(width, height);
+    // Set final SVG dimensions with mermaid-style viewBox offset for visual padding
+    // Mermaid uses viewBox="-50 -10 width height" to create visual padding around content
+    let content_height = bottom_actor_y + actor_height;
+    let total_width = content_width + 2.0 * diagram_margin_x;
+    let total_height = content_height + 2.0 * diagram_margin_y;
+    doc.set_size_with_origin(
+        -diagram_margin_x,
+        -diagram_margin_y,
+        total_width,
+        total_height,
+    );
 
     Ok(doc.to_string())
 }
@@ -1350,4 +1376,62 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {{
         activation_bkg_color = theme.activation_bkg_color,
         activation_border_color = theme.activation_border_color,
     )
+}
+
+/// Calculate dynamic actor spacing based on message text widths
+/// Mimics mermaid.js getMaxMessageWidthPerActor and calculateActorMargins logic
+fn calculate_actor_spacing(
+    actors: &[&crate::diagrams::sequence::Actor],
+    messages: &[crate::diagrams::sequence::Message],
+    base_spacing: f64,
+    actor_width: f64,
+    char_width: f64,
+    wrap_padding: f64,
+    actor_margin: f64,
+) -> f64 {
+    // Build actor name to index mapping
+    let actor_index: std::collections::HashMap<&str, usize> = actors
+        .iter()
+        .enumerate()
+        .map(|(i, a)| (a.name.as_str(), i))
+        .collect();
+
+    // Calculate max message width per actor (between adjacent actors)
+    let mut max_width_per_actor: Vec<f64> = vec![0.0; actors.len()];
+
+    for msg in messages {
+        // Get from and to indices (handling Option<String>)
+        let from_idx = msg
+            .from
+            .as_ref()
+            .and_then(|f| actor_index.get(f.as_str()).copied());
+        let to_idx = msg
+            .to
+            .as_ref()
+            .and_then(|t| actor_index.get(t.as_str()).copied());
+
+        if let (Some(from), Some(to)) = (from_idx, to_idx) {
+            if from != to {
+                // Calculate message text width
+                let text_width =
+                    msg.message.chars().count() as f64 * char_width + 2.0 * wrap_padding;
+
+                // Determine which actor to assign the width to (the one with the smaller index)
+                let min_idx = std::cmp::min(from, to);
+                let current_max: f64 = max_width_per_actor[min_idx];
+                max_width_per_actor[min_idx] = current_max.max(text_width);
+            }
+        }
+    }
+
+    // Calculate required spacing: max of base_spacing or (message_width + actor_margin - actor_width/2)
+    let mut max_required_spacing = base_spacing;
+    for width in max_width_per_actor {
+        if width > 0.0 {
+            let required = width + actor_margin - actor_width / 2.0;
+            max_required_spacing = max_required_spacing.max(required);
+        }
+    }
+
+    max_required_spacing
 }


### PR DESCRIPTION
## Summary
- Improve sequence diagram rendering to better match mermaid.js output
- Use mermaid-style viewBox offset (-50, -10) for visual padding
- Calculate dynamic actor spacing based on message text width
- Actors start at y=0, using viewBox for padding (matching mermaid behavior)
- Use boxMargin * 2 for bottom actor positioning

## Test plan
- [x] All existing sequence tests pass
- [x] Eval shows 2 diagrams at 50.3% SSIM (up from 21% average)
- [x] SVG documentation updated with new rendering

## Notes
Visual parity improved from 21% to ~26% average SSIM. Two diagrams reach the 50% target. Further improvements would require structural changes to loop/alt/opt fragment rendering (mermaid uses paths/lines instead of rects for fragment borders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)