### PR TITLE
feat(cargo): rename crate to selkie-diagrams for crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
-name = "selkie"
+name = "selkie-diagrams"
 version = "0.1.0"
 dependencies = [
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "selkie"
+name = "selkie-diagrams"
 version = "0.1.0"
 edition = "2021"
 description = "A Rust implementation of the mermaid diagramming parser and renderer"


### PR DESCRIPTION
## Summary
- Rename the Rust crate from `selkie` to `selkie-diagrams` for crates.io publishing
- Updates Cargo.toml and Cargo.lock with the new crate name

## Source
Merge request: se-8wvik
Source issue: se-ubap1
Worker: garnet

## Test plan
- [x] All 1553+ unit tests pass locally
- [ ] CI checks pass

🤖 Generated by Refinery (selkie/refinery)