### PR TITLE
fix(docs): update library import to use selkie instead of mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Requires [Mermaid CLI](https://github.com/mermaid-js/mermaid-cli) for reference 
 ### As a Library
 
 ```rust
-use mermaid::{parse, render};
+use selkie::{parse, render};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let diagram_source = r#"


### PR DESCRIPTION
## Summary
- Updates library import references in docs

## Test plan
- [x] Build passes
- [x] Lint passes
- [ ] CI tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)