### PR TITLE
feat: improve xychart rendering for better visual parity

### DIFF
--- a/docs/images/xychart.svg
+++ b/docs/images/xychart.svg
@@ -136,50 +136,50 @@ marker path {
 
     </g>
     <rect x="0" y="0" width="700" height="500" class="xychart-background" fill="white"/>
-    <rect x="99.33333333333331" y="346" width="74.66666666666667" height="64" class="xychart-bar" fill="#ECECFF"/>
-    <rect x="192.66666666666666" y="298" width="74.66666666666667" height="112" class="xychart-bar" fill="#ECECFF"/>
-    <rect x="286" y="266" width="74.66666666666667" height="144" class="xychart-bar" fill="#ECECFF"/>
-    <rect x="379.3333333333333" y="211.6" width="74.66666666666667" height="198.4" class="xychart-bar" fill="#ECECFF"/>
-    <rect x="472.6666666666667" y="160.39999999999998" width="74.66666666666667" height="249.60000000000002" class="xychart-bar" fill="#ECECFF"/>
-    <rect x="565.9999999999999" y="118.80000000000001" width="74.66666666666667" height="291.2" class="xychart-bar" fill="#ECECFF"/>
-    <path d="M 90 362 L 202 314 L 314 282 L 426 234 L 538 186 L 650 138" class="xychart-line" stroke="#4C78A8" stroke-width="2" fill="none"/>
-    <path d="M 90 90 L 90 410" class="xychart-axis" stroke-width="2" fill="none" stroke="#131300"/>
-    <path d="M 90 410 L 85 410" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
-    <path d="M 90 378 L 85 378" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
-    <path d="M 90 346 L 85 346" class="xychart-tick" fill="none" stroke-width="2" stroke="#131300"/>
-    <path d="M 90 314 L 85 314" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
-    <path d="M 90 282 L 85 282" class="xychart-tick" stroke="#131300" fill="none" stroke-width="2"/>
-    <path d="M 90 250 L 85 250" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
-    <path d="M 90 218 L 85 218" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
-    <path d="M 90 186 L 85 186" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
-    <path d="M 90 154 L 85 154" class="xychart-tick" stroke="#131300" fill="none" stroke-width="2"/>
-    <path d="M 90 122 L 85 122" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
-    <path d="M 90 90 L 85 90" class="xychart-tick" stroke="#131300" fill="none" stroke-width="2"/>
-    <path d="M 90 410 L 650 410" class="xychart-axis" stroke="#131300" stroke-width="2" fill="none"/>
-    <path d="M 136.66666666666666 410 L 136.66666666666666 415" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
-    <path d="M 230 410 L 230 415" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
-    <path d="M 323.3333333333333 410 L 323.3333333333333 415" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
-    <path d="M 416.66666666666663 410 L 416.66666666666663 415" class="xychart-tick" stroke="#131300" fill="none" stroke-width="2"/>
-    <path d="M 510 410 L 510 415" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
-    <path d="M 603.3333333333333 410 L 603.3333333333333 415" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
-    <text x="350" y="50" class="xychart-title" fill="#131300" text-anchor="middle" font-weight="bold" font-size="20" dominant-baseline="hanging">Monthly Sales</text>
-    <text x="15" y="250" class="xychart-axis-title" text-anchor="middle" dominant-baseline="middle" transform="rotate(-90 15 250)" fill="#131300" font-size="16">Sales (units)</text>
-    <text x="80" y="410" class="xychart-axis-label" text-anchor="end" dominant-baseline="middle" fill="#131300" font-size="14">0</text>
-    <text x="80" y="378" class="xychart-axis-label" text-anchor="end" dominant-baseline="middle" font-size="14" fill="#131300">10</text>
-    <text x="80" y="346" class="xychart-axis-label" font-size="14" text-anchor="end" dominant-baseline="middle" fill="#131300">20</text>
-    <text x="80" y="314" class="xychart-axis-label" text-anchor="end" font-size="14" dominant-baseline="middle" fill="#131300">30</text>
-    <text x="80" y="282" class="xychart-axis-label" fill="#131300" font-size="14" text-anchor="end" dominant-baseline="middle">40</text>
-    <text x="80" y="250" class="xychart-axis-label" fill="#131300" font-size="14" dominant-baseline="middle" text-anchor="end">50</text>
-    <text x="80" y="218" class="xychart-axis-label" dominant-baseline="middle" fill="#131300" text-anchor="end" font-size="14">60</text>
-    <text x="80" y="186" class="xychart-axis-label" font-size="14" fill="#131300" dominant-baseline="middle" text-anchor="end">70</text>
-    <text x="80" y="154" class="xychart-axis-label" font-size="14" fill="#131300" text-anchor="end" dominant-baseline="middle">80</text>
-    <text x="80" y="122" class="xychart-axis-label" fill="#131300" dominant-baseline="middle" text-anchor="end" font-size="14">90</text>
-    <text x="80" y="90" class="xychart-axis-label" dominant-baseline="middle" fill="#131300" text-anchor="end" font-size="14">100</text>
-    <text x="136.66666666666666" y="425" class="xychart-axis-label" text-anchor="middle" font-size="14" fill="#131300" dominant-baseline="hanging">Jan</text>
-    <text x="230" y="425" class="xychart-axis-label" text-anchor="middle" font-size="14" dominant-baseline="hanging" fill="#131300">Feb</text>
-    <text x="323.3333333333333" y="425" class="xychart-axis-label" dominant-baseline="hanging" font-size="14" text-anchor="middle" fill="#131300">Mar</text>
-    <text x="416.66666666666663" y="425" class="xychart-axis-label" dominant-baseline="hanging" text-anchor="middle" fill="#131300" font-size="14">Apr</text>
-    <text x="510" y="425" class="xychart-axis-label" dominant-baseline="hanging" fill="#131300" text-anchor="middle" font-size="14">May</text>
-    <text x="603.3333333333333" y="425" class="xychart-axis-label" text-anchor="middle" dominant-baseline="hanging" fill="#131300" font-size="14">Jun</text>
+    <rect x="68.20000000000002" y="381.76" width="68.39999999999999" height="84.44" class="xychart-bar" fill="#ECECFF"/>
+    <rect x="180.52000000000004" y="318.43" width="68.39999999999999" height="147.76999999999998" class="xychart-bar" fill="#ECECFF"/>
+    <rect x="292.84000000000003" y="276.21" width="68.39999999999999" height="189.99" class="xychart-bar" fill="#ECECFF"/>
+    <rect x="405.16" y="204.43599999999998" width="68.39999999999999" height="261.764" class="xychart-bar" fill="#ECECFF"/>
+    <rect x="517.48" y="136.88400000000001" width="68.39999999999999" height="329.316" class="xychart-bar" fill="#ECECFF"/>
+    <rect x="629.8" y="81.99799999999999" width="68.39999999999999" height="384.202" class="xychart-bar" fill="#ECECFF"/>
+    <path d="M 102.4 402.87 L 214.72000000000003 339.53999999999996 L 327.04 297.32 L 439.36 233.98999999999998 L 551.6800000000001 170.66000000000003 L 664 107.32999999999998" class="xychart-line" fill="none" stroke="#4C78A8" stroke-width="2"/>
+    <path d="M 66.4 44 L 66.4 466.2" class="xychart-axis" fill="none" stroke-width="2" stroke="#131300"/>
+    <path d="M 66.4 466.2 L 61.400000000000006 466.2" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
+    <path d="M 66.4 423.98 L 61.400000000000006 423.98" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 66.4 381.76 L 61.400000000000006 381.76" class="xychart-tick" fill="none" stroke-width="2" stroke="#131300"/>
+    <path d="M 66.4 339.53999999999996 L 61.400000000000006 339.53999999999996" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 66.4 297.32 L 61.400000000000006 297.32" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 66.4 255.1 L 61.400000000000006 255.1" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
+    <path d="M 66.4 212.88 L 61.400000000000006 212.88" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
+    <path d="M 66.4 170.66000000000003 L 61.400000000000006 170.66000000000003" class="xychart-tick" stroke="#131300" fill="none" stroke-width="2"/>
+    <path d="M 66.4 128.44 L 61.400000000000006 128.44" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
+    <path d="M 66.4 86.22 L 61.400000000000006 86.22" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
+    <path d="M 66.4 44 L 61.400000000000006 44" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
+    <path d="M 66.4 466.2 L 700 466.2" class="xychart-axis" fill="none" stroke-width="2" stroke="#131300"/>
+    <path d="M 102.4 466.2 L 102.4 471.2" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
+    <path d="M 214.72000000000003 466.2 L 214.72000000000003 471.2" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 327.04 466.2 L 327.04 471.2" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 439.36 466.2 L 439.36 471.2" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
+    <path d="M 551.6800000000001 466.2 L 551.6800000000001 471.2" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 664 466.2 L 664 471.2" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
+    <text x="350" y="22" class="xychart-title" dominant-baseline="middle" font-weight="bold" fill="#131300" text-anchor="middle" font-size="20">Monthly Sales</text>
+    <text x="15" y="255.1" class="xychart-axis-title" font-size="16" text-anchor="middle" fill="#131300" dominant-baseline="middle" transform="rotate(-90 15 255.1)">Sales (units)</text>
+    <text x="56.400000000000006" y="466.2" class="xychart-axis-label" fill="#131300" font-size="14" dominant-baseline="middle" text-anchor="end">0</text>
+    <text x="56.400000000000006" y="423.98" class="xychart-axis-label" font-size="14" dominant-baseline="middle" fill="#131300" text-anchor="end">10</text>
+    <text x="56.400000000000006" y="381.76" class="xychart-axis-label" fill="#131300" font-size="14" dominant-baseline="middle" text-anchor="end">20</text>
+    <text x="56.400000000000006" y="339.53999999999996" class="xychart-axis-label" text-anchor="end" fill="#131300" font-size="14" dominant-baseline="middle">30</text>
+    <text x="56.400000000000006" y="297.32" class="xychart-axis-label" text-anchor="end" dominant-baseline="middle" fill="#131300" font-size="14">40</text>
+    <text x="56.400000000000006" y="255.1" class="xychart-axis-label" font-size="14" text-anchor="end" dominant-baseline="middle" fill="#131300">50</text>
+    <text x="56.400000000000006" y="212.88" class="xychart-axis-label" dominant-baseline="middle" font-size="14" fill="#131300" text-anchor="end">60</text>
+    <text x="56.400000000000006" y="170.66000000000003" class="xychart-axis-label" dominant-baseline="middle" fill="#131300" text-anchor="end" font-size="14">70</text>
+    <text x="56.400000000000006" y="128.44" class="xychart-axis-label" text-anchor="end" font-size="14" dominant-baseline="middle" fill="#131300">80</text>
+    <text x="56.400000000000006" y="86.22" class="xychart-axis-label" font-size="14" fill="#131300" text-anchor="end" dominant-baseline="middle">90</text>
+    <text x="56.400000000000006" y="44" class="xychart-axis-label" fill="#131300" text-anchor="end" dominant-baseline="middle" font-size="14">100</text>
+    <text x="102.4" y="478.2" class="xychart-axis-label" dominant-baseline="hanging" font-size="14" text-anchor="middle" fill="#131300">Jan</text>
+    <text x="214.72000000000003" y="478.2" class="xychart-axis-label" fill="#131300" font-size="14" dominant-baseline="hanging" text-anchor="middle">Feb</text>
+    <text x="327.04" y="478.2" class="xychart-axis-label" fill="#131300" text-anchor="middle" dominant-baseline="hanging" font-size="14">Mar</text>
+    <text x="439.36" y="478.2" class="xychart-axis-label" font-size="14" text-anchor="middle" dominant-baseline="hanging" fill="#131300">Apr</text>
+    <text x="551.6800000000001" y="478.2" class="xychart-axis-label" font-size="14" fill="#131300" text-anchor="middle" dominant-baseline="hanging">May</text>
+    <text x="664" y="478.2" class="xychart-axis-label" dominant-baseline="hanging" text-anchor="middle" font-size="14" fill="#131300">Jun</text>
   </g>
 </svg>

--- a/docs/images/xychart_complex.svg
+++ b/docs/images/xychart_complex.svg
@@ -136,54 +136,54 @@ marker path {
 
     </g>
     <rect x="0" y="0" width="700" height="500" class="xychart-background" fill="white"/>
-    <rect x="98" y="333.2" width="64" height="76.8" class="xychart-bar" fill="#ECECFF"/>
-    <rect x="178" y="294.8" width="64" height="115.19999999999999" class="xychart-bar" fill="#ECECFF"/>
-    <rect x="258" y="250" width="64" height="160" class="xychart-bar" fill="#ECECFF"/>
-    <rect x="338" y="269.2" width="64" height="140.8" class="xychart-bar" fill="#ECECFF"/>
-    <rect x="418" y="218" width="64" height="192" class="xychart-bar" fill="#ECECFF"/>
-    <rect x="498" y="122" width="64" height="288" class="xychart-bar" fill="#ECECFF"/>
-    <rect x="578" y="141.2" width="64" height="268.8" class="xychart-bar" fill="#ECECFF"/>
-    <path d="M 90 346 L 183.33333333333331 314 L 276.66666666666663 282 L 370 294.8 L 463.3333333333333 250 L 556.6666666666666 154 L 650 166.8" class="xychart-line" stroke-width="2" stroke="#4C78A8" fill="none"/>
-    <path d="M 90 358.8 L 183.33333333333331 333.2 L 276.66666666666663 294.8 L 370 314 L 463.3333333333333 269.2 L 556.6666666666666 186 L 650 218" class="xychart-line" fill="none" stroke="#F58518" stroke-width="2"/>
-    <path d="M 90 90 L 90 410" class="xychart-axis" stroke="#131300" stroke-width="2" fill="none"/>
-    <path d="M 90 410 L 85 410" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
-    <path d="M 90 378 L 85 378" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
-    <path d="M 90 346 L 85 346" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
-    <path d="M 90 314 L 85 314" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
-    <path d="M 90 282 L 85 282" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
-    <path d="M 90 250 L 85 250" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
-    <path d="M 90 218 L 85 218" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
-    <path d="M 90 186 L 85 186" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
-    <path d="M 90 154 L 85 154" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
-    <path d="M 90 122 L 85 122" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
-    <path d="M 90 90 L 85 90" class="xychart-tick" fill="none" stroke-width="2" stroke="#131300"/>
-    <path d="M 90 410 L 650 410" class="xychart-axis" stroke="#131300" stroke-width="2" fill="none"/>
-    <path d="M 130 410 L 130 415" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
-    <path d="M 210 410 L 210 415" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
-    <path d="M 290 410 L 290 415" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
-    <path d="M 370 410 L 370 415" class="xychart-tick" fill="none" stroke-width="2" stroke="#131300"/>
-    <path d="M 450 410 L 450 415" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
-    <path d="M 530 410 L 530 415" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
-    <path d="M 610 410 L 610 415" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
-    <text x="350" y="50" class="xychart-title" fill="#131300" font-size="20" font-weight="bold" text-anchor="middle" dominant-baseline="hanging">Website Analytics</text>
-    <text x="15" y="250" class="xychart-axis-title" fill="#131300" transform="rotate(-90 15 250)" text-anchor="middle" dominant-baseline="middle" font-size="16">Visitors (thousands)</text>
-    <text x="80" y="410" class="xychart-axis-label" fill="#131300" font-size="14" dominant-baseline="middle" text-anchor="end">0</text>
-    <text x="80" y="378" class="xychart-axis-label" dominant-baseline="middle" font-size="14" fill="#131300" text-anchor="end">5</text>
-    <text x="80" y="346" class="xychart-axis-label" font-size="14" dominant-baseline="middle" text-anchor="end" fill="#131300">10</text>
-    <text x="80" y="314" class="xychart-axis-label" font-size="14" fill="#131300" text-anchor="end" dominant-baseline="middle">15</text>
-    <text x="80" y="282" class="xychart-axis-label" fill="#131300" text-anchor="end" font-size="14" dominant-baseline="middle">20</text>
-    <text x="80" y="250" class="xychart-axis-label" dominant-baseline="middle" fill="#131300" text-anchor="end" font-size="14">25</text>
-    <text x="80" y="218" class="xychart-axis-label" text-anchor="end" font-size="14" dominant-baseline="middle" fill="#131300">30</text>
-    <text x="80" y="186" class="xychart-axis-label" dominant-baseline="middle" font-size="14" text-anchor="end" fill="#131300">35</text>
-    <text x="80" y="154" class="xychart-axis-label" font-size="14" text-anchor="end" dominant-baseline="middle" fill="#131300">40</text>
-    <text x="80" y="122" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" font-size="14" fill="#131300">45</text>
-    <text x="80" y="90" class="xychart-axis-label" dominant-baseline="middle" font-size="14" fill="#131300" text-anchor="end">50</text>
-    <text x="130" y="425" class="xychart-axis-label" font-size="14" dominant-baseline="hanging" fill="#131300" text-anchor="middle">Mon</text>
-    <text x="210" y="425" class="xychart-axis-label" fill="#131300" dominant-baseline="hanging" text-anchor="middle" font-size="14">Tue</text>
-    <text x="290" y="425" class="xychart-axis-label" fill="#131300" dominant-baseline="hanging" font-size="14" text-anchor="middle">Wed</text>
-    <text x="370" y="425" class="xychart-axis-label" dominant-baseline="hanging" fill="#131300" text-anchor="middle" font-size="14">Thu</text>
-    <text x="450" y="425" class="xychart-axis-label" fill="#131300" text-anchor="middle" dominant-baseline="hanging" font-size="14">Fri</text>
-    <text x="530" y="425" class="xychart-axis-label" dominant-baseline="hanging" text-anchor="middle" fill="#131300" font-size="14">Sat</text>
-    <text x="610" y="425" class="xychart-axis-label" font-size="14" fill="#131300" dominant-baseline="hanging" text-anchor="middle">Sun</text>
+    <rect x="59.6" y="364.872" width="60.8" height="101.32799999999999" class="xychart-bar" fill="#ECECFF"/>
+    <rect x="155.9333333333333" y="314.20799999999997" width="60.8" height="151.992" class="xychart-bar" fill="#ECECFF"/>
+    <rect x="252.26666666666662" y="255.1" width="60.8" height="211.1" class="xychart-bar" fill="#ECECFF"/>
+    <rect x="348.6" y="280.432" width="60.8" height="185.768" class="xychart-bar" fill="#ECECFF"/>
+    <rect x="444.93333333333334" y="212.88" width="60.8" height="253.32" class="xychart-bar" fill="#ECECFF"/>
+    <rect x="541.2666666666668" y="86.21999999999997" width="60.8" height="379.98" class="xychart-bar" fill="#ECECFF"/>
+    <rect x="637.6" y="111.55200000000002" width="60.8" height="354.64799999999997" class="xychart-bar" fill="#ECECFF"/>
+    <path d="M 90 381.76 L 186.33333333333331 339.53999999999996 L 282.66666666666663 297.32 L 379 314.20799999999997 L 475.3333333333333 255.1 L 571.6666666666667 128.44 L 668 145.32799999999997" class="xychart-line" stroke="#4C78A8" stroke-width="2" fill="none"/>
+    <path d="M 90 398.648 L 186.33333333333331 364.872 L 282.66666666666663 314.20799999999997 L 379 339.53999999999996 L 475.3333333333333 280.432 L 571.6666666666667 170.66000000000003 L 668 212.88" class="xychart-line" stroke="#F58518" fill="none" stroke-width="2"/>
+    <path d="M 58 44 L 58 466.2" class="xychart-axis" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 58 466.2 L 53 466.2" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 58 423.98 L 53 423.98" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 58 381.76 L 53 381.76" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
+    <path d="M 58 339.53999999999996 L 53 339.53999999999996" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
+    <path d="M 58 297.32 L 53 297.32" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
+    <path d="M 58 255.1 L 53 255.1" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
+    <path d="M 58 212.88 L 53 212.88" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
+    <path d="M 58 170.66000000000003 L 53 170.66000000000003" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 58 128.44 L 53 128.44" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
+    <path d="M 58 86.22 L 53 86.22" class="xychart-tick" stroke="#131300" fill="none" stroke-width="2"/>
+    <path d="M 58 44 L 53 44" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 58 466.2 L 700 466.2" class="xychart-axis" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 90 466.2 L 90 471.2" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
+    <path d="M 186.33333333333331 466.2 L 186.33333333333331 471.2" class="xychart-tick" stroke="#131300" fill="none" stroke-width="2"/>
+    <path d="M 282.66666666666663 466.2 L 282.66666666666663 471.2" class="xychart-tick" stroke-width="2" stroke="#131300" fill="none"/>
+    <path d="M 379 466.2 L 379 471.2" class="xychart-tick" fill="none" stroke-width="2" stroke="#131300"/>
+    <path d="M 475.3333333333333 466.2 L 475.3333333333333 471.2" class="xychart-tick" stroke="#131300" stroke-width="2" fill="none"/>
+    <path d="M 571.6666666666667 466.2 L 571.6666666666667 471.2" class="xychart-tick" fill="none" stroke="#131300" stroke-width="2"/>
+    <path d="M 668 466.2 L 668 471.2" class="xychart-tick" stroke-width="2" fill="none" stroke="#131300"/>
+    <text x="350" y="22" class="xychart-title" text-anchor="middle" font-weight="bold" fill="#131300" dominant-baseline="middle" font-size="20">Website Analytics</text>
+    <text x="15" y="255.1" class="xychart-axis-title" text-anchor="middle" dominant-baseline="middle" fill="#131300" font-size="16" transform="rotate(-90 15 255.1)">Visitors (thousands)</text>
+    <text x="48" y="466.2" class="xychart-axis-label" dominant-baseline="middle" text-anchor="end" fill="#131300" font-size="14">0</text>
+    <text x="48" y="423.98" class="xychart-axis-label" text-anchor="end" fill="#131300" dominant-baseline="middle" font-size="14">5</text>
+    <text x="48" y="381.76" class="xychart-axis-label" dominant-baseline="middle" font-size="14" fill="#131300" text-anchor="end">10</text>
+    <text x="48" y="339.53999999999996" class="xychart-axis-label" text-anchor="end" fill="#131300" dominant-baseline="middle" font-size="14">15</text>
+    <text x="48" y="297.32" class="xychart-axis-label" fill="#131300" dominant-baseline="middle" font-size="14" text-anchor="end">20</text>
+    <text x="48" y="255.1" class="xychart-axis-label" font-size="14" fill="#131300" text-anchor="end" dominant-baseline="middle">25</text>
+    <text x="48" y="212.88" class="xychart-axis-label" dominant-baseline="middle" fill="#131300" text-anchor="end" font-size="14">30</text>
+    <text x="48" y="170.66000000000003" class="xychart-axis-label" font-size="14" dominant-baseline="middle" fill="#131300" text-anchor="end">35</text>
+    <text x="48" y="128.44" class="xychart-axis-label" font-size="14" text-anchor="end" fill="#131300" dominant-baseline="middle">40</text>
+    <text x="48" y="86.22" class="xychart-axis-label" dominant-baseline="middle" font-size="14" fill="#131300" text-anchor="end">45</text>
+    <text x="48" y="44" class="xychart-axis-label" font-size="14" dominant-baseline="middle" text-anchor="end" fill="#131300">50</text>
+    <text x="90" y="478.2" class="xychart-axis-label" font-size="14" fill="#131300" dominant-baseline="hanging" text-anchor="middle">Mon</text>
+    <text x="186.33333333333331" y="478.2" class="xychart-axis-label" fill="#131300" font-size="14" text-anchor="middle" dominant-baseline="hanging">Tue</text>
+    <text x="282.66666666666663" y="478.2" class="xychart-axis-label" font-size="14" dominant-baseline="hanging" text-anchor="middle" fill="#131300">Wed</text>
+    <text x="379" y="478.2" class="xychart-axis-label" font-size="14" fill="#131300" text-anchor="middle" dominant-baseline="hanging">Thu</text>
+    <text x="475.3333333333333" y="478.2" class="xychart-axis-label" font-size="14" dominant-baseline="hanging" fill="#131300" text-anchor="middle">Fri</text>
+    <text x="571.6666666666667" y="478.2" class="xychart-axis-label" text-anchor="middle" dominant-baseline="hanging" font-size="14" fill="#131300">Sat</text>
+    <text x="668" y="478.2" class="xychart-axis-label" dominant-baseline="hanging" fill="#131300" text-anchor="middle" font-size="14">Sun</text>
   </g>
 </svg>

--- a/src/render/xychart.rs
+++ b/src/render/xychart.rs
@@ -9,10 +9,22 @@ use crate::render::svg::{Attrs, RenderConfig, SvgDocument, SvgElement};
 /// Default chart dimensions (matching mermaid.js defaults)
 const DEFAULT_WIDTH: f64 = 700.0;
 const DEFAULT_HEIGHT: f64 = 500.0;
-const PADDING: f64 = 50.0;
-const TITLE_HEIGHT: f64 = 30.0;
-const AXIS_LABEL_PADDING: f64 = 40.0;
+
+/// Layout constants matching mermaid.js config defaults
+/// These values are derived from analyzing mermaid's chartBuilder
+const TITLE_FONT_SIZE: f64 = 20.0;
+const TITLE_PADDING: f64 = 10.0;
+const AXIS_LABEL_FONT_SIZE: f64 = 14.0;
+const AXIS_LABEL_PADDING: f64 = 5.0;
+const AXIS_TITLE_FONT_SIZE: f64 = 16.0;
+const AXIS_TITLE_PADDING: f64 = 5.0;
 const TICK_LENGTH: f64 = 5.0;
+const AXIS_LINE_WIDTH: f64 = 2.0;
+
+/// Estimated character width as fraction of font size (for label width calculation)
+const CHAR_WIDTH_RATIO: f64 = 0.6;
+/// Estimated character height as fraction of font size
+const CHAR_HEIGHT_RATIO: f64 = 1.2;
 
 /// XY Chart color palette (matching mermaid.js default theme)
 const PLOT_COLORS: &[&str] = &[
@@ -35,6 +47,87 @@ struct ChartArea {
     y_min: f64,
     y_max: f64,
     num_points: usize,
+    /// Outer padding for bar charts (half of bar width space at edges)
+    outer_padding: f64,
+}
+
+/// Layout dimensions calculated from content
+struct LayoutDimensions {
+    /// Width of Y-axis area (title + labels + ticks + axis line)
+    y_axis_width: f64,
+    /// Height of X-axis area (title + labels + ticks + axis line)
+    x_axis_height: f64,
+    /// Height of chart title area
+    title_height: f64,
+}
+
+/// Calculate layout dimensions based on chart content (similar to mermaid's space calculation)
+fn calculate_layout(db: &XYChartDb, y_min: f64, y_max: f64) -> LayoutDimensions {
+    // Calculate Y-axis label width (widest number in tick values)
+    let tick_values = calculate_nice_ticks(y_min, y_max);
+    let max_label_len = tick_values
+        .iter()
+        .map(|v| format_number(*v).len())
+        .max()
+        .unwrap_or(1);
+    let y_label_width = max_label_len as f64 * AXIS_LABEL_FONT_SIZE * CHAR_WIDTH_RATIO;
+
+    // Y-axis width: title + padding + labels + padding + ticks + axis line
+    let has_y_title = db
+        .y_axis
+        .as_ref()
+        .map(|y| match y {
+            YAxisData::Linear(d) => !d.title.is_empty(),
+        })
+        .unwrap_or(false);
+
+    let y_axis_width = if has_y_title {
+        AXIS_TITLE_FONT_SIZE * CHAR_HEIGHT_RATIO
+            + AXIS_TITLE_PADDING * 2.0
+            + y_label_width
+            + AXIS_LABEL_PADDING
+            + TICK_LENGTH
+            + AXIS_LINE_WIDTH
+    } else {
+        y_label_width + AXIS_LABEL_PADDING + TICK_LENGTH + AXIS_LINE_WIDTH
+    };
+
+    // X-axis height: axis line + ticks + labels + padding + title
+    let has_x_title = db
+        .x_axis
+        .as_ref()
+        .map(|x| match x {
+            XAxisData::Band(d) => !d.title.is_empty(),
+            XAxisData::Linear(d) => !d.title.is_empty(),
+        })
+        .unwrap_or(false);
+
+    let x_axis_height = if has_x_title {
+        AXIS_LINE_WIDTH
+            + TICK_LENGTH
+            + AXIS_LABEL_FONT_SIZE * CHAR_HEIGHT_RATIO
+            + AXIS_LABEL_PADDING * 2.0
+            + AXIS_TITLE_FONT_SIZE * CHAR_HEIGHT_RATIO
+            + AXIS_TITLE_PADDING
+    } else {
+        AXIS_LINE_WIDTH
+            + TICK_LENGTH
+            + AXIS_LABEL_FONT_SIZE * CHAR_HEIGHT_RATIO
+            + AXIS_LABEL_PADDING * 2.0
+    };
+
+    // Title height
+    let title_height = if !db.title.is_empty() {
+        TITLE_FONT_SIZE * CHAR_HEIGHT_RATIO + TITLE_PADDING * 2.0
+    } else {
+        0.0
+    };
+
+    LayoutDimensions {
+        y_axis_width,
+        x_axis_height,
+        title_height,
+    }
 }
 
 /// Render an XY chart to SVG
@@ -51,17 +144,18 @@ pub fn render_xychart(db: &XYChartDb, config: &RenderConfig) -> Result<String> {
         doc.add_style(&generate_xychart_css(&config.theme));
     }
 
-    // Calculate plot area
-    let title_offset = if !db.title.is_empty() {
-        TITLE_HEIGHT + 10.0
-    } else {
-        0.0
-    };
+    // Calculate data range first (needed for layout calculation)
+    let (y_min, y_max) = calculate_y_range(db);
+    let num_points = calculate_num_points(db);
 
-    let plot_left = PADDING + AXIS_LABEL_PADDING;
-    let plot_right = width - PADDING;
-    let plot_top = PADDING + title_offset;
-    let plot_bottom = height - PADDING - AXIS_LABEL_PADDING;
+    // Calculate layout dimensions based on content
+    let layout = calculate_layout(db, y_min, y_max);
+
+    // Calculate plot area based on layout
+    let plot_left = layout.y_axis_width;
+    let plot_right = width; // Plot extends to right edge
+    let plot_top = layout.title_height;
+    let plot_bottom = height - layout.x_axis_height;
 
     let plot_width = plot_right - plot_left;
     let plot_height = plot_bottom - plot_top;
@@ -80,15 +174,15 @@ pub fn render_xychart(db: &XYChartDb, config: &RenderConfig) -> Result<String> {
     };
     doc.add_element(bg);
 
-    // Note: Title is rendered after chart shapes for proper z-order (see render_chart_title)
-
-    // Calculate data range
-    let (y_min, y_max) = calculate_y_range(db);
-    let num_points = calculate_num_points(db);
-
     if num_points == 0 {
         return Ok(doc.to_string());
     }
+
+    // Calculate outer padding for bar charts
+    // This matches mermaid's recalculateOuterPaddingToDrawBar logic
+    let tick_distance = plot_width / num_points as f64;
+    let bar_width_ratio = 0.7; // BAR_WIDTH_TO_TICK_WIDTH_RATIO in mermaid
+    let outer_padding = (bar_width_ratio * tick_distance / 2.0).floor();
 
     let area = ChartArea {
         plot_left,
@@ -98,6 +192,7 @@ pub fn render_xychart(db: &XYChartDb, config: &RenderConfig) -> Result<String> {
         y_min,
         y_max,
         num_points,
+        outer_padding,
     };
 
     // Render based on orientation
@@ -146,16 +241,7 @@ fn render_vertical_chart(
         area.y_max,
         false,
     );
-    render_x_axis_shapes(
-        doc,
-        db,
-        config,
-        area.plot_left,
-        plot_bottom,
-        area.plot_width,
-        area.num_points,
-        false,
-    );
+    render_x_axis_shapes(doc, db, config, area, plot_bottom, false);
 
     // PHASE 2: Render all text labels (after shapes for z-order)
     render_chart_title(doc, db, config);
@@ -170,16 +256,7 @@ fn render_vertical_chart(
         area.y_max,
         false,
     );
-    render_x_axis_text(
-        doc,
-        db,
-        config,
-        area.plot_left,
-        plot_bottom,
-        area.plot_width,
-        area.num_points,
-        false,
-    );
+    render_x_axis_text(doc, db, config, area, plot_bottom, false);
 }
 
 /// Render a horizontal chart (x-axis at left, y-axis at top)
@@ -220,16 +297,7 @@ fn render_horizontal_chart(
         area.y_max,
         true,
     );
-    render_x_axis_shapes(
-        doc,
-        db,
-        config,
-        area.plot_left,
-        area.plot_top,
-        area.plot_height,
-        area.num_points,
-        true,
-    );
+    render_x_axis_shapes(doc, db, config, area, area.plot_top, true);
 
     // PHASE 2: Render all text labels (after shapes for z-order)
     render_chart_title(doc, db, config);
@@ -244,29 +312,46 @@ fn render_horizontal_chart(
         area.y_max,
         true,
     );
-    render_x_axis_text(
-        doc,
-        db,
-        config,
-        area.plot_left,
-        area.plot_top,
-        area.plot_height,
-        area.num_points,
-        true,
-    );
+    render_x_axis_text(doc, db, config, area, area.plot_top, true);
+}
+
+/// Get the x-coordinate for a data point at index i (tick-centered positioning)
+/// This mimics D3's scaleBand with paddingInner(1), paddingOuter(0), align(0.5)
+fn get_tick_x(area: &ChartArea, i: usize) -> f64 {
+    // Calculate range with outer padding applied
+    let range_start = area.plot_left + area.outer_padding;
+    let range_end = area.plot_left + area.plot_width - area.outer_padding;
+    let range_width = range_end - range_start;
+
+    if area.num_points <= 1 {
+        // Single point centered
+        range_start + range_width / 2.0
+    } else {
+        // Points distributed evenly across the range
+        range_start + range_width * (i as f64) / (area.num_points - 1) as f64
+    }
 }
 
 /// Render vertical bars for a bar plot
 fn render_vertical_bars(doc: &mut SvgDocument, plot: &Plot, color: &str, area: &ChartArea) {
-    let bar_spacing = area.plot_width / area.num_points as f64;
-    let bar_padding = 0.1; // 10% padding on each side
-    let bar_width = bar_spacing * (1.0 - 2.0 * bar_padding);
+    // Bar width calculation matching mermaid: min(outerPadding * 2, tickDistance) * (1 - barPaddingPercent)
+    let tick_distance = if area.num_points > 1 {
+        let range_width = area.plot_width - 2.0 * area.outer_padding;
+        range_width / (area.num_points - 1) as f64
+    } else {
+        area.plot_width
+    };
+
+    let bar_padding_percent = 0.05;
+    let bar_width = (area.outer_padding * 2.0).min(tick_distance) * (1.0 - bar_padding_percent);
+    let bar_width_half = bar_width / 2.0;
 
     let plot_bottom = area.plot_top + area.plot_height;
     let y_range = area.y_max - area.y_min;
 
     for (i, data_point) in plot.data.iter().enumerate() {
-        let x = area.plot_left + bar_spacing * (i as f64 + 0.5) - bar_width / 2.0;
+        let tick_x = get_tick_x(area, i);
+        let x = tick_x - bar_width_half;
 
         // Calculate bar height and y position
         let value_ratio = if y_range != 0.0 {
@@ -304,16 +389,39 @@ fn render_vertical_bars(doc: &mut SvgDocument, plot: &Plot, color: &str, area: &
     }
 }
 
+/// Get the y-coordinate for a data point at index i in horizontal mode (tick-centered)
+fn get_tick_y(area: &ChartArea, i: usize) -> f64 {
+    // Calculate range with outer padding applied
+    let range_start = area.plot_top + area.outer_padding;
+    let range_end = area.plot_top + area.plot_height - area.outer_padding;
+    let range_height = range_end - range_start;
+
+    if area.num_points <= 1 {
+        range_start + range_height / 2.0
+    } else {
+        range_start + range_height * (i as f64) / (area.num_points - 1) as f64
+    }
+}
+
 /// Render horizontal bars for a bar plot
 fn render_horizontal_bars(doc: &mut SvgDocument, plot: &Plot, color: &str, area: &ChartArea) {
-    let bar_spacing = area.plot_height / area.num_points as f64;
-    let bar_padding = 0.1;
-    let bar_height = bar_spacing * (1.0 - 2.0 * bar_padding);
+    // Bar height calculation for horizontal mode
+    let tick_distance = if area.num_points > 1 {
+        let range_height = area.plot_height - 2.0 * area.outer_padding;
+        range_height / (area.num_points - 1) as f64
+    } else {
+        area.plot_height
+    };
+
+    let bar_padding_percent = 0.05;
+    let bar_height = (area.outer_padding * 2.0).min(tick_distance) * (1.0 - bar_padding_percent);
+    let bar_height_half = bar_height / 2.0;
 
     let y_range = area.y_max - area.y_min;
 
     for (i, data_point) in plot.data.iter().enumerate() {
-        let y = area.plot_top + bar_spacing * (i as f64 + 0.5) - bar_height / 2.0;
+        let tick_y = get_tick_y(area, i);
+        let y = tick_y - bar_height_half;
 
         // Calculate bar width
         let value_ratio = if y_range != 0.0 {
@@ -344,23 +452,14 @@ fn render_vertical_line(doc: &mut SvgDocument, plot: &Plot, color: &str, area: &
         return;
     }
 
-    let x_spacing = if area.num_points > 1 {
-        area.plot_width / (area.num_points - 1) as f64
-    } else {
-        area.plot_width
-    };
-
     let plot_bottom = area.plot_top + area.plot_height;
     let y_range = area.y_max - area.y_min;
 
     let mut path_data = String::new();
 
     for (i, data_point) in plot.data.iter().enumerate() {
-        let x = if area.num_points > 1 {
-            area.plot_left + x_spacing * i as f64
-        } else {
-            area.plot_left + area.plot_width / 2.0
-        };
+        // Use same tick positioning as bars
+        let x = get_tick_x(area, i);
 
         let value_ratio = if y_range != 0.0 {
             (data_point.value - area.y_min) / y_range
@@ -395,23 +494,13 @@ fn render_horizontal_line(doc: &mut SvgDocument, plot: &Plot, color: &str, area:
         return;
     }
 
-    // Use edge-to-edge spacing (like vertical lines) for visual consistency
-    let y_spacing = if area.num_points > 1 {
-        area.plot_height / (area.num_points - 1) as f64
-    } else {
-        area.plot_height
-    };
-
     let y_range = area.y_max - area.y_min;
 
     let mut path_data = String::new();
 
     for (i, data_point) in plot.data.iter().enumerate() {
-        let y = if area.num_points > 1 {
-            area.plot_top + y_spacing * i as f64
-        } else {
-            area.plot_top + area.plot_height / 2.0
-        };
+        // Use same tick positioning as horizontal bars
+        let y = get_tick_y(area, i);
 
         let value_ratio = if y_range != 0.0 {
             (data_point.value - area.y_min) / y_range
@@ -442,13 +531,16 @@ fn render_horizontal_line(doc: &mut SvgDocument, plot: &Plot, color: &str, area:
 /// Render chart title - called after shapes for proper z-order
 fn render_chart_title(doc: &mut SvgDocument, db: &XYChartDb, config: &RenderConfig) {
     if !db.title.is_empty() {
+        // Position title centered horizontally, with padding from top
+        // Mermaid uses titlePadding + titleHeight/2 with dominant-baseline: middle
+        let title_y = TITLE_PADDING + (TITLE_FONT_SIZE * CHAR_HEIGHT_RATIO) / 2.0;
         let title_elem = SvgElement::Text {
             x: DEFAULT_WIDTH / 2.0,
-            y: PADDING,
+            y: title_y,
             content: db.title.clone(),
             attrs: Attrs::new()
                 .with_attr("text-anchor", "middle")
-                .with_attr("dominant-baseline", "hanging")
+                .with_attr("dominant-baseline", "middle")
                 .with_class("xychart-title")
                 .with_attr("font-size", "20")
                 .with_attr("font-weight", "bold")
@@ -613,12 +705,17 @@ fn render_x_axis_shapes(
     doc: &mut SvgDocument,
     db: &XYChartDb,
     config: &RenderConfig,
-    plot_left: f64,
+    area: &ChartArea,
     axis_y: f64,
-    axis_length: f64,
-    num_points: usize,
     is_horizontal: bool,
 ) {
+    let plot_left = area.plot_left;
+    let axis_length = if is_horizontal {
+        area.plot_height
+    } else {
+        area.plot_width
+    };
+
     // Axis line
     let (x1, y1, x2, y2) = if is_horizontal {
         (plot_left, axis_y, plot_left, axis_y + axis_length)
@@ -637,21 +734,15 @@ fn render_x_axis_shapes(
     doc.add_element(axis_line);
 
     // Get category labels for tick count
-    let categories = get_x_axis_categories(db, num_points);
+    let categories = get_x_axis_categories(db, area.num_points);
 
-    // X-axis tick marks
-    let spacing = if num_points > 0 {
-        axis_length / num_points as f64
-    } else {
-        axis_length
-    };
-
+    // X-axis tick marks at tick-centered positions
     for i in 0..categories.len() {
         let (tick_x, tick_y) = if is_horizontal {
-            let y = axis_y + spacing * (i as f64 + 0.5);
+            let y = get_tick_y(area, i);
             (plot_left, y)
         } else {
-            let x = plot_left + spacing * (i as f64 + 0.5);
+            let x = get_tick_x(area, i);
             (x, axis_y)
         };
 
@@ -685,14 +776,19 @@ fn render_x_axis_text(
     doc: &mut SvgDocument,
     db: &XYChartDb,
     config: &RenderConfig,
-    plot_left: f64,
+    area: &ChartArea,
     axis_y: f64,
-    axis_length: f64,
-    num_points: usize,
     is_horizontal: bool,
 ) {
+    let plot_left = area.plot_left;
+    let axis_length = if is_horizontal {
+        area.plot_height
+    } else {
+        area.plot_width
+    };
+
     // Get category labels
-    let categories = get_x_axis_categories(db, num_points);
+    let categories = get_x_axis_categories(db, area.num_points);
 
     // X-axis title
     if let Some(x_axis) = &db.x_axis {
@@ -727,20 +823,16 @@ fn render_x_axis_text(
         }
     }
 
-    // X-axis labels
-    let spacing = if num_points > 0 {
-        axis_length / num_points as f64
-    } else {
-        axis_length
-    };
-
+    // X-axis labels at tick-centered positions
+    // Position: axisY + labelPadding + tickLength + axisLineWidth (matching mermaid)
+    let label_offset = AXIS_LABEL_PADDING + TICK_LENGTH + AXIS_LINE_WIDTH;
     for (i, category) in categories.iter().enumerate() {
         let (label_x, label_y) = if is_horizontal {
-            let y = axis_y + spacing * (i as f64 + 0.5);
+            let y = get_tick_y(area, i);
             (plot_left - 10.0, y)
         } else {
-            let x = plot_left + spacing * (i as f64 + 0.5);
-            (x, axis_y + 15.0)
+            let x = get_tick_x(area, i);
+            (x, axis_y + label_offset)
         };
 
         let label = SvgElement::Text {


### PR DESCRIPTION
## Summary
- Improve xychart rendering for better visual parity with mermaid.js
- Significant changes to layout and rendering logic (300+ lines)
- Fixed dead code warning (unused y_label_width struct field)

## Source
Merge request: se-ut85g
Source issue: se-9eo7j
Worker: ruby

## Test plan
- [x] All 1553+ unit tests pass locally
- [x] Clippy passes
- [ ] CI checks pass

🤖 Generated by Refinery (selkie/refinery)