### PR TITLE
fix(kanban): match mermaid.js 185px card width

### DIFF
--- a/docs/images/kanban.svg
+++ b/docs/images/kanban.svg
@@ -138,25 +138,25 @@
       <g class="sections">
         <g class="cluster section-1" id="id1">
           <rect x="0" y="0" width="200" height="152" rx="5" ry="5" class="section section-1 " style=""/>
-          <text x="100" y="22" class="section-label" dominant-baseline="middle" text-anchor="middle">Todo</text>
+          <text x="100" y="22" class="section-label" text-anchor="middle" dominant-baseline="middle">Todo</text>
         </g>
         <g class="cluster section-2" id="id2">
           <rect x="205" y="0" width="200" height="103" rx="5" ry="5" class="section section-2 " style=""/>
-          <text x="305" y="22" class="section-label" dominant-baseline="middle" text-anchor="middle">In Progress</text>
+          <text x="305" y="22" class="section-label" text-anchor="middle" dominant-baseline="middle">In Progress</text>
         </g>
       </g>
       <g class="items">
-        <g class="node kanban-item-group" transform="translate(10, 25)">
-          <rect x="0" y="0" width="180" height="44" rx="5" ry="5" class="kanban-item " style=""/>
-          <text x="90" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Create Documentation</text>
+        <g class="node kanban-item-group" transform="translate(7.5, 25)">
+          <rect x="0" y="0" width="185" height="44" rx="5" ry="5" class="kanban-item " style=""/>
+          <text x="92.5" y="22" class="kanban-label" dominant-baseline="middle" text-anchor="middle">Create Documentation</text>
         </g>
-        <g class="node kanban-item-group" transform="translate(10, 74)">
-          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item " style=""/>
-          <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Create Blog about</tspan><tspan x="90" dy="1.2em">the new diagram</tspan></text>
+        <g class="node kanban-item-group" transform="translate(7.5, 74)">
+          <rect x="0" y="0" width="185" height="68" rx="5" ry="5" class="kanban-item " style=""/>
+          <text x="92.5" y="10" text-anchor="middle" class="kanban-label"><tspan x="92.5" dy="0.5em">Create Blog about the</tspan><tspan x="92.5" dy="1.2em">new diagram</tspan></text>
         </g>
-        <g class="node kanban-item-group" transform="translate(215, 25)">
-          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item " style=""/>
-          <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Create renderer for</tspan><tspan x="90" dy="1.2em">all cases</tspan></text>
+        <g class="node kanban-item-group" transform="translate(212.5, 25)">
+          <rect x="0" y="0" width="185" height="68" rx="5" ry="5" class="kanban-item " style=""/>
+          <text x="92.5" y="10" text-anchor="middle" class="kanban-label"><tspan x="92.5" dy="0.5em">Create renderer for</tspan><tspan x="92.5" dy="1.2em">all cases</tspan></text>
         </g>
       </g>
     </g>

--- a/docs/images/kanban_complex.svg
+++ b/docs/images/kanban_complex.svg
@@ -146,11 +146,11 @@
         </g>
         <g class="cluster section-3" id="id9">
           <rect x="410" y="0" width="200" height="50" rx="5" ry="5" class="section section-3 " style=""/>
-          <text x="510" y="22" class="section-label" text-anchor="middle" dominant-baseline="middle">Ready for deploy</text>
+          <text x="510" y="22" class="section-label" dominant-baseline="middle" text-anchor="middle">Ready for deploy</text>
         </g>
         <g class="cluster section-4" id="id10">
           <rect x="615" y="0" width="200" height="103" rx="5" ry="5" class="section section-4 " style=""/>
-          <text x="715" y="22" class="section-label" text-anchor="middle" dominant-baseline="middle">Ready for test</text>
+          <text x="715" y="22" class="section-label" dominant-baseline="middle" text-anchor="middle">Ready for test</text>
         </g>
         <g class="cluster section-5" id="id11">
           <rect x="820" y="0" width="200" height="297" rx="5" ry="5" class="section section-5 " style=""/>
@@ -158,54 +158,54 @@
         </g>
         <g class="cluster section-6" id="id12">
           <rect x="1025" y="0" width="200" height="103" rx="5" ry="5" class="section section-6 " style=""/>
-          <text x="1125" y="22" class="section-label" text-anchor="middle" dominant-baseline="middle">Can&apos;t reproduce</text>
+          <text x="1125" y="22" class="section-label" dominant-baseline="middle" text-anchor="middle">Can&apos;t reproduce</text>
         </g>
       </g>
       <g class="items">
-        <g class="node kanban-item-group" transform="translate(10, 25)">
-          <rect x="0" y="0" width="180" height="44" rx="5" ry="5" class="kanban-item " style=""/>
-          <text x="90" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Create Documentation</text>
+        <g class="node kanban-item-group" transform="translate(7.5, 25)">
+          <rect x="0" y="0" width="185" height="44" rx="5" ry="5" class="kanban-item " style=""/>
+          <text x="92.5" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Create Documentation</text>
         </g>
-        <g class="node kanban-item-group" transform="translate(10, 74)">
-          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item " style=""/>
-          <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Create Blog about</tspan><tspan x="90" dy="1.2em">the new diagram</tspan></text>
+        <g class="node kanban-item-group" transform="translate(7.5, 74)">
+          <rect x="0" y="0" width="185" height="68" rx="5" ry="5" class="kanban-item " style=""/>
+          <text x="92.5" y="10" text-anchor="middle" class="kanban-label"><tspan x="92.5" dy="0.5em">Create Blog about the</tspan><tspan x="92.5" dy="1.2em">new diagram</tspan></text>
         </g>
-        <g class="node kanban-item-group" transform="translate(215, 25)">
-          <rect x="0" y="0" width="180" height="140" rx="5" ry="5" class="kanban-item " style=""/>
-          <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Create renderer so</tspan><tspan x="90" dy="1.2em">that it works in all</tspan><tspan x="90" dy="1.2em">cases. We also add</tspan><tspan x="90" dy="1.2em">some extra text here</tspan><tspan x="90" dy="1.2em">for testing</tspan><tspan x="90" dy="1.2em">purposes.</tspan></text>
+        <g class="node kanban-item-group" transform="translate(212.5, 25)">
+          <rect x="0" y="0" width="185" height="140" rx="5" ry="5" class="kanban-item " style=""/>
+          <text x="92.5" y="10" text-anchor="middle" class="kanban-label"><tspan x="92.5" dy="0.5em">Create renderer so</tspan><tspan x="92.5" dy="1.2em">that it works in all</tspan><tspan x="92.5" dy="1.2em">cases. We also add</tspan><tspan x="92.5" dy="1.2em">some extra text here</tspan><tspan x="92.5" dy="1.2em">for testing purposes.</tspan></text>
         </g>
-        <g class="node kanban-item-group" transform="translate(215, 170)">
-          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item " style=""/>
-          <text x="90" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Design grammar</text>
-          <text x="170" y="46" class="kanban-assigned" font-size="12px" text-anchor="end">knsv</text>
+        <g class="node kanban-item-group" transform="translate(212.5, 170)">
+          <rect x="0" y="0" width="185" height="68" rx="5" ry="5" class="kanban-item " style=""/>
+          <text x="92.5" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Design grammar</text>
+          <text x="175" y="46" class="kanban-assigned" font-size="12px" text-anchor="end">knsv</text>
         </g>
-        <g class="node kanban-item-group" transform="translate(625, 25)">
-          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item " style=""/>
+        <g class="node kanban-item-group" transform="translate(622.5, 25)">
+          <rect x="0" y="0" width="185" height="68" rx="5" ry="5" class="kanban-item " style=""/>
           <line x1="2" y1="2.5" x2="2" y2="65.5" class="priority-indicator" stroke-width="4" stroke="orange"/>
-          <text x="90" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Create parsing tests</text>
+          <text x="92.5" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Create parsing tests</text>
           <text x="10" y="46" class="kanban-ticket" text-anchor="start" font-size="12px">MC-2038</text>
-          <text x="170" y="46" class="kanban-assigned" font-size="12px" text-anchor="end">K.Sveidqvist</text>
+          <text x="175" y="46" class="kanban-assigned" text-anchor="end" font-size="12px">K.Sveidqvist</text>
         </g>
-        <g class="node kanban-item-group" transform="translate(830, 25)">
-          <rect x="0" y="0" width="180" height="44" rx="5" ry="5" class="kanban-item " style=""/>
-          <text x="90" y="22" class="kanban-label" dominant-baseline="middle" text-anchor="middle">define getData</text>
+        <g class="node kanban-item-group" transform="translate(827.5, 25)">
+          <rect x="0" y="0" width="185" height="44" rx="5" ry="5" class="kanban-item " style=""/>
+          <text x="92.5" y="22" class="kanban-label" dominant-baseline="middle" text-anchor="middle">define getData</text>
         </g>
-        <g class="node kanban-item-group" transform="translate(830, 74)">
-          <rect x="0" y="0" width="180" height="140" rx="5" ry="5" class="kanban-item " style=""/>
+        <g class="node kanban-item-group" transform="translate(827.5, 74)">
+          <rect x="0" y="0" width="185" height="140" rx="5" ry="5" class="kanban-item " style=""/>
           <line x1="2" y1="2.5" x2="2" y2="137.5" class="priority-indicator" stroke="red" stroke-width="4"/>
-          <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Title of diagram is</tspan><tspan x="90" dy="1.2em">more than 100 chars</tspan><tspan x="90" dy="1.2em">when user duplicates</tspan><tspan x="90" dy="1.2em">diagram</tspan></text>
-          <text x="10" y="118" class="kanban-ticket" font-size="12px" text-anchor="start">MC-2036</text>
+          <text x="92.5" y="10" text-anchor="middle" class="kanban-label"><tspan x="92.5" dy="0.5em">Title of diagram is</tspan><tspan x="92.5" dy="1.2em">more than 100 chars</tspan><tspan x="92.5" dy="1.2em">when user duplicates</tspan><tspan x="92.5" dy="1.2em">diagram</tspan></text>
+          <text x="10" y="118" class="kanban-ticket" text-anchor="start" font-size="12px">MC-2036</text>
         </g>
-        <g class="node kanban-item-group" transform="translate(830, 219)">
-          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item " style=""/>
+        <g class="node kanban-item-group" transform="translate(827.5, 219)">
+          <rect x="0" y="0" width="185" height="68" rx="5" ry="5" class="kanban-item " style=""/>
           <line x1="2" y1="2.5" x2="2" y2="65.5" class="priority-indicator" stroke="orange" stroke-width="4"/>
-          <text x="90" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Update DB function</text>
-          <text x="10" y="46" class="kanban-ticket" text-anchor="start" font-size="12px">MC-2037</text>
-          <text x="170" y="46" class="kanban-assigned" text-anchor="end" font-size="12px">knsv</text>
+          <text x="92.5" y="22" class="kanban-label" text-anchor="middle" dominant-baseline="middle">Update DB function</text>
+          <text x="10" y="46" class="kanban-ticket" font-size="12px" text-anchor="start">MC-2037</text>
+          <text x="175" y="46" class="kanban-assigned" font-size="12px" text-anchor="end">knsv</text>
         </g>
-        <g class="node kanban-item-group" transform="translate(1035, 25)">
-          <rect x="0" y="0" width="180" height="68" rx="5" ry="5" class="kanban-item " style=""/>
-          <text x="90" y="10" text-anchor="middle" class="kanban-label"><tspan x="90" dy="0.5em">Weird flickering in</tspan><tspan x="90" dy="1.2em">Firefox</tspan></text>
+        <g class="node kanban-item-group" transform="translate(1032.5, 25)">
+          <rect x="0" y="0" width="185" height="68" rx="5" ry="5" class="kanban-item " style=""/>
+          <text x="92.5" y="10" text-anchor="middle" class="kanban-label"><tspan x="92.5" dy="0.5em">Weird flickering in</tspan><tspan x="92.5" dy="1.2em">Firefox</tspan></text>
         </g>
       </g>
     </g>

--- a/src/render/kanban.rs
+++ b/src/render/kanban.rs
@@ -267,6 +267,9 @@ fn render_section_label(text: &str, section_x: f64, section_width: f64) -> SvgEl
     }
 }
 
+/// Card width matches mermaid.js (185px)
+const CARD_WIDTH: f64 = 185.0;
+
 /// Render kanban items (cards)
 fn render_items(db: &KanbanDb, layout: &KanbanLayout, _config: &RenderConfig) -> SvgElement {
     let sections = db.get_sections();
@@ -283,11 +286,13 @@ fn render_items(db: &KanbanDb, layout: &KanbanLayout, _config: &RenderConfig) ->
 
         for (item_idx, item) in items.iter().enumerate() {
             if let Some((y, height)) = positions.get(item_idx) {
+                // Center card horizontally within section: (200 - 185) / 2 = 7.5px margin
+                let card_margin = (SECTION_WIDTH - CARD_WIDTH) / 2.0;
                 let item_elem = render_item(
                     item,
-                    section_x + PADDING,
+                    section_x + card_margin,
                     *y,
-                    SECTION_WIDTH - 2.0 * PADDING,
+                    CARD_WIDTH,
                     *height,
                 );
                 children.push(item_elem);

--- a/src/render/kanban.rs
+++ b/src/render/kanban.rs
@@ -288,13 +288,7 @@ fn render_items(db: &KanbanDb, layout: &KanbanLayout, _config: &RenderConfig) ->
             if let Some((y, height)) = positions.get(item_idx) {
                 // Center card horizontally within section: (200 - 185) / 2 = 7.5px margin
                 let card_margin = (SECTION_WIDTH - CARD_WIDTH) / 2.0;
-                let item_elem = render_item(
-                    item,
-                    section_x + card_margin,
-                    *y,
-                    CARD_WIDTH,
-                    *height,
-                );
+                let item_elem = render_item(item, section_x + card_margin, *y, CARD_WIDTH, *height);
                 children.push(item_elem);
             }
         }

--- a/tests/kanban_render.rs
+++ b/tests/kanban_render.rs
@@ -401,18 +401,18 @@ fn kanban_visual_parity_section_corner_radius() {
 
 #[test]
 fn kanban_visual_parity_item_width() {
-    // Mermaid.js kanban items are 185px wide (SECTION_WIDTH - 2*PADDING = 200 - 15 = 185)
-    // Actually mermaid uses 180px items inside 200px sections
+    // Mermaid.js kanban items are 185px wide inside 200px sections
+    // Cards are centered with 7.5px margin on each side
     let input = r#"kanban
   id1[Todo]
     task1[Task 1]"#;
 
     let svg = render_kanban_svg(input);
 
-    // Items should be 180px wide
+    // Items should be 185px wide (matching mermaid reference)
     assert!(
-        svg.contains(r#"width="180""#),
-        "Kanban items should be 180px wide for mermaid parity"
+        svg.contains(r#"width="185""#),
+        "Kanban items should be 185px wide for mermaid parity"
     );
 }
 


### PR DESCRIPTION
## Summary
- Match mermaid.js 185px card width for kanban diagrams

## Test plan
- [x] All tests pass

**Source:** polecat/obsidian/se-2ok9c (se-8yuto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)