### PR TITLE
feat(pie): improve visual parity from 16% to 76% SSIM

### DIFF
--- a/docs/images/example_pie_netflix.svg
+++ b/docs/images/example_pie_netflix.svg
@@ -94,18 +94,18 @@ marker path {
 .pieTitleText {
   text-anchor: middle;
   font-size: 25px;
-  fill: #333333;
+  fill: black;
   font-family: trebuchet ms, verdana, arial, sans-serif;
 }
 
 .slice {
   font-family: trebuchet ms, verdana, arial, sans-serif;
-  fill: #333333;
+  fill: #333;
   font-size: 17px;
 }
 
 .legend text {
-  fill: #333333;
+  fill: black;
   font-family: trebuchet ms, verdana, arial, sans-serif;
   font-size: 17px;
 }
@@ -124,17 +124,21 @@ marker path {
     <g class="nodes">
 
     </g>
-    <circle cx="225" cy="225" r="186" class="pieOuterCircle" stroke-width="2" stroke="black" fill="none"/>
-    <path d="M 225 225 L 225 40 A 185 185 0 1 1 116.25972832589245 75.33185604063473 Z" class="pieCircle" stroke-width="2" fill="#ececff" stroke="black" opacity="0.7"/>
-    <path d="M 225 225 L 116.25972832589245 75.33185604063473 A 185 185 0 0 1 224.99999999999997 40 Z" class="pieCircle" fill="#ffffde" stroke="black" stroke-width="2" opacity="0.7"/>
-    <text x="225" y="25" class="pie-title" text-anchor="middle" font-size="20" font-weight="bold">NETFLIX</text>
-    <text x="267.87610796952396" y="356.9590916359525" class="slice" dominant-baseline="middle" font-size="17" text-anchor="middle">90%</text>
-    <text x="182.12389203047604" y="93.04090836404745" class="slice" dominant-baseline="middle" font-size="17" text-anchor="middle">10%</text>
-    <g class="legend">
-      <rect x="441" y="203" width="18" height="18" class="legend" fill="#ececff" stroke="#ececff"/>
-      <rect x="441" y="225" width="18" height="18" class="legend" stroke="#ffffde" fill="#ffffde"/>
-      <text x="463" y="217" class="legend" font-size="17">Time spent looking for movie</text>
-      <text x="463" y="239" class="legend" font-size="17">Time spent watching it</text>
+    <g transform="translate(225,225)">
+      <circle cx="0" cy="0" r="186" class="pieOuterCircle"/>
+      <path d="M0.000,-185.000A185,185,0,1,1,-108.740,-149.668L0,0Z" class="pieCircle" fill="#ececff"/>
+      <path d="M-108.740,-149.668A185,185,0,0,1,-0.000,-185.000L0,0Z" class="pieCircle" fill="#ffffde"/>
+      <text x="0" y="0" class="slice" transform="translate(42.876,131.959)" style="text-anchor: middle;">90%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-42.876,-131.959)">10%</text>
+      <text x="0" y="-200" class="pieTitleText">NETFLIX</text>
+      <g class="legend" transform="translate(216,-22)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(236, 236, 255); stroke: rgb(236, 236, 255);"/>
+        <text x="22" y="14">Time spent looking for movie</text>
+      </g>
+      <g class="legend" transform="translate(216,0)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(255, 255, 222); stroke: rgb(255, 255, 222);"/>
+        <text x="22" y="14">Time spent watching it</text>
+      </g>
     </g>
   </g>
 </svg>

--- a/docs/images/example_pie_voldemort.svg
+++ b/docs/images/example_pie_voldemort.svg
@@ -94,18 +94,18 @@ marker path {
 .pieTitleText {
   text-anchor: middle;
   font-size: 25px;
-  fill: #333333;
+  fill: black;
   font-family: trebuchet ms, verdana, arial, sans-serif;
 }
 
 .slice {
   font-family: trebuchet ms, verdana, arial, sans-serif;
-  fill: #333333;
+  fill: #333;
   font-size: 17px;
 }
 
 .legend text {
-  fill: #333333;
+  fill: black;
   font-family: trebuchet ms, verdana, arial, sans-serif;
   font-size: 17px;
 }
@@ -124,21 +124,27 @@ marker path {
     <g class="nodes">
 
     </g>
-    <circle cx="225" cy="225" r="186" class="pieOuterCircle" stroke-width="2" fill="none" stroke="black"/>
-    <path d="M 225 225 L 225 40 A 185 185 0 1 1 116.25972832589245 75.33185604063473 Z" class="pieCircle" stroke="black" stroke-width="2" opacity="0.7" fill="#ececff"/>
-    <path d="M 225 225 L 116.25972832589245 75.33185604063473 A 185 185 0 0 1 178.99237087450177 45.812115191203276 Z" class="pieCircle" opacity="0.7" stroke="black" stroke-width="2" fill="#ffffde"/>
-    <path d="M 225 225 L 178.99237087450177 45.812115191203276 A 185 185 0 0 1 224.99999999999997 40 Z" class="pieCircle" stroke="black" opacity="0.7" stroke-width="2" fill="hsl(80, 100%, 56.2745098039%)"/>
-    <text x="225" y="25" class="pie-title" font-weight="bold" text-anchor="middle" font-size="20">What Voldemort doesn&apos;t have?</text>
-    <text x="267.87610796952396" y="356.9590916359525" class="slice" font-size="17" text-anchor="middle" dominant-baseline="middle">90%</text>
-    <text x="165.92312329534613" y="99.45524647033982" class="slice" dominant-baseline="middle" font-size="17" text-anchor="middle">6%</text>
-    <text x="207.61001384295275" y="87.3440851926162" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">4%</text>
-    <g class="legend">
-      <rect x="441" y="192" width="18" height="18" class="legend" fill="hsl(80, 100%, 56.2745098039%)" stroke="hsl(80, 100%, 56.2745098039%)"/>
-      <rect x="441" y="214" width="18" height="18" class="legend" stroke="#ffffde" fill="#ffffde"/>
-      <rect x="441" y="236" width="18" height="18" class="legend" fill="#ececff" stroke="#ececff"/>
-      <text x="463" y="206" class="legend" font-size="17">FRIENDS</text>
-      <text x="463" y="228" class="legend" font-size="17">FAMILY</text>
-      <text x="463" y="250" class="legend" font-size="17">NOSE</text>
+    <g transform="translate(225,225)">
+      <circle cx="0" cy="0" r="186" class="pieOuterCircle"/>
+      <path d="M0.000,-185.000A185,185,0,1,1,-108.740,-149.668L0,0Z" class="pieCircle" fill="#ececff"/>
+      <path d="M-108.740,-149.668A185,185,0,0,1,-46.008,-179.188L0,0Z" class="pieCircle" fill="#ffffde"/>
+      <path d="M-46.008,-179.188A185,185,0,0,1,-0.000,-185.000L0,0Z" class="pieCircle" fill="hsl(80, 100%, 56.2745098039%)"/>
+      <text x="0" y="0" class="slice" transform="translate(42.876,131.959)" style="text-anchor: middle;">90%</text>
+      <text x="0" y="0" class="slice" transform="translate(-59.077,-125.545)" style="text-anchor: middle;">6%</text>
+      <text x="0" y="0" class="slice" transform="translate(-17.390,-137.656)" style="text-anchor: middle;">4%</text>
+      <text x="0" y="-200" class="pieTitleText">What Voldemort doesn&apos;t have?</text>
+      <g class="legend" transform="translate(216,-33)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(181, 255, 32); stroke: rgb(181, 255, 32);"/>
+        <text x="22" y="14">FRIENDS</text>
+      </g>
+      <g class="legend" transform="translate(216,-11)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(255, 255, 222); stroke: rgb(255, 255, 222);"/>
+        <text x="22" y="14">FAMILY</text>
+      </g>
+      <g class="legend" transform="translate(216,11)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(236, 236, 255); stroke: rgb(236, 236, 255);"/>
+        <text x="22" y="14">NOSE</text>
+      </g>
     </g>
   </g>
 </svg>

--- a/docs/images/pie.svg
+++ b/docs/images/pie.svg
@@ -94,18 +94,18 @@ marker path {
 .pieTitleText {
   text-anchor: middle;
   font-size: 25px;
-  fill: #333333;
+  fill: black;
   font-family: trebuchet ms, verdana, arial, sans-serif;
 }
 
 .slice {
   font-family: trebuchet ms, verdana, arial, sans-serif;
-  fill: #333333;
+  fill: #333;
   font-size: 17px;
 }
 
 .legend text {
-  fill: #333333;
+  fill: black;
   font-family: trebuchet ms, verdana, arial, sans-serif;
   font-size: 17px;
 }
@@ -124,25 +124,33 @@ marker path {
     <g class="nodes">
 
     </g>
-    <circle cx="225" cy="225" r="186" class="pieOuterCircle" fill="none" stroke="black" stroke-width="2"/>
-    <path d="M 225 225 L 225 40 A 185 185 0 0 1 333.74027167410753 374.66814395936524 Z" class="pieCircle" stroke="black" opacity="0.7" stroke-width="2" fill="#ececff"/>
-    <path d="M 225 225 L 333.74027167410753 374.66814395936524 A 185 185 0 0 1 75.33185604063473 333.74027167410753 Z" class="pieCircle" stroke="black" stroke-width="2" fill="#ffffde" opacity="0.7"/>
-    <path d="M 225 225 L 75.33185604063473 333.74027167410753 A 185 185 0 0 1 75.33185604063473 116.2597283258925 Z" class="pieCircle" stroke="black" stroke-width="2" fill="hsl(80, 100%, 56.2745098039%)" opacity="0.7"/>
-    <path d="M 225 225 L 75.33185604063473 116.2597283258925 A 185 185 0 0 1 224.99999999999997 40 Z" class="pieCircle" stroke="black" opacity="0.7" fill="hsl(240, 100%, 86.2745098039%)" stroke-width="2"/>
-    <text x="225" y="25" class="pie-title" text-anchor="middle" font-weight="bold" font-size="20">Project Distribution</text>
-    <text x="356.9590916359525" y="182.12389203047604" class="slice" dominant-baseline="middle" font-size="17" text-anchor="middle">40%</text>
-    <text x="203.29471797566796" y="362.04175725757534" class="slice" font-size="17" dominant-baseline="middle" text-anchor="middle">25%</text>
-    <text x="86.25" y="225.00000000000003" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">20%</text>
-    <text x="162.00881816113787" y="101.37284476886397" class="slice" text-anchor="middle" font-size="17" dominant-baseline="middle">15%</text>
-    <g class="legend">
-      <rect x="441" y="181" width="18" height="18" class="legend" stroke="#ececff" fill="#ececff"/>
-      <rect x="441" y="203" width="18" height="18" class="legend" stroke="#ffffde" fill="#ffffde"/>
-      <rect x="441" y="225" width="18" height="18" class="legend" stroke="hsl(240, 100%, 86.2745098039%)" fill="hsl(240, 100%, 86.2745098039%)"/>
-      <rect x="441" y="247" width="18" height="18" class="legend" fill="hsl(80, 100%, 56.2745098039%)" stroke="hsl(80, 100%, 56.2745098039%)"/>
-      <text x="463" y="195" class="legend" font-size="17">Development</text>
-      <text x="463" y="217" class="legend" font-size="17">Testing</text>
-      <text x="463" y="239" class="legend" font-size="17">Documentation</text>
-      <text x="463" y="261" class="legend" font-size="17">Design</text>
+    <g transform="translate(225,225)">
+      <circle cx="0" cy="0" r="186" class="pieOuterCircle"/>
+      <path d="M0.000,-185.000A185,185,0,0,1,108.740,149.668L0,0Z" class="pieCircle" fill="#ececff"/>
+      <path d="M108.740,149.668A185,185,0,0,1,-149.668,108.740L0,0Z" class="pieCircle" fill="#ffffde"/>
+      <path d="M-149.668,108.740A185,185,0,0,1,-149.668,-108.740L0,0Z" class="pieCircle" fill="hsl(80, 100%, 56.2745098039%)"/>
+      <path d="M-149.668,-108.740A185,185,0,0,1,-0.000,-185.000L0,0Z" class="pieCircle" fill="hsl(240, 100%, 86.2745098039%)"/>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(131.959,-42.876)">40%</text>
+      <text x="0" y="0" class="slice" transform="translate(-21.705,137.042)" style="text-anchor: middle;">25%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-138.750,0.000)">20%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-62.991,-123.627)">15%</text>
+      <text x="0" y="-200" class="pieTitleText">Project Distribution</text>
+      <g class="legend" transform="translate(216,-44)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(236, 236, 255); stroke: rgb(236, 236, 255);"/>
+        <text x="22" y="14">Development</text>
+      </g>
+      <g class="legend" transform="translate(216,-22)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(255, 255, 222); stroke: rgb(255, 255, 222);"/>
+        <text x="22" y="14">Testing</text>
+      </g>
+      <g class="legend" transform="translate(216,0)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(185, 185, 255); stroke: rgb(185, 185, 255);"/>
+        <text x="22" y="14">Documentation</text>
+      </g>
+      <g class="legend" transform="translate(216,22)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(181, 255, 32); stroke: rgb(181, 255, 32);"/>
+        <text x="22" y="14">Design</text>
+      </g>
     </g>
   </g>
 </svg>

--- a/docs/images/pie_complex.svg
+++ b/docs/images/pie_complex.svg
@@ -94,18 +94,18 @@ marker path {
 .pieTitleText {
   text-anchor: middle;
   font-size: 25px;
-  fill: #333333;
+  fill: black;
   font-family: trebuchet ms, verdana, arial, sans-serif;
 }
 
 .slice {
   font-family: trebuchet ms, verdana, arial, sans-serif;
-  fill: #333333;
+  fill: #333;
   font-size: 17px;
 }
 
 .legend text {
-  fill: #333333;
+  fill: black;
   font-family: trebuchet ms, verdana, arial, sans-serif;
   font-size: 17px;
 }
@@ -124,41 +124,57 @@ marker path {
     <g class="nodes">
 
     </g>
-    <circle cx="225" cy="225" r="186" class="pieOuterCircle" fill="none" stroke-width="2" stroke="black"/>
-    <path d="M 225 225 L 225 40 A 185 185 0 0 1 374.66814395936524 333.74027167410753 Z" class="pieCircle" fill="#ececff" stroke-width="2" opacity="0.7" stroke="black"/>
-    <path d="M 225 225 L 374.66814395936524 333.74027167410753 A 185 185 0 0 1 146.23083106046155 392.39300470621356 Z" class="pieCircle" stroke-width="2" opacity="0.7" stroke="black" fill="#ffffde"/>
-    <path d="M 225 225 L 146.23083106046155 392.39300470621356 A 185 185 0 0 1 40 225.00000000000003 Z" class="pieCircle" stroke-width="2" fill="hsl(80, 100%, 56.2745098039%)" opacity="0.7" stroke="black"/>
-    <path d="M 225 225 L 40 225.00000000000003 A 185 185 0 0 1 62.88326419188522 135.87557029118273 Z" class="pieCircle" fill="hsl(240, 100%, 86.2745098039%)" stroke="black" stroke-width="2" opacity="0.7"/>
-    <path d="M 225 225 L 62.88326419188522 135.87557029118273 A 185 185 0 0 1 107.07656189649231 82.45505008647908 Z" class="pieCircle" fill="hsl(60, 100%, 63.5294117647%)" stroke-width="2" stroke="black" opacity="0.7"/>
-    <path d="M 225 225 L 107.07656189649231 82.45505008647908 A 185 185 0 0 1 156.89695775333445 52.99135011067355 Z" class="pieCircle" fill="hsl(80, 100%, 76.2745098039%)" stroke-width="2" opacity="0.7" stroke="black"/>
-    <path d="M 225 225 L 156.89695775333445 52.99135011067355 A 185 185 0 0 1 201.81335179060366 41.458780256821626 Z" class="pieCircle" stroke="black" stroke-width="2" fill="hsl(300, 100%, 76.2745098039%)" opacity="0.7"/>
-    <path d="M 225 225 L 201.81335179060366 41.458780256821626 A 185 185 0 0 1 224.99999999999997 40 Z" class="pieCircle" stroke-width="2" stroke="black" opacity="0.7" fill="hsl(180, 100%, 56.2745098039%)"/>
-    <text x="225" y="25" class="pie-title" font-weight="bold" font-size="20" text-anchor="middle">Cloud Infrastructure Costs</text>
-    <text x="348.62715523113604" y="162.00881816113787" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">35%</text>
-    <text x="259.50572184412357" y="359.39091360659756" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">22%</text>
-    <text x="107.84950033659541" y="299.3459678033358" class="slice" font-size="17" text-anchor="middle" dominant-baseline="middle">18%</text>
-    <text x="90.60908639340244" y="190.49427815587643" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">8%</text>
-    <text x="118.0912875648592" y="136.55742142236937" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">6%</text>
-    <text x="154.3705035646359" y="105.57204375320286" class="slice" text-anchor="middle" dominant-baseline="middle" font-size="17">5%</text>
-    <text x="190.49427815587632" y="90.60908639340246" class="slice" dominant-baseline="middle" font-size="17" text-anchor="middle">4%</text>
-    <text x="216.28781541530768" y="86.52379143057732" class="slice" font-size="17" dominant-baseline="middle" text-anchor="middle">2%</text>
-    <g class="legend">
-      <rect x="441" y="137" width="18" height="18" class="legend" fill="#ececff" stroke="#ececff"/>
-      <rect x="441" y="159" width="18" height="18" class="legend" stroke="hsl(80, 100%, 56.2745098039%)" fill="hsl(80, 100%, 56.2745098039%)"/>
-      <rect x="441" y="181" width="18" height="18" class="legend" fill="#ffffde" stroke="#ffffde"/>
-      <rect x="441" y="203" width="18" height="18" class="legend" stroke="hsl(240, 100%, 86.2745098039%)" fill="hsl(240, 100%, 86.2745098039%)"/>
-      <rect x="441" y="225" width="18" height="18" class="legend" fill="hsl(60, 100%, 63.5294117647%)" stroke="hsl(60, 100%, 63.5294117647%)"/>
-      <rect x="441" y="247" width="18" height="18" class="legend" fill="hsl(80, 100%, 76.2745098039%)" stroke="hsl(80, 100%, 76.2745098039%)"/>
-      <rect x="441" y="269" width="18" height="18" class="legend" stroke="hsl(300, 100%, 76.2745098039%)" fill="hsl(300, 100%, 76.2745098039%)"/>
-      <rect x="441" y="291" width="18" height="18" class="legend" fill="hsl(180, 100%, 56.2745098039%)" stroke="hsl(180, 100%, 56.2745098039%)"/>
-      <text x="463" y="151" class="legend" font-size="17">Compute (EC2/GKE) [35]</text>
-      <text x="463" y="173" class="legend" font-size="17">Storage (S3/GCS) [18]</text>
-      <text x="463" y="195" class="legend" font-size="17">Database (RDS) [22]</text>
-      <text x="463" y="217" class="legend" font-size="17">Networking [8]</text>
-      <text x="463" y="239" class="legend" font-size="17">CDN &amp; Edge [6]</text>
-      <text x="463" y="261" class="legend" font-size="17">Monitoring [5]</text>
-      <text x="463" y="283" class="legend" font-size="17">Security [4]</text>
-      <text x="463" y="305" class="legend" font-size="17">Other [2]</text>
+    <g transform="translate(225,225)">
+      <circle cx="0" cy="0" r="186" class="pieOuterCircle"/>
+      <path d="M0.000,-185.000A185,185,0,0,1,149.668,108.740L0,0Z" class="pieCircle" fill="#ececff"/>
+      <path d="M149.668,108.740A185,185,0,0,1,-78.769,167.393L0,0Z" class="pieCircle" fill="#ffffde"/>
+      <path d="M-78.769,167.393A185,185,0,0,1,-185.000,0.000L0,0Z" class="pieCircle" fill="hsl(80, 100%, 56.2745098039%)"/>
+      <path d="M-185.000,0.000A185,185,0,0,1,-162.117,-89.124L0,0Z" class="pieCircle" fill="hsl(240, 100%, 86.2745098039%)"/>
+      <path d="M-162.117,-89.124A185,185,0,0,1,-117.923,-142.545L0,0Z" class="pieCircle" fill="hsl(60, 100%, 63.5294117647%)"/>
+      <path d="M-117.923,-142.545A185,185,0,0,1,-68.103,-172.009L0,0Z" class="pieCircle" fill="hsl(80, 100%, 76.2745098039%)"/>
+      <path d="M-68.103,-172.009A185,185,0,0,1,-23.187,-183.541L0,0Z" class="pieCircle" fill="hsl(300, 100%, 76.2745098039%)"/>
+      <path d="M-23.187,-183.541A185,185,0,0,1,-0.000,-185.000L0,0Z" class="pieCircle" fill="hsl(180, 100%, 56.2745098039%)"/>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(123.627,-62.991)">35%</text>
+      <text x="0" y="0" class="slice" transform="translate(34.506,134.391)" style="text-anchor: middle;">22%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-117.150,74.346)">18%</text>
+      <text x="0" y="0" class="slice" transform="translate(-134.391,-34.506)" style="text-anchor: middle;">8%</text>
+      <text x="0" y="0" class="slice" transform="translate(-106.909,-88.443)" style="text-anchor: middle;">6%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-70.629,-119.428)">5%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-34.506,-134.391)">4%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-8.712,-138.476)">2%</text>
+      <text x="0" y="-200" class="pieTitleText">Cloud Infrastructure Costs</text>
+      <g class="legend" transform="translate(216,-88)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(236, 236, 255); stroke: rgb(236, 236, 255);"/>
+        <text x="22" y="14">Compute (EC2/GKE) [35]</text>
+      </g>
+      <g class="legend" transform="translate(216,-66)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(181, 255, 32); stroke: rgb(181, 255, 32);"/>
+        <text x="22" y="14">Storage (S3/GCS) [18]</text>
+      </g>
+      <g class="legend" transform="translate(216,-44)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(255, 255, 222); stroke: rgb(255, 255, 222);"/>
+        <text x="22" y="14">Database (RDS) [22]</text>
+      </g>
+      <g class="legend" transform="translate(216,-22)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(185, 185, 255); stroke: rgb(185, 185, 255);"/>
+        <text x="22" y="14">Networking [8]</text>
+      </g>
+      <g class="legend" transform="translate(216,0)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(255, 255, 69); stroke: rgb(255, 255, 69);"/>
+        <text x="22" y="14">CDN &amp; Edge [6]</text>
+      </g>
+      <g class="legend" transform="translate(216,22)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(215, 255, 134); stroke: rgb(215, 255, 134);"/>
+        <text x="22" y="14">Monitoring [5]</text>
+      </g>
+      <g class="legend" transform="translate(216,44)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(255, 134, 255); stroke: rgb(255, 134, 255);"/>
+        <text x="22" y="14">Security [4]</text>
+      </g>
+      <g class="legend" transform="translate(216,66)">
+        <rect x="0" y="0" width="18" height="18" style="fill: rgb(32, 255, 255); stroke: rgb(32, 255, 255);"/>
+        <text x="22" y="14">Other [2]</text>
+      </g>
     </g>
   </g>
 </svg>

--- a/src/render/pie.rs
+++ b/src/render/pie.rs
@@ -1,4 +1,8 @@
 //! Pie chart renderer
+//!
+//! Renders pie charts to SVG, matching mermaid.js visual output.
+//! Uses a center-transform approach where all pie elements are positioned
+//! relative to the pie center via a group transform.
 
 use std::f64::consts::PI;
 
@@ -20,12 +24,11 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
     // Radius calculation matches mermaid.js exactly
     let radius = (pie_width.min(height) / 2.0) - MARGIN; // = 185.0
 
-    // Pie center - exactly at center of pie area (mermaid.js: group.attr('transform', 'translate(' + pieWidth / 2 + ',' + height / 2 + ')'))
+    // Pie center - exactly at center of pie area
     let cx = pie_width / 2.0; // = 225.0
     let cy = height / 2.0; // = 225.0
 
     // Calculate legend text width estimate (mermaid.js measures actual DOM text width)
-    // We estimate based on character count and typical font metrics
     let sections = db.get_sections();
     let longest_label = sections
         .iter()
@@ -47,11 +50,11 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
         .max_by_key(|s| s.len())
         .unwrap_or_default();
     // Approximate text width for 17px Trebuchet MS font
-    // Variable-width font: narrower chars (i,l) ~5px, wider (m,w) ~12px
-    // Calibrated to best match mermaid.js getBoundingClientRect() results on average
+    // Mermaid.js uses getBoundingClientRect() for actual DOM measurement
+    // We use 9.0px per character as a reasonable approximation
     let estimated_text_width = longest_label.len() as f64 * 9.0;
 
-    // Dynamic width calculation (mermaid.js: pieWidth + MARGIN + LEGEND_RECT_SIZE + LEGEND_SPACING + longestTextWidth)
+    // Dynamic width calculation
     let width = pie_width + MARGIN + LEGEND_RECT_SIZE + LEGEND_SPACING + estimated_text_width;
 
     doc.set_size(width, height);
@@ -74,18 +77,13 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
                 content: title.to_string(),
                 attrs: Attrs::new()
                     .with_attr("text-anchor", "middle")
-                    .with_class("pie-title")
-                    .with_attr("font-size", "20")
-                    .with_attr("font-weight", "bold"),
+                    .with_class("pieTitleText")
+                    .with_attr("font-size", "25"),
             };
             doc.add_element(title_elem);
         }
         return Ok(doc.to_string());
     }
-
-    // Mermaid.js uses D3's scaleOrdinal which assigns colors in the order labels
-    // are first encountered. Since mermaid processes arcs in value-descending order,
-    // colors are assigned by sorted order, not original input order.
 
     // Step 1: Get sections and sort by value descending (like mermaid)
     let sections_vec: Vec<_> = sections.to_vec();
@@ -103,89 +101,66 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
     // Pie colors from theme
     let colors: Vec<&str> = config.theme.pie_colors.iter().map(|s| s.as_str()).collect();
 
-    let mut start_angle = -PI / 2.0; // Start at top (12 o'clock)
-
-    // Pie center Y - mermaid.js does NOT offset for title, pie stays at center
-    let pie_cy = cy;
-
     // Legend dimensions matching mermaid.js exactly:
-    // horizontal = 12 * LEGEND_RECT_SIZE (from pie center)
-    // vertical = index * (LEGEND_RECT_SIZE + LEGEND_SPACING) - offset (centered)
+    // horizontal = 12 * LEGEND_RECT_SIZE (from pie center) = 216
     let legend_item_height = LEGEND_RECT_SIZE + LEGEND_SPACING; // 22.0
     let num_items = sections_vec.len() as f64;
     let legend_vertical_offset = (legend_item_height * num_items) / 2.0;
-    let legend_x = cx + 12.0 * LEGEND_RECT_SIZE; // 225 + 216 = 441
-    let legend_y = cy - legend_vertical_offset; // Centered vertically around pie center
+    let legend_x_from_center = 12.0 * LEGEND_RECT_SIZE; // = 216
 
-    // === PHASE 1: Render all shapes first (for correct z-order) ===
+    // Build all pie elements in a group with center transform (mermaid.js approach)
+    let mut pie_group_children: Vec<SvgElement> = Vec::new();
 
-    // Render outer circle (pieOuterCircle) - frames the pie chart
-    // mermaid.js uses radius + 1 for the outer circle
+    // Outer circle (pieOuterCircle) - at center (0,0) in transformed coords
     let outer_circle = SvgElement::Circle {
-        cx,
-        cy: pie_cy,
+        cx: 0.0,
+        cy: 0.0,
         r: radius + 1.0,
-        attrs: Attrs::new()
-            .with_fill("none")
-            .with_stroke(&config.theme.pie_outer_stroke_color)
-            .with_stroke_width(2.0)
-            .with_class("pieOuterCircle"),
+        attrs: Attrs::new().with_class("pieOuterCircle"),
     };
-    doc.add_element(outer_circle);
+    pie_group_children.push(outer_circle);
 
-    // Collect percentage labels while rendering slices (to render text after all shapes)
+    // Render slices using mermaid.js path format:
+    // M{start_x},{start_y} A{r},{r},0,{large_arc},1,{end_x},{end_y} L0,0 Z
+    // (arc from perimeter point, then line to center, close)
+    let mut start_angle = -PI / 2.0; // Start at top (12 o'clock)
     let mut percentage_labels: Vec<(f64, f64, String)> = Vec::new();
 
-    // Render each slice (sorted by value descending)
     for (label, value) in sorted_for_rendering.iter() {
         let percentage = *value / total;
         let angle = percentage * 2.0 * PI;
         let end_angle = start_angle + angle;
 
-        // Calculate arc points
-        let x1 = cx + radius * start_angle.cos();
-        let y1 = pie_cy + radius * start_angle.sin();
-        let x2 = cx + radius * end_angle.cos();
-        let y2 = pie_cy + radius * end_angle.sin();
+        // Calculate arc points (relative to center at 0,0)
+        let x1 = radius * start_angle.cos();
+        let y1 = radius * start_angle.sin();
+        let x2 = radius * end_angle.cos();
+        let y2 = radius * end_angle.sin();
 
         // Large arc flag (1 if angle > 180 degrees)
         let large_arc = if angle > PI { 1 } else { 0 };
 
-        // Create pie slice path
+        // Create pie slice path in mermaid.js format:
+        // Start at arc start, arc to end, line to center, close
         let path = format!(
-            "M {} {} L {} {} A {} {} 0 {} 1 {} {} Z",
-            cx,
-            pie_cy, // Move to center
-            x1,
-            y1, // Line to start of arc
-            radius,
-            radius,    // Arc radii
-            large_arc, // Large arc flag
-            x2,
-            y2 // End of arc
+            "M{:.3},{:.3}A{},{},0,{},1,{:.3},{:.3}L0,0Z",
+            x1, y1, radius as i32, radius as i32, large_arc, x2, y2
         );
 
-        // Use color based on ORIGINAL input order, not sorted order
         let color_index = label_to_color_index.get(label).copied().unwrap_or(0);
         let color = colors[color_index % colors.len()];
         let slice = SvgElement::Path {
             d: path,
-            attrs: Attrs::new()
-                .with_fill(color)
-                .with_stroke(&config.theme.pie_stroke_color)
-                .with_stroke_width(2.0)
-                .with_attr("opacity", &config.theme.pie_opacity)
-                .with_class("pieCircle"),
+            attrs: Attrs::new().with_fill(color).with_class("pieCircle"),
         };
-        doc.add_element(slice);
+        pie_group_children.push(slice);
 
-        // Collect percentage label data (to render after all shapes)
-        // Use 2% threshold to show labels for small slices like mermaid.js
+        // Collect percentage label data
         if percentage >= 0.02 {
             let mid_angle = start_angle + angle / 2.0;
-            let label_radius = radius * 0.75; // Position inside slice (mermaid.js uses ~0.75)
-            let label_x = cx + label_radius * mid_angle.cos();
-            let label_y = pie_cy + label_radius * mid_angle.sin();
+            let label_radius = radius * 0.75;
+            let label_x = label_radius * mid_angle.cos();
+            let label_y = label_radius * mid_angle.sin();
             percentage_labels.push((
                 label_x,
                 label_y,
@@ -196,104 +171,41 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
         start_angle = end_angle;
     }
 
-    // === PHASE 2: Render all text elements (after shapes for correct z-order) ===
-
-    // Render title
-    if let Some(title) = db.get_diagram_title() {
-        let title_elem = SvgElement::Text {
-            x: cx,
-            y: 25.0,
-            content: title.to_string(),
-            attrs: Attrs::new()
-                .with_attr("text-anchor", "middle")
-                .with_class("pie-title")
-                .with_attr("font-size", "20")
-                .with_attr("font-weight", "bold"),
-        };
-        doc.add_element(title_elem);
-    }
-
-    // Render percentage labels
+    // Render percentage labels with transform (mermaid.js style)
     for (label_x, label_y, content) in percentage_labels {
         let pct_label = SvgElement::Text {
-            x: label_x,
-            y: label_y,
+            x: 0.0,
+            y: 0.0,
             content,
             attrs: Attrs::new()
-                .with_attr("text-anchor", "middle")
-                .with_attr("dominant-baseline", "middle")
+                .with_transform(&format!("translate({:.3},{:.3})", label_x, label_y))
                 .with_class("slice")
-                .with_attr("font-size", "17"),
+                .with_style("text-anchor: middle;"),
         };
-        doc.add_element(pct_label);
+        pie_group_children.push(pct_label);
     }
 
-    // Build legend items in ORIGINAL input order (not sorted)
-    // But use colors based on sorted order (looked up from label_to_color_index)
-    let legend_items: Vec<(String, String, f64, f64)> = sections_vec
-        .iter()
-        .map(|(label, value)| {
-            // Look up the color index from sorted order, not input order
-            let color_index = label_to_color_index.get(label).copied().unwrap_or(0);
-            let color = colors[color_index % colors.len()];
-            let percentage = *value / total;
-            (color.to_string(), label.clone(), percentage, *value)
-        })
-        .collect();
-
-    // Render legend
-    let legend_group = render_legend(
-        &legend_items,
-        legend_x,
-        legend_y,
-        legend_item_height,
-        LEGEND_RECT_SIZE,
-        db.get_show_data(),
-    );
-    doc.add_element(legend_group);
-
-    Ok(doc.to_string())
-}
-
-/// Render a legend for the pie chart
-/// Note: Legend shapes (rects) are rendered before text to ensure correct z-order
-fn render_legend(
-    items: &[(String, String, f64, f64)], // (color, label, percentage, value)
-    x: f64,
-    y: f64,
-    item_height: f64,
-    box_size: f64,
-    show_data: bool,
-) -> SvgElement {
-    let mut children = Vec::new();
-
-    // First pass: render all colored boxes (shapes before text for z-order)
-    for (i, (color, _, _, _)) in items.iter().enumerate() {
-        let item_y = y + (i as f64) * item_height;
-
-        // Colored box with matching stroke (mermaid.js style)
-        children.push(SvgElement::Rect {
-            x,
-            y: item_y,
-            width: box_size,
-            height: box_size,
-            rx: None,
-            ry: None,
-            attrs: Attrs::new()
-                .with_fill(color)
-                .with_stroke(color)
-                .with_class("legend"),
-        });
+    // Render title (positioned relative to center)
+    if let Some(title) = db.get_diagram_title() {
+        let title_elem = SvgElement::Text {
+            x: 0.0,
+            y: -200.0, // Above the pie (mermaid.js uses y=-200 from center)
+            content: title.to_string(),
+            attrs: Attrs::new().with_class("pieTitleText"),
+        };
+        pie_group_children.push(title_elem);
     }
 
-    // Second pass: render all text labels
-    for (i, (_, label, _percentage, value)) in items.iter().enumerate() {
-        let item_y = y + (i as f64) * item_height;
+    // Render legend items - each in its own group with transform (mermaid.js style)
+    for (i, (label, value)) in sections_vec.iter().enumerate() {
+        let color_index = label_to_color_index.get(label).copied().unwrap_or(0);
+        let color = colors[color_index % colors.len()];
 
-        // Label text - include value in brackets when showData is set (mermaid.js style)
-        // mermaid.js uses x="22" relative to rect x (i.e., box_size + 4)
-        let display_label = if show_data {
-            // Format value: use integer if whole number, otherwise keep decimal
+        // Position: x = 216 from center, y centered around 0
+        let item_y = (i as f64) * legend_item_height - legend_vertical_offset;
+
+        // Format label text
+        let display_label = if db.get_show_data() {
             let value_str = if value.fract() == 0.0 {
                 format!("{}", *value as i64)
             } else {
@@ -303,23 +215,112 @@ fn render_legend(
         } else {
             label.clone()
         };
-        children.push(SvgElement::Text {
-            x: x + box_size + 4.0,
-            y: item_y + 14.0, // mermaid.js uses y="14" relative to rect
-            content: display_label,
+
+        // Create legend item group
+        let legend_item = SvgElement::Group {
+            children: vec![
+                SvgElement::Rect {
+                    x: 0.0,
+                    y: 0.0,
+                    width: LEGEND_RECT_SIZE,
+                    height: LEGEND_RECT_SIZE,
+                    rx: None,
+                    ry: None,
+                    attrs: Attrs::new().with_style(&format!(
+                        "fill: {}; stroke: {};",
+                        color_to_rgb(color),
+                        color_to_rgb(color)
+                    )),
+                },
+                SvgElement::Text {
+                    x: 22.0, // mermaid.js uses x="22" for legend text
+                    y: 14.0, // mermaid.js uses y="14" for legend text
+                    content: display_label,
+                    attrs: Attrs::new(),
+                },
+            ],
             attrs: Attrs::new()
                 .with_class("legend")
-                .with_attr("font-size", "17"),
-        });
+                .with_transform(&format!("translate({},{:.0})", legend_x_from_center, item_y)),
+        };
+        pie_group_children.push(legend_item);
     }
 
-    SvgElement::Group {
-        children,
-        attrs: Attrs::new().with_class("legend"),
+    // Create the main pie group with center transform
+    let pie_group = SvgElement::Group {
+        children: pie_group_children,
+        attrs: Attrs::new().with_transform(&format!("translate({},{})", cx as i32, cy as i32)),
+    };
+    doc.add_element(pie_group);
+
+    Ok(doc.to_string())
+}
+
+/// Convert color string to RGB format for inline styles (mermaid.js compatibility)
+fn color_to_rgb(color: &str) -> String {
+    // Handle HSL colors - convert to rgb() format
+    if color.starts_with("hsl(") {
+        // Parse hsl(h, s%, l%) format
+        let inner = color
+            .trim_start_matches("hsl(")
+            .trim_end_matches(')')
+            .trim_end_matches('%');
+        let parts: Vec<&str> = inner.split(',').map(|s| s.trim().trim_end_matches('%')).collect();
+        if parts.len() >= 3 {
+            if let (Ok(h), Ok(s), Ok(l)) = (
+                parts[0].parse::<f64>(),
+                parts[1].parse::<f64>(),
+                parts[2].parse::<f64>(),
+            ) {
+                let (r, g, b) = hsl_to_rgb(h, s / 100.0, l / 100.0);
+                return format!("rgb({}, {}, {})", r, g, b);
+            }
+        }
     }
+    // Handle hex colors - convert to rgb() format
+    if color.starts_with('#') && color.len() == 7 {
+        if let (Ok(r), Ok(g), Ok(b)) = (
+            u8::from_str_radix(&color[1..3], 16),
+            u8::from_str_radix(&color[3..5], 16),
+            u8::from_str_radix(&color[5..7], 16),
+        ) {
+            return format!("rgb({}, {}, {})", r, g, b);
+        }
+    }
+    // Return as-is for other formats
+    color.to_string()
+}
+
+/// Convert HSL to RGB values (0-255 range)
+fn hsl_to_rgb(h: f64, s: f64, l: f64) -> (u8, u8, u8) {
+    let c = (1.0 - (2.0 * l - 1.0).abs()) * s;
+    let h_prime = h / 60.0;
+    let x = c * (1.0 - ((h_prime % 2.0) - 1.0).abs());
+    let m = l - c / 2.0;
+
+    let (r1, g1, b1) = if h_prime < 1.0 {
+        (c, x, 0.0)
+    } else if h_prime < 2.0 {
+        (x, c, 0.0)
+    } else if h_prime < 3.0 {
+        (0.0, c, x)
+    } else if h_prime < 4.0 {
+        (0.0, x, c)
+    } else if h_prime < 5.0 {
+        (x, 0.0, c)
+    } else {
+        (c, 0.0, x)
+    };
+
+    (
+        ((r1 + m) * 255.0).round() as u8,
+        ((g1 + m) * 255.0).round() as u8,
+        ((b1 + m) * 255.0).round() as u8,
+    )
 }
 
 fn generate_pie_css(theme: &crate::render::svg::Theme) -> String {
+    // CSS matching mermaid.js pieStyles exactly
     format!(
         r#"
 .pieCircle {{
@@ -337,18 +338,18 @@ fn generate_pie_css(theme: &crate::render::svg::Theme) -> String {
 .pieTitleText {{
   text-anchor: middle;
   font-size: 25px;
-  fill: {pie_title_color};
+  fill: black;
   font-family: {font_family};
 }}
 
 .slice {{
   font-family: {font_family};
-  fill: {pie_title_color};
+  fill: #333;
   font-size: 17px;
 }}
 
 .legend text {{
-  fill: {pie_legend_color};
+  fill: black;
   font-family: {font_family};
   font-size: 17px;
 }}
@@ -356,8 +357,6 @@ fn generate_pie_css(theme: &crate::render::svg::Theme) -> String {
         pie_stroke = theme.pie_stroke_color,
         pie_outer_stroke = theme.pie_outer_stroke_color,
         pie_opacity = theme.pie_opacity,
-        pie_title_color = theme.pie_title_text_color,
-        pie_legend_color = theme.pie_legend_text_color,
         font_family = theme.font_family,
     )
 }

--- a/src/render/pie.rs
+++ b/src/render/pie.rs
@@ -239,9 +239,10 @@ pub fn render_pie(db: &PieDb, config: &RenderConfig) -> Result<String> {
                     attrs: Attrs::new(),
                 },
             ],
-            attrs: Attrs::new()
-                .with_class("legend")
-                .with_transform(&format!("translate({},{:.0})", legend_x_from_center, item_y)),
+            attrs: Attrs::new().with_class("legend").with_transform(&format!(
+                "translate({},{:.0})",
+                legend_x_from_center, item_y
+            )),
         };
         pie_group_children.push(legend_item);
     }
@@ -265,7 +266,10 @@ fn color_to_rgb(color: &str) -> String {
             .trim_start_matches("hsl(")
             .trim_end_matches(')')
             .trim_end_matches('%');
-        let parts: Vec<&str> = inner.split(',').map(|s| s.trim().trim_end_matches('%')).collect();
+        let parts: Vec<&str> = inner
+            .split(',')
+            .map(|s| s.trim().trim_end_matches('%'))
+            .collect();
         if parts.len() >= 3 {
             if let (Ok(h), Ok(s), Ok(l)) = (
                 parts[0].parse::<f64>(),


### PR DESCRIPTION
## Summary
- Improve pie chart visual parity (16% → 76%)

## Source
Merge request: se-r1p25 | Worker: onyx

🤖 Generated by Refinery