### PR TITLE
feat: rename crate from selkie-diagrams to selkie-rs for crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1014,7 +1014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
-name = "selkie-diagrams"
+name = "selkie-rs"
 version = "0.1.0"
 dependencies = [
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "selkie-diagrams"
+name = "selkie-rs"
 version = "0.1.0"
 edition = "2021"
 description = "A Rust implementation of the mermaid diagramming parser and renderer"

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Selkie supports parsing and rendering for all major Mermaid diagram types.
 ## Installation
 
 ```bash
-cargo install selkie
+cargo install selkie-rs
 ```
 
 Or build from source:
@@ -240,7 +240,7 @@ cargo build --release --features png
 cargo build --release --features all-formats
 
 # Install with PDF support
-cargo install selkie --features pdf
+cargo install selkie-rs --features pdf
 
 # Library only (no CLI, minimal dependencies)
 cargo build --release --no-default-features
@@ -289,7 +289,7 @@ wasm-pack build --target web --features wasm
 Convenience feature that enables `png`, `pdf`, and `kitty` together. Best for development or when you need maximum flexibility:
 
 ```bash
-cargo install selkie --features all-formats
+cargo install selkie-rs --features all-formats
 ```
 
 ## Issue Tracking


### PR DESCRIPTION
## Summary
- Renames crate from selkie-diagrams to selkie-rs for crates.io publishing

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)