### PR TITLE
fix(sequence): resolve z-order issue with fragment labels

### DIFF
--- a/docs/images/example_sequence_basic.svg
+++ b/docs/images/example_sequence_basic.svg
@@ -217,17 +217,17 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
     </g>
     <g class="edgePaths">
       <line x1="75" y1="109" x2="295" y2="109" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="295" y1="153" x2="515" y2="153" class="message-line" stroke-dasharray="3,3" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="295" y1="197" x2="75" y2="197" class="message-line" marker-end="url(#arrow-cross)" stroke-width="1.5" stroke-dasharray="3,3"/>
-      <line x1="295" y1="241" x2="515" y2="241" class="message-line" marker-end="url(#arrow-cross)" stroke-width="1.5"/>
-      <line x1="295" y1="334" x2="75" y2="334" class="message-line" stroke-width="1.5" stroke-dasharray="3,3"/>
+      <line x1="295" y1="153" x2="515" y2="153" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
+      <line x1="295" y1="197" x2="75" y2="197" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-cross)"/>
+      <line x1="295" y1="241" x2="515" y2="241" class="message-line" stroke-width="1.5" marker-end="url(#arrow-cross)"/>
+      <line x1="295" y1="334" x2="75" y2="334" class="message-line" stroke-dasharray="3,3" stroke-width="1.5"/>
       <line x1="75" y1="378" x2="515" y2="378" class="message-line" stroke-width="1.5"/>
     </g>
     <g class="edgeLabels">
-      <text x="185" y="99" class="message-label" text-anchor="middle" font-size="16">Hello Bob, how are you?</text>
-      <text x="405" y="143" class="message-label" font-size="16" text-anchor="middle">How about you John?</text>
-      <text x="185" y="187" class="message-label" font-size="16" text-anchor="middle">I am good thanks!</text>
-      <text x="405" y="231" class="message-label" font-size="16" text-anchor="middle">I am good thanks!</text>
+      <text x="185" y="99" class="message-label" font-size="16" text-anchor="middle">Hello Bob, how are you?</text>
+      <text x="405" y="143" class="message-label" text-anchor="middle" font-size="16">How about you John?</text>
+      <text x="185" y="187" class="message-label" text-anchor="middle" font-size="16">I am good thanks!</text>
+      <text x="405" y="231" class="message-label" text-anchor="middle" font-size="16">I am good thanks!</text>
       <text x="185" y="324" class="message-label" font-size="16" text-anchor="middle">Checking with John...</text>
       <text x="295" y="368" class="message-label" text-anchor="middle" font-size="16">Yes... John, how are you?</text>
     </g>
@@ -236,33 +236,33 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
     </g>
     <g class="actor">
       <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="75" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
+      <text x="75" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Alice</text>
     </g>
     <g class="actor">
-      <rect x="220" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="295" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Bob</text>
+      <rect x="220" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="295" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Bob</text>
     </g>
     <g class="actor">
-      <rect x="440" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <rect x="440" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
       <text x="515" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">John</text>
     </g>
     <g class="note">
-      <rect x="540" y="251" width="150" height="96" class="note" stroke="#666" fill="#EDF2AE"/>
-      <text x="615" y="256" class="noteText" alignment-baseline="middle" font-size="16" text-anchor="middle" dominant-baseline="middle" dy="1em">Bob thinks a long</text>
-      <text x="615" y="275" class="noteText" dominant-baseline="middle" alignment-baseline="middle" font-size="16" dy="1em" text-anchor="middle">long time, so long</text>
-      <text x="615" y="294" class="noteText" text-anchor="middle" dominant-baseline="middle" font-size="16" dy="1em" alignment-baseline="middle">that the text does</text>
-      <text x="615" y="313" class="noteText" dominant-baseline="middle" font-size="16" text-anchor="middle" alignment-baseline="middle" dy="1em">not fit on a row.</text>
+      <rect x="540" y="251" width="150" height="96" class="note" fill="#EDF2AE" stroke="#666"/>
+      <text x="615" y="256" class="noteText" alignment-baseline="middle" text-anchor="middle" dominant-baseline="middle" font-size="16" dy="1em">Bob thinks a long</text>
+      <text x="615" y="275" class="noteText" dominant-baseline="middle" text-anchor="middle" alignment-baseline="middle" dy="1em" font-size="16">long time, so long</text>
+      <text x="615" y="294" class="noteText" text-anchor="middle" alignment-baseline="middle" dominant-baseline="middle" font-size="16" dy="1em">that the text does</text>
+      <text x="615" y="313" class="noteText" text-anchor="middle" dy="1em" alignment-baseline="middle" dominant-baseline="middle" font-size="16">not fit on a row.</text>
     </g>
     <g class="actor">
-      <rect x="0" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="75" y="430.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Alice</text>
+      <rect x="0" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="75" y="430.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="220" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <rect x="220" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
       <text x="295" y="430.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Bob</text>
     </g>
     <g class="actor">
-      <rect x="440" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <rect x="440" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
       <text x="515" y="430.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">John</text>
     </g>
   </g>

--- a/docs/images/example_sequence_blogging.svg
+++ b/docs/images/example_sequence_blogging.svg
@@ -214,7 +214,9 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
       <line x1="-10" y1="378" x2="672" y2="378" class="loopLine" stroke-dasharray="3,3"/>
       <line x1="256" y1="735" x2="1174" y2="735" class="loopLine" stroke-dasharray="3,3"/>
       <rect x="0" y="581" width="1174" height="220" rx="3" ry="3" class="loopLine" fill="none"/>
+      <polygon points="10,581 60,581 60,594 52,601 10,601" class="labelBox"/>
       <rect x="-10" y="268" width="1194" height="533" rx="3" ry="3" class="loopLine" fill="none"/>
+      <polygon points="0,268 50,268 50,281 42,288 0,288" class="labelBox"/>
       <line x1="75" y1="65" x2="75" y2="799" class="actor-line" stroke-width="0.5px"/>
       <line x1="331" y1="65" x2="331" y2="799" class="actor-line" stroke-width="0.5px"/>
       <line x1="587" y1="65" x2="587" y2="799" class="actor-line" stroke-width="0.5px"/>
@@ -226,65 +228,63 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
     <g class="edgePaths">
       <line x1="75" y1="158" x2="587" y2="158" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
       <line x1="587" y1="202" x2="1099" y2="202" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="1099" y1="246" x2="587" y2="246" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="1099" y1="246" x2="587" y2="246" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
       <line x1="587" y1="334" x2="75" y2="334" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
       <line x1="587" y1="422" x2="75" y2="422" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="75" y1="515" x2="331" y2="515" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="75" y1="515" x2="331" y2="515" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
       <line x1="331" y1="559" x2="1099" y2="559" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <path d="M 331 647 L 371 647 L 371 677 L 331 677" class="message-line" fill="none" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
-      <path d="M 331 691 L 371 691 L 371 721 L 331 721" class="message-line" stroke-width="1.5" fill="none" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
-      <line x1="331" y1="779" x2="75" y2="779" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
+      <path d="M 331 647 L 371 647 L 371 677 L 331 677" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="3,3" fill="none" stroke-width="1.5"/>
+      <path d="M 331 691 L 371 691 L 371 721 L 331 721" class="message-line" fill="none" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="331" y1="779" x2="75" y2="779" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
     </g>
     <g class="edgeLabels">
       <text x="331" y="148" class="message-label" text-anchor="middle" font-size="16">Logs in using credentials</text>
       <text x="843" y="192" class="message-label" text-anchor="middle" font-size="16">Query stored accounts</text>
-      <text x="843" y="236" class="message-label" text-anchor="middle" font-size="16">Respond with query result</text>
-      <text x="331" y="324" class="message-label" text-anchor="middle" font-size="16">Invalid credentials</text>
+      <text x="843" y="236" class="message-label" font-size="16" text-anchor="middle">Respond with query result</text>
+      <text x="331" y="324" class="message-label" font-size="16" text-anchor="middle">Invalid credentials</text>
       <text x="331" y="396" class="loopText" text-anchor="middle" font-size="16">[Credentials found]</text>
-      <text x="331" y="412" class="message-label" font-size="16" text-anchor="middle">Successfully logged in</text>
+      <text x="331" y="412" class="message-label" text-anchor="middle" font-size="16">Successfully logged in</text>
       <text x="203" y="505" class="message-label" text-anchor="middle" font-size="16">Submit new post</text>
-      <text x="715" y="549" class="message-label" text-anchor="middle" font-size="16">Store post data</text>
+      <text x="715" y="549" class="message-label" font-size="16" text-anchor="middle">Store post data</text>
       <text x="376" y="662" class="message-label" text-anchor="start" font-size="16">Send mail to blog subscribers</text>
       <text x="376" y="706" class="message-label" font-size="16" text-anchor="start">Store in-site notifications</text>
-      <text x="715" y="753" class="loopText" text-anchor="middle" font-size="16">[Response]</text>
-      <text x="203" y="769" class="message-label" text-anchor="middle" font-size="16">Successfully posted</text>
-      <polygon points="10,581 60,581 60,594 52,601 10,601" class="labelBox"/>
-      <text x="35" y="594" class="labelText" text-anchor="middle" font-size="16">par</text>
+      <text x="715" y="753" class="loopText" font-size="16" text-anchor="middle">[Response]</text>
+      <text x="203" y="769" class="message-label" font-size="16" text-anchor="middle">Successfully posted</text>
+      <text x="35" y="594" class="labelText" font-size="16" text-anchor="middle">par</text>
       <text x="587" y="599" class="loopText" font-size="16" text-anchor="middle">[Notifications]</text>
-      <polygon points="0,268 50,268 50,281 42,288 0,288" class="labelBox"/>
-      <text x="25" y="281" class="labelText" text-anchor="middle" font-size="16">alt</text>
-      <text x="587" y="286" class="loopText" font-size="16" text-anchor="middle">[Credentials not found]</text>
+      <text x="25" y="281" class="labelText" font-size="16" text-anchor="middle">alt</text>
+      <text x="587" y="286" class="loopText" text-anchor="middle" font-size="16">[Credentials not found]</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="75" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Web Browser</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="75" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Web Browser</text>
     </g>
     <g class="actor">
-      <rect x="256" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="331" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Blog Service</text>
+      <rect x="256" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="331" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Blog Service</text>
     </g>
     <g class="actor">
       <rect x="512" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="587" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Account Service</text>
+      <text x="587" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Account Service</text>
     </g>
     <g class="actor">
-      <rect x="768" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <rect x="768" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
       <text x="843" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Mail Service</text>
     </g>
     <g class="actor">
       <rect x="1024" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="1099" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Storage</text>
+      <text x="1099" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Storage</text>
     </g>
     <g class="note">
       <rect x="50" y="75" width="1074" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="587" y="80" class="noteText" dy="1em" dominant-baseline="middle" alignment-baseline="middle" font-size="16" text-anchor="middle">The user must be logged in to submit blog posts</text>
+      <text x="587" y="80" class="noteText" alignment-baseline="middle" text-anchor="middle" font-size="16" dominant-baseline="middle" dy="1em">The user must be logged in to submit blog posts</text>
     </g>
     <g class="note">
-      <rect x="50" y="432" width="1074" height="39" class="note" stroke="#666" fill="#EDF2AE"/>
-      <text x="587" y="437" class="noteText" text-anchor="middle" font-size="16" dominant-baseline="middle" alignment-baseline="middle" dy="1em">When the user is authenticated, they can now submit new posts</text>
+      <rect x="50" y="432" width="1074" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
+      <text x="587" y="437" class="noteText" alignment-baseline="middle" text-anchor="middle" font-size="16" dominant-baseline="middle" dy="1em">When the user is authenticated, they can now submit new posts</text>
     </g>
     <g class="actor">
       <rect x="0" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
@@ -292,19 +292,19 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
     </g>
     <g class="actor">
       <rect x="256" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="331" y="831.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Blog Service</text>
+      <text x="331" y="831.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Blog Service</text>
     </g>
     <g class="actor">
       <rect x="512" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="587" y="831.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Account Service</text>
+      <text x="587" y="831.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Account Service</text>
     </g>
     <g class="actor">
-      <rect x="768" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="843" y="831.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Mail Service</text>
+      <rect x="768" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="843" y="831.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Mail Service</text>
     </g>
     <g class="actor">
-      <rect x="1024" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="1099" y="831.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Storage</text>
+      <rect x="1024" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="1099" y="831.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Storage</text>
     </g>
   </g>
 </svg>

--- a/docs/images/example_sequence_loops.svg
+++ b/docs/images/example_sequence_loops.svg
@@ -213,51 +213,51 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
     <g class="clusters">
       <line x1="0" y1="285" x2="379" y2="285" class="loopLine" stroke-dasharray="3,3"/>
       <rect x="0" y="175" width="379" height="176" rx="3" ry="3" class="loopLine" fill="none"/>
+      <polygon points="10,175 60,175 60,188 52,195 10,195" class="labelBox"/>
       <rect x="0" y="351" width="379" height="88" rx="3" ry="3" class="loopLine" fill="none"/>
+      <polygon points="10,351 60,351 60,364 52,371 10,371" class="labelBox"/>
       <rect x="-10" y="87" width="399" height="352" rx="3" ry="3" class="loopLine" fill="none"/>
+      <polygon points="0,87 50,87 50,100 42,107 0,107" class="labelBox"/>
       <line x1="75" y1="65" x2="75" y2="437" class="actor-line" stroke-width="0.5px"/>
       <line x1="304" y1="65" x2="304" y2="437" class="actor-line" stroke-width="0.5px"/>
     </g>
     <g class="edgePaths">
-      <line x1="75" y1="153" x2="304" y2="153" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="75" y1="153" x2="304" y2="153" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
       <line x1="304" y1="241" x2="75" y2="241" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="304" y1="329" x2="75" y2="329" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="304" y1="417" x2="75" y2="417" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="304" y1="329" x2="75" y2="329" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="304" y1="417" x2="75" y2="417" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
     </g>
     <g class="edgeLabels">
       <text x="189.5" y="143" class="message-label" text-anchor="middle" font-size="16">Hello Bob, how are you?</text>
-      <text x="189.5" y="231" class="message-label" text-anchor="middle" font-size="16">Not so good :(</text>
-      <text x="189.5" y="303" class="loopText" font-size="16" text-anchor="middle">[is well]</text>
-      <text x="189.5" y="319" class="message-label" font-size="16" text-anchor="middle">Feeling fresh like a daisy</text>
-      <polygon points="10,175 60,175 60,188 52,195 10,195" class="labelBox"/>
-      <text x="35" y="188" class="labelText" text-anchor="middle" font-size="16">alt</text>
+      <text x="189.5" y="231" class="message-label" font-size="16" text-anchor="middle">Not so good :(</text>
+      <text x="189.5" y="303" class="loopText" text-anchor="middle" font-size="16">[is well]</text>
+      <text x="189.5" y="319" class="message-label" text-anchor="middle" font-size="16">Feeling fresh like a daisy</text>
+      <text x="35" y="188" class="labelText" font-size="16" text-anchor="middle">alt</text>
       <text x="189.5" y="193" class="loopText" font-size="16" text-anchor="middle">[is sick]</text>
       <text x="189.5" y="407" class="message-label" text-anchor="middle" font-size="16">Thanks for asking</text>
-      <polygon points="10,351 60,351 60,364 52,371 10,371" class="labelBox"/>
-      <text x="35" y="364" class="labelText" text-anchor="middle" font-size="16">opt</text>
+      <text x="35" y="364" class="labelText" font-size="16" text-anchor="middle">opt</text>
       <text x="189.5" y="369" class="loopText" text-anchor="middle" font-size="16">[Extra response]</text>
-      <polygon points="0,87 50,87 50,100 42,107 0,107" class="labelBox"/>
-      <text x="25" y="100" class="labelText" font-size="16" text-anchor="middle">loop</text>
-      <text x="189.5" y="105" class="loopText" text-anchor="middle" font-size="16">[Daily query]</text>
+      <text x="25" y="100" class="labelText" text-anchor="middle" font-size="16">loop</text>
+      <text x="189.5" y="105" class="loopText" font-size="16" text-anchor="middle">[Daily query]</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="75" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Alice</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="75" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Alice</text>
     </g>
     <g class="actor">
-      <rect x="229" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="304" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Bob</text>
+      <rect x="229" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="304" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Bob</text>
     </g>
     <g class="actor">
       <rect x="0" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="75" y="469.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Alice</text>
+      <text x="75" y="469.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="229" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="304" y="469.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Bob</text>
+      <rect x="229" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="304" y="469.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Bob</text>
     </g>
   </g>
 </svg>

--- a/docs/images/example_sequence_self_loop.svg
+++ b/docs/images/example_sequence_self_loop.svg
@@ -212,58 +212,58 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
   <g class="root">
     <g class="clusters">
       <rect x="412" y="131" width="170" height="88" rx="3" ry="3" class="loopLine" fill="none"/>
+      <polygon points="422,131 472,131 472,144 464,151 422,151" class="labelBox"/>
       <line x1="75" y1="65" x2="75" y2="398" class="actor-line" stroke-width="0.5px"/>
       <line x1="286" y1="65" x2="286" y2="398" class="actor-line" stroke-width="0.5px"/>
       <line x1="497" y1="65" x2="497" y2="398" class="actor-line" stroke-width="0.5px"/>
     </g>
     <g class="edgePaths">
       <line x1="75" y1="109" x2="497" y2="109" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <path d="M 497 197 L 537 197 L 537 227 L 497 227" class="message-line" stroke-width="1.5" fill="none" marker-end="url(#arrow-filled)"/>
-      <line x1="497" y1="290" x2="75" y2="290" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="3,3" stroke-width="1.5"/>
-      <line x1="497" y1="334" x2="286" y2="334" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="286" y1="378" x2="497" y2="378" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="3,3" stroke-width="1.5"/>
+      <path d="M 497 197 L 537 197 L 537 227 L 497 227" class="message-line" marker-end="url(#arrow-filled)" fill="none" stroke-width="1.5"/>
+      <line x1="497" y1="290" x2="75" y2="290" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="497" y1="334" x2="286" y2="334" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="286" y1="378" x2="497" y2="378" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
     </g>
     <g class="edgeLabels">
-      <text x="286" y="99" class="message-label" text-anchor="middle" font-size="16">Hello John, how are you?</text>
-      <text x="542" y="212" class="message-label" font-size="16" text-anchor="start">Fight against hypochondria</text>
-      <polygon points="422,131 472,131 472,144 464,151 422,151" class="labelBox"/>
-      <text x="447" y="144" class="labelText" font-size="16" text-anchor="middle">loop</text>
+      <text x="286" y="99" class="message-label" font-size="16" text-anchor="middle">Hello John, how are you?</text>
+      <text x="542" y="212" class="message-label" text-anchor="start" font-size="16">Fight against hypochondria</text>
+      <text x="447" y="144" class="labelText" text-anchor="middle" font-size="16">loop</text>
       <text x="497" y="149" class="loopText" font-size="16" text-anchor="middle">[HealthCheck]</text>
-      <text x="286" y="280" class="message-label" text-anchor="middle" font-size="16">Great!</text>
-      <text x="391.5" y="324" class="message-label" font-size="16" text-anchor="middle">How about you?</text>
+      <text x="286" y="280" class="message-label" font-size="16" text-anchor="middle">Great!</text>
+      <text x="391.5" y="324" class="message-label" text-anchor="middle" font-size="16">How about you?</text>
       <text x="391.5" y="368" class="message-label" text-anchor="middle" font-size="16">Jolly good!</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="75" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Alice</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="75" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Alice</text>
     </g>
     <g class="actor">
       <rect x="211" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="286" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Bob</text>
+      <text x="286" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Bob</text>
     </g>
     <g class="actor">
-      <rect x="422" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="497" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">John</text>
+      <rect x="422" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="497" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">John</text>
     </g>
     <g class="note">
-      <rect x="522" y="207" width="150" height="58" class="note" stroke="#666" fill="#EDF2AE"/>
-      <text x="597" y="212" class="noteText" dominant-baseline="middle" dy="1em" font-size="16" text-anchor="middle" alignment-baseline="middle">Rational thoughts</text>
-      <text x="597" y="231" class="noteText" font-size="16" dy="1em" text-anchor="middle" dominant-baseline="middle" alignment-baseline="middle">prevail...</text>
+      <rect x="522" y="207" width="150" height="58" class="note" fill="#EDF2AE" stroke="#666"/>
+      <text x="597" y="212" class="noteText" text-anchor="middle" alignment-baseline="middle" dy="1em" font-size="16" dominant-baseline="middle">Rational thoughts</text>
+      <text x="597" y="231" class="noteText" dominant-baseline="middle" alignment-baseline="middle" dy="1em" font-size="16" text-anchor="middle">prevail...</text>
     </g>
     <g class="actor">
-      <rect x="0" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="75" y="430.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
+      <rect x="0" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="75" y="430.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="211" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="286" y="430.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Bob</text>
+      <rect x="211" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="286" y="430.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Bob</text>
     </g>
     <g class="actor">
-      <rect x="422" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="497" y="430.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">John</text>
+      <rect x="422" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="497" y="430.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">John</text>
     </g>
   </g>
 </svg>

--- a/docs/images/sequence.svg
+++ b/docs/images/sequence.svg
@@ -218,17 +218,17 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
     </g>
     <g class="edgePaths">
       <line x1="75" y1="109" x2="275" y2="109" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="275" y1="153" x2="75" y2="153" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
+      <line x1="275" y1="153" x2="75" y2="153" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
       <line x1="75" y1="246" x2="475" y2="246" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="475" y1="290" x2="75" y2="290" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
+      <line x1="475" y1="290" x2="75" y2="290" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
       <line x1="75" y1="334" x2="275" y2="334" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="275" y1="378" x2="75" y2="378" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="3,3" stroke-width="1.5"/>
+      <line x1="275" y1="378" x2="75" y2="378" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
     </g>
     <g class="edgeLabels">
-      <text x="175" y="99" class="message-label" text-anchor="middle" font-size="16">Hello Bob!</text>
-      <text x="175" y="143" class="message-label" font-size="16" text-anchor="middle">Hi Alice!</text>
-      <text x="275" y="236" class="message-label" text-anchor="middle" font-size="16">Login request</text>
-      <text x="275" y="280" class="message-label" text-anchor="middle" font-size="16">Token</text>
+      <text x="175" y="99" class="message-label" font-size="16" text-anchor="middle">Hello Bob!</text>
+      <text x="175" y="143" class="message-label" text-anchor="middle" font-size="16">Hi Alice!</text>
+      <text x="275" y="236" class="message-label" font-size="16" text-anchor="middle">Login request</text>
+      <text x="275" y="280" class="message-label" font-size="16" text-anchor="middle">Token</text>
       <text x="175" y="324" class="message-label" font-size="16" text-anchor="middle">How are you?</text>
       <text x="175" y="368" class="message-label" text-anchor="middle" font-size="16">I&apos;m good, thanks!</text>
     </g>
@@ -236,35 +236,35 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
 
     </g>
     <g class="actor">
-      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="75" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Alice</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="75" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="200" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <rect x="200" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
       <text x="275" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Bob</text>
     </g>
     <g class="actor">
-      <rect x="400" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="475" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Server</text>
+      <rect x="400" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="475" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Server</text>
     </g>
     <g class="note">
-      <rect x="50" y="163" width="250" height="39" class="note" stroke="#666" fill="#EDF2AE"/>
-      <text x="175" y="168" class="noteText" alignment-baseline="middle" text-anchor="middle" font-size="16" dominant-baseline="middle" dy="1em">Authentication</text>
+      <rect x="50" y="163" width="250" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
+      <text x="175" y="168" class="noteText" text-anchor="middle" dominant-baseline="middle" font-size="16" alignment-baseline="middle" dy="1em">Authentication</text>
     </g>
     <g class="note">
-      <rect x="300" y="388" width="150" height="39" class="note" stroke="#666" fill="#EDF2AE"/>
-      <text x="375" y="393" class="noteText" font-size="16" alignment-baseline="middle" text-anchor="middle" dominant-baseline="middle" dy="1em">Bob thinks</text>
+      <rect x="300" y="388" width="150" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
+      <text x="375" y="393" class="noteText" alignment-baseline="middle" text-anchor="middle" dy="1em" font-size="16" dominant-baseline="middle">Bob thinks</text>
     </g>
     <g class="actor">
-      <rect x="0" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="75" y="479.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Alice</text>
+      <rect x="0" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="75" y="479.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Alice</text>
     </g>
     <g class="actor">
-      <rect x="200" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="275" y="479.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Bob</text>
+      <rect x="200" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="275" y="479.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Bob</text>
     </g>
     <g class="actor">
-      <rect x="400" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <rect x="400" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
       <text x="475" y="479.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Server</text>
     </g>
   </g>

--- a/docs/images/sequence_complex.svg
+++ b/docs/images/sequence_complex.svg
@@ -214,8 +214,11 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
       <line x1="-10" y1="603" x2="582" y2="603" class="loopLine" stroke-dasharray="3,3"/>
       <line x1="422" y1="823" x2="1205" y2="823" class="loopLine" stroke-dasharray="3,3"/>
       <rect x="422" y="669" width="783" height="220" rx="3" ry="3" class="loopLine" fill="none"/>
+      <polygon points="432,669 482,669 482,682 474,689 432,689" class="labelBox"/>
       <rect x="422" y="933" width="783" height="132" rx="3" ry="3" class="loopLine" fill="none"/>
+      <polygon points="432,933 482,933 482,946 474,953 432,953" class="labelBox"/>
       <rect x="-10" y="449" width="1225" height="753" rx="3" ry="3" class="loopLine" fill="none"/>
+      <polygon points="0,449 50,449 50,462 42,469 0,469" class="labelBox"/>
       <line x1="75" y1="65" x2="75" y2="1200" class="actor-line" stroke-width="0.5px"/>
       <line x1="286" y1="65" x2="286" y2="1200" class="actor-line" stroke-width="0.5px"/>
       <line x1="497" y1="65" x2="497" y2="1200" class="actor-line" stroke-width="0.5px"/>
@@ -232,146 +235,143 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
       <circle cx="75" cy="158" r="11" class="sequenceNumber-circle"/>
       <line x1="286" y1="202" x2="497" y2="202" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
       <circle cx="286" cy="202" r="11" class="sequenceNumber-circle"/>
-      <line x1="497" y1="295" x2="708" y2="295" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="497" y1="295" x2="708" y2="295" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
       <circle cx="497" cy="295" r="11" class="sequenceNumber-circle"/>
       <line x1="708" y1="339" x2="919" y2="339" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
       <circle cx="708" cy="339" r="11" class="sequenceNumber-circle"/>
-      <line x1="919" y1="383" x2="708" y2="383" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
+      <line x1="919" y1="383" x2="708" y2="383" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
       <circle cx="919" cy="383" r="11" class="sequenceNumber-circle"/>
-      <line x1="708" y1="427" x2="497" y2="427" class="message-line" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#arrow-filled)"/>
+      <line x1="708" y1="427" x2="497" y2="427" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
       <circle cx="708" cy="427" r="11" class="sequenceNumber-circle"/>
-      <line x1="497" y1="515" x2="286" y2="515" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
+      <line x1="497" y1="515" x2="286" y2="515" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
       <circle cx="497" cy="515" r="11" class="sequenceNumber-circle"/>
-      <line x1="286" y1="559" x2="75" y2="559" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
+      <line x1="286" y1="559" x2="75" y2="559" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
       <circle cx="286" cy="559" r="11" class="sequenceNumber-circle"/>
-      <line x1="497" y1="647" x2="919" y2="647" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="497" y1="647" x2="919" y2="647" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
       <circle cx="497" cy="647" r="11" class="sequenceNumber-circle"/>
       <line x1="497" y1="735" x2="1130" y2="735" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
       <circle cx="497" cy="735" r="11" class="sequenceNumber-circle"/>
-      <line x1="1130" y1="779" x2="497" y2="779" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="1130" y1="779" x2="497" y2="779" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
       <circle cx="1130" cy="779" r="11" class="sequenceNumber-circle"/>
-      <path d="M 497 867 L 537 867 L 537 897 L 497 897" class="message-line" fill="none" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <path d="M 497 867 L 537 867 L 537 897 L 497 897" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" fill="none" stroke-dasharray="3,3"/>
       <circle cx="497" cy="867" r="11" class="sequenceNumber-circle"/>
-      <line x1="919" y1="911" x2="497" y2="911" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
+      <line x1="919" y1="911" x2="497" y2="911" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
       <circle cx="919" cy="911" r="11" class="sequenceNumber-circle"/>
-      <line x1="497" y1="999" x2="1130" y2="999" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="497" y1="999" x2="1130" y2="999" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
       <circle cx="497" cy="999" r="11" class="sequenceNumber-circle"/>
-      <line x1="1130" y1="1043" x2="497" y2="1043" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="3,3" stroke-width="1.5"/>
+      <line x1="1130" y1="1043" x2="497" y2="1043" class="message-line" stroke-dasharray="3,3" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
       <circle cx="1130" cy="1043" r="11" class="sequenceNumber-circle"/>
-      <line x1="497" y1="1136" x2="286" y2="1136" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
+      <line x1="497" y1="1136" x2="286" y2="1136" class="message-line" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#arrow-filled)"/>
       <circle cx="497" cy="1136" r="11" class="sequenceNumber-circle"/>
-      <line x1="286" y1="1180" x2="75" y2="1180" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
+      <line x1="286" y1="1180" x2="75" y2="1180" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
       <circle cx="286" cy="1180" r="11" class="sequenceNumber-circle"/>
     </g>
     <g class="edgeLabels">
-      <text x="75" y="162" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">1</text>
-      <text x="180.5" y="148" class="message-label" text-anchor="middle" font-size="16">Click Checkout</text>
-      <text x="286" y="206" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">2</text>
+      <text x="75" y="162" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">1</text>
+      <text x="180.5" y="148" class="message-label" font-size="16" text-anchor="middle">Click Checkout</text>
+      <text x="286" y="206" class="sequenceNumber" font-family="sans-serif" font-size="12" text-anchor="middle">2</text>
       <text x="391.5" y="192" class="message-label" text-anchor="middle" font-size="16">POST /checkout</text>
       <text x="497" y="299" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">3</text>
       <text x="602.5" y="285" class="message-label" text-anchor="middle" font-size="16">Verify session</text>
-      <text x="708" y="343" class="sequenceNumber" font-family="sans-serif" font-size="12" text-anchor="middle">4</text>
+      <text x="708" y="343" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">4</text>
       <text x="813.5" y="329" class="message-label" text-anchor="middle" font-size="16">Query user</text>
-      <text x="919" y="387" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">5</text>
-      <text x="813.5" y="373" class="message-label" font-size="16" text-anchor="middle">User record</text>
-      <text x="708" y="431" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">6</text>
+      <text x="919" y="387" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">5</text>
+      <text x="813.5" y="373" class="message-label" text-anchor="middle" font-size="16">User record</text>
+      <text x="708" y="431" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">6</text>
       <text x="602.5" y="417" class="message-label" text-anchor="middle" font-size="16">Session valid</text>
-      <text x="497" y="519" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">7</text>
+      <text x="497" y="519" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">7</text>
       <text x="391.5" y="505" class="message-label" font-size="16" text-anchor="middle">Error: Empty cart</text>
-      <text x="286" y="563" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">8</text>
+      <text x="286" y="563" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">8</text>
       <text x="180.5" y="549" class="message-label" text-anchor="middle" font-size="16">Show error</text>
       <text x="286" y="621" class="loopText" font-size="16" text-anchor="middle">[Cart Valid]</text>
-      <text x="497" y="651" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">9</text>
-      <text x="708" y="637" class="message-label" text-anchor="middle" font-size="16">Reserve inventory</text>
-      <text x="497" y="739" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">10</text>
+      <text x="497" y="651" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">9</text>
+      <text x="708" y="637" class="message-label" font-size="16" text-anchor="middle">Reserve inventory</text>
+      <text x="497" y="739" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">10</text>
       <text x="813.5" y="725" class="message-label" text-anchor="middle" font-size="16">Queue payment job</text>
-      <text x="1130" y="783" class="sequenceNumber" font-family="sans-serif" font-size="12" text-anchor="middle">11</text>
-      <text x="813.5" y="769" class="message-label" font-size="16" text-anchor="middle">Job queued</text>
+      <text x="1130" y="783" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">11</text>
+      <text x="813.5" y="769" class="message-label" text-anchor="middle" font-size="16">Job queued</text>
       <text x="813.5" y="841" class="loopText" font-size="16" text-anchor="middle">[Send Notifications]</text>
-      <text x="497" y="871" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">12</text>
-      <text x="542" y="882" class="message-label" text-anchor="start" font-size="16">Queue email confirmation</text>
-      <polygon points="432,669 482,669 482,682 474,689 432,689" class="labelBox"/>
-      <text x="457" y="682" class="labelText" font-size="16" text-anchor="middle">par</text>
+      <text x="497" y="871" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">12</text>
+      <text x="542" y="882" class="message-label" font-size="16" text-anchor="start">Queue email confirmation</text>
+      <text x="457" y="682" class="labelText" text-anchor="middle" font-size="16">par</text>
       <text x="813.5" y="687" class="loopText" text-anchor="middle" font-size="16">[Process Payment]</text>
-      <text x="919" y="915" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">13</text>
-      <text x="708" y="901" class="message-label" text-anchor="middle" font-size="16">Inventory reserved</text>
-      <text x="497" y="1003" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">14</text>
+      <text x="919" y="915" class="sequenceNumber" font-family="sans-serif" font-size="12" text-anchor="middle">13</text>
+      <text x="708" y="901" class="message-label" font-size="16" text-anchor="middle">Inventory reserved</text>
+      <text x="497" y="1003" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">14</text>
       <text x="813.5" y="989" class="message-label" text-anchor="middle" font-size="16">Check payment status</text>
       <text x="1130" y="1047" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">15</text>
-      <text x="813.5" y="1033" class="message-label" font-size="16" text-anchor="middle">Payment pending</text>
-      <polygon points="432,933 482,933 482,946 474,953 432,953" class="labelBox"/>
+      <text x="813.5" y="1033" class="message-label" text-anchor="middle" font-size="16">Payment pending</text>
       <text x="457" y="946" class="labelText" text-anchor="middle" font-size="16">loop</text>
       <text x="813.5" y="951" class="loopText" font-size="16" text-anchor="middle">[Retry up to 3 times]</text>
-      <text x="497" y="1140" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">16</text>
-      <text x="391.5" y="1126" class="message-label" font-size="16" text-anchor="middle">Order confirmed</text>
-      <text x="286" y="1184" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">17</text>
-      <text x="180.5" y="1170" class="message-label" font-size="16" text-anchor="middle">Show confirmation</text>
-      <polygon points="0,449 50,449 50,462 42,469 0,469" class="labelBox"/>
-      <text x="25" y="462" class="labelText" font-size="16" text-anchor="middle">alt</text>
+      <text x="497" y="1140" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">16</text>
+      <text x="391.5" y="1126" class="message-label" text-anchor="middle" font-size="16">Order confirmed</text>
+      <text x="286" y="1184" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">17</text>
+      <text x="180.5" y="1170" class="message-label" text-anchor="middle" font-size="16">Show confirmation</text>
+      <text x="25" y="462" class="labelText" text-anchor="middle" font-size="16">alt</text>
       <text x="602.5" y="467" class="loopText" font-size="16" text-anchor="middle">[Cart Empty]</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
       <text x="75" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">User</text>
     </g>
     <g class="actor">
-      <rect x="211" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="286" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Browser</text>
+      <rect x="211" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="286" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Browser</text>
     </g>
     <g class="actor">
-      <rect x="422" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="497" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">API</text>
+      <rect x="422" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="497" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">API</text>
     </g>
     <g class="actor">
-      <rect x="633" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="708" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Auth</text>
+      <rect x="633" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="708" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Auth</text>
     </g>
     <g class="actor">
-      <rect x="844" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="919" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">DB</text>
+      <rect x="844" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="919" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">DB</text>
     </g>
     <g class="actor">
-      <rect x="1055" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="1130" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Queue</text>
+      <rect x="1055" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="1130" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Queue</text>
     </g>
     <g class="note">
       <rect x="50" y="75" width="1105" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="602.5" y="80" class="noteText" dominant-baseline="middle" dy="1em" font-size="16" alignment-baseline="middle" text-anchor="middle">E-Commerce Checkout Flow</text>
+      <text x="602.5" y="80" class="noteText" text-anchor="middle" font-size="16" alignment-baseline="middle" dominant-baseline="middle" dy="1em">E-Commerce Checkout Flow</text>
     </g>
     <g class="note">
       <rect x="522" y="212" width="150" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="597" y="217" class="noteText" font-size="16" text-anchor="middle" dominant-baseline="middle" dy="1em" alignment-baseline="middle">Validate cart items</text>
+      <text x="597" y="217" class="noteText" font-size="16" alignment-baseline="middle" text-anchor="middle" dominant-baseline="middle" dy="1em">Validate cart items</text>
     </g>
     <g class="note">
       <rect x="472" y="1053" width="683" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="813.5" y="1058" class="noteText" dy="1em" font-size="16" dominant-baseline="middle" text-anchor="middle" alignment-baseline="middle">Payment confirmed</text>
+      <text x="813.5" y="1058" class="noteText" dy="1em" text-anchor="middle" dominant-baseline="middle" alignment-baseline="middle" font-size="16">Payment confirmed</text>
     </g>
     <g class="actor">
       <rect x="0" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="75" y="1232.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">User</text>
+      <text x="75" y="1232.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">User</text>
     </g>
     <g class="actor">
-      <rect x="211" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="286" y="1232.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Browser</text>
+      <rect x="211" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="286" y="1232.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Browser</text>
     </g>
     <g class="actor">
-      <rect x="422" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <rect x="422" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
       <text x="497" y="1232.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">API</text>
     </g>
     <g class="actor">
-      <rect x="633" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="708" y="1232.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Auth</text>
+      <rect x="633" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="708" y="1232.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Auth</text>
     </g>
     <g class="actor">
       <rect x="844" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="919" y="1232.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">DB</text>
+      <text x="919" y="1232.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">DB</text>
     </g>
     <g class="actor">
-      <rect x="1055" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="1130" y="1232.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Queue</text>
+      <rect x="1055" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="1130" y="1232.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Queue</text>
     </g>
   </g>
 </svg>

--- a/src/render/sequence.rs
+++ b/src/render/sequence.rs
@@ -239,9 +239,13 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
                             current_y,
                             label,
                         );
-                        // Add fragment labels to edge_labels for proper z-order
-                        for element in label_elements {
-                            doc.add_edge_label(element);
+                        // Add shapes to clusters (renders first) for proper z-order
+                        for shape in label_elements.shapes {
+                            doc.add_cluster(shape);
+                        }
+                        // Add text labels to edge_labels (renders after shapes)
+                        for label in label_elements.labels {
+                            doc.add_edge_label(label);
                         }
                     }
                     current_y += message_spacing;
@@ -280,9 +284,13 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
                             fragment.start_y,
                             &fragment.label,
                         );
-                        // Add fragment labels to edge_labels for proper z-order
-                        for element in label_elements {
-                            doc.add_edge_label(element);
+                        // Add shapes to clusters (renders first) for proper z-order
+                        for shape in label_elements.shapes {
+                            doc.add_cluster(shape);
+                        }
+                        // Add text labels to edge_labels (renders after shapes)
+                        for label in label_elements.labels {
+                            doc.add_edge_label(label);
                         }
                     }
                     // Don't advance current_y after fragment end - content already positioned
@@ -493,6 +501,13 @@ struct FragmentState {
 /// Message elements separated into shapes (lines/paths) and labels (text)
 /// This enables proper SVG z-order: shapes render before labels
 struct MessageElements {
+    shapes: Vec<SvgElement>,
+    labels: Vec<SvgElement>,
+}
+
+/// Fragment label elements separated into shapes (polygons) and labels (text)
+/// This enables proper SVG z-order: shapes in clusters, labels in edge_labels
+struct FragmentLabelElements {
     shapes: Vec<SvgElement>,
     labels: Vec<SvgElement>,
 }
@@ -875,8 +890,9 @@ fn render_fragment_label(
     width: f64,
     y: f64,
     text: &str,
-) -> Vec<SvgElement> {
-    let mut elements = Vec::new();
+) -> FragmentLabelElements {
+    let mut shapes = Vec::new();
+    let mut labels = Vec::new();
     let label_height = 20.0;
     let label_y = y;
 
@@ -917,11 +933,13 @@ fn render_fragment_label(
             },
         ];
 
-        elements.push(SvgElement::Polygon {
+        // Polygon is a shape - goes to clusters for proper z-order
+        shapes.push(SvgElement::Polygon {
             points,
             attrs: Attrs::new().with_class("labelBox"),
         });
-        elements.push(SvgElement::Text {
+        // Text is a label - goes to edge_labels
+        labels.push(SvgElement::Text {
             x: label_x + label_width / 2.0,
             y: label_y + 13.0,
             content: prefix.to_string(),
@@ -940,7 +958,7 @@ fn render_fragment_label(
             } else {
                 format!("[{}]", condition_text)
             };
-            elements.push(SvgElement::Text {
+            labels.push(SvgElement::Text {
                 x: x + width / 2.0,
                 y: label_y + label_height - 2.0,
                 content: wrapped,
@@ -952,7 +970,7 @@ fn render_fragment_label(
         }
     }
 
-    elements
+    FragmentLabelElements { shapes, labels }
 }
 
 fn fragment_prefix(kind: FragmentKind) -> &'static str {


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Fragment label shapes (labelBox polygons) were being added to edgeLabels alongside text, causing message text inside fragments to render before the polygon shapes
- The fix separates `FragmentLabelElements` into shapes and labels: shapes go to clusters (rendered first), text labels stay in edgeLabels (rendered after)
- This ensures proper SVG z-order where shapes render before text, matching expected visual layering

## Eval Results
- Z-order warnings: reduced from 4 to 0
- Total warnings: reduced from 33 to 29
- Affected diagrams now render with proper label box visibility

## Test plan
- [x] `cargo fmt` passes
- [x] `cargo clippy --features all-formats -- -D warnings` passes
- [x] `cargo test --features all-formats` passes
- [x] `cargo run --features eval --bin selkie -- eval --type sequence` shows no z_order warnings
- [x] Visual inspection of SVG output confirms polygons render before text

🤖 Generated with [Claude Code](https://claude.com/claude-code)