### PR TITLE
fix(treemap): position labels at top-left instead of centered

### DIFF
--- a/src/render/treemap.rs
+++ b/src/render/treemap.rs
@@ -964,16 +964,18 @@ fn render_leaf(rect: &TreemapRect, index: usize, config: &RenderConfig) -> SvgEl
         ),
     });
 
-    // Calculate center position for labels
-    let center_x = rect.x + rect.width / 2.0;
-    let center_y = rect.y + rect.height / 2.0;
+    // Calculate top-left position for labels (matching mermaid.js)
+    // Labels should be positioned at top-left with padding, not centered
+    let padding = 8.0; // Padding from edges
+    let label_x = rect.x + padding;
+    let label_y = rect.y + padding;
 
     // Extract text color from styles
     let text_style = extract_text_style(&rect.styles);
 
     // Calculate font size based on available space
-    let available_width = rect.width - 8.0; // 4px padding on each side
-    let available_height = rect.height - 8.0;
+    let available_width = rect.width - 2.0 * padding;
+    let available_height = rect.height - 2.0 * padding;
 
     // Estimate text width (rough approximation)
     let char_width = LEAF_FONT_SIZE * 0.6;
@@ -999,40 +1001,38 @@ fn render_leaf(rect: &TreemapRect, index: usize, config: &RenderConfig) -> SvgEl
     // Only show text if there's enough space
     let min_display_size = 20.0;
     if rect.width >= min_display_size && rect.height >= min_display_size {
-        // Calculate positions to center label + value together
-        // The label and value form a text block that should be centered
-        let gap = 2.0; // Gap between label and value
-        let total_text_height = label_font_size + gap + value_font_size;
-        let label_y = center_y - total_text_height / 2.0 + label_font_size / 2.0;
-        let value_y = label_y + label_font_size / 2.0 + gap;
+        // Position label at top-left with padding
+        // Use "hanging" baseline so y coordinate is at top of text
+        let text_y = label_y + label_font_size * 0.85; // Adjust for baseline
 
-        // Leaf label (centered) with clip-path reference
+        // Leaf label (left-aligned, top-left position) with clip-path reference
         children.push(SvgElement::Text {
-            x: center_x,
-            y: label_y,
+            x: label_x,
+            y: text_y,
             content: rect.name.clone(),
             attrs: Attrs::new()
                 .with_class(&format!("treemapLabel {}", section_class))
-                .with_attr("text-anchor", "middle")
-                .with_attr("dominant-baseline", "middle")
+                .with_attr("text-anchor", "start")
+                .with_attr("dominant-baseline", "auto")
                 .with_attr("font-size", &format!("{}px", label_font_size))
                 .with_attr("clip-path", &format!("url(#{})", clip_id))
                 .with_fill(&text_color)
                 .with_style_if(!text_style.is_empty(), &text_style),
         });
 
-        // Leaf value (below label) with clip-path reference
+        // Leaf value (below label, also left-aligned) with clip-path reference
         // Note: mermaid.js uses rgb(255, 255, 255) format for white value text
         if let Some(value) = rect.value {
             let value_text_color = convert_white_to_rgb(&text_color);
+            let value_y = text_y + label_font_size * 0.3 + value_font_size * 0.85;
             children.push(SvgElement::Text {
-                x: center_x,
+                x: label_x,
                 y: value_y,
                 content: format_value(value),
                 attrs: Attrs::new()
                     .with_class(&format!("treemapValue {}", section_class))
-                    .with_attr("text-anchor", "middle")
-                    .with_attr("dominant-baseline", "hanging")
+                    .with_attr("text-anchor", "start")
+                    .with_attr("dominant-baseline", "auto")
                     .with_attr("font-size", &format!("{}px", value_font_size))
                     .with_attr("clip-path", &format!("url(#{})", clip_id))
                     .with_fill(&value_text_color)

--- a/tests/treemap_rendering.rs
+++ b/tests/treemap_rendering.rs
@@ -821,3 +821,136 @@ fn treemap_visual_parity_inline_colors() {
         "treemapSection elements should have inline fill attribute"
     );
 }
+
+// ============================================================================
+// Test: Text positioning - labels should be top-left, not centered
+// ============================================================================
+
+/// Get text-anchor attribute from text elements with a specific class
+fn get_text_anchor(doc: &Document<'_>, class_name: &str) -> Option<String> {
+    for node in doc.descendants() {
+        if let Some(class) = node.attribute("class") {
+            if class.split_whitespace().any(|c| c == class_name) {
+                if let Some(anchor) = node.attribute("text-anchor") {
+                    return Some(anchor.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Get position attributes (x, y) from the first element with a specific class
+fn get_element_position(doc: &Document<'_>, class_name: &str) -> Option<(f64, f64)> {
+    for node in doc.descendants() {
+        if let Some(class) = node.attribute("class") {
+            if class.split_whitespace().any(|c| c == class_name) {
+                let x: f64 = node.attribute("x")?.parse().ok()?;
+                let y: f64 = node.attribute("y")?.parse().ok()?;
+                return Some((x, y));
+            }
+        }
+    }
+    None
+}
+
+/// Get rect bounds (x, y, width, height) from the first element with a specific class
+fn get_rect_bounds(doc: &Document<'_>, class_name: &str) -> Option<(f64, f64, f64, f64)> {
+    for node in doc.descendants() {
+        if let Some(class) = node.attribute("class") {
+            if class.split_whitespace().any(|c| c == class_name) && node.tag_name().name() == "rect"
+            {
+                let x: f64 = node.attribute("x")?.parse().ok()?;
+                let y: f64 = node.attribute("y")?.parse().ok()?;
+                let w: f64 = node.attribute("width")?.parse().ok()?;
+                let h: f64 = node.attribute("height")?.parse().ok()?;
+                return Some((x, y, w, h));
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn treemap_text_positioning_top_left() {
+    // Test: Leaf labels should be positioned at top-left, not centered
+    // Reference: mermaid.js positions labels at top-left with padding
+    let input = r#"treemap-beta
+"Category"
+    "Backend": 400000
+    "Frontend": 200000
+"#;
+    let svg = render_treemap_svg(input);
+    let doc = parse_svg(&svg);
+
+    // Get text-anchor from treemapLabel elements
+    // Should be "start" for left-aligned text (mermaid.js behavior)
+    // Currently returns "middle" which is the bug
+    let anchor = get_text_anchor(&doc, "treemapLabel");
+    assert!(
+        anchor.is_some(),
+        "treemapLabel should have text-anchor attribute"
+    );
+    assert_eq!(
+        anchor.unwrap(),
+        "start",
+        "treemapLabel text-anchor should be 'start' (left-aligned) for top-left positioning"
+    );
+}
+
+#[test]
+fn treemap_text_position_relative_to_rect() {
+    // Test: Label position should be near top-left of the leaf rect, not center
+    let input = r#"treemap-beta
+"Category"
+    "Backend": 400000
+"#;
+    let svg = render_treemap_svg(input);
+    let doc = parse_svg(&svg);
+
+    // Get the leaf rect bounds
+    let rect_bounds = get_rect_bounds(&doc, "treemapLeaf");
+    assert!(rect_bounds.is_some(), "Should have treemapLeaf rect");
+    let (rect_x, rect_y, rect_w, rect_h) = rect_bounds.unwrap();
+
+    // Get the label position
+    let label_pos = get_element_position(&doc, "treemapLabel");
+    assert!(label_pos.is_some(), "Should have treemapLabel element");
+    let (label_x, label_y) = label_pos.unwrap();
+
+    // Label X should be near left edge (within 20% of width from left)
+    // Not centered (which would be rect_x + rect_w / 2.0)
+    let max_x_offset = rect_w * 0.2;
+    let center_x = rect_x + rect_w / 2.0;
+    assert!(
+        label_x < center_x,
+        "Label x ({}) should be left of center ({}), near top-left",
+        label_x,
+        center_x
+    );
+    assert!(
+        label_x - rect_x <= max_x_offset,
+        "Label x ({}) should be within 20% of left edge (rect_x={}, max_offset={})",
+        label_x,
+        rect_x,
+        max_x_offset
+    );
+
+    // Label Y should be near top edge (within 30% of height from top)
+    // Not centered (which would be rect_y + rect_h / 2.0)
+    let max_y_offset = rect_h * 0.3;
+    let center_y = rect_y + rect_h / 2.0;
+    assert!(
+        label_y < center_y,
+        "Label y ({}) should be above center ({}), near top-left",
+        label_y,
+        center_y
+    );
+    assert!(
+        label_y - rect_y <= max_y_offset,
+        "Label y ({}) should be within 30% of top edge (rect_y={}, max_offset={})",
+        label_y,
+        rect_y,
+        max_y_offset
+    );
+}


### PR DESCRIPTION
## Summary
- Positions labels at top-left instead of centered to match mermaid.js

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)