### PR TITLE
fix(state): reduce node dimensions and increase composite expansion

### DIFF
--- a/docs/images/state.svg
+++ b/docs/images/state.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="192.97699350487358" height="404" viewBox="3 -8 192.97699350487358 404" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="191.431264933764" height="392" viewBox="3 -8 191.431264933764 392" class="mermaid">
   <style>
 
 .mermaid {
@@ -180,7 +180,7 @@ marker path {
   </style>
   <defs>
     <marker id="arrow" viewBox="0 0 20 14" refX="19" refY="7" markerWidth="20" markerHeight="14" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 19,7 L9,13 L14,7 L9,1 Z" fill="#333333" stroke="#333333" stroke-width="1"/>
+      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke="#333333" stroke-width="1" fill="#333333"/>
     </marker>
   </defs>
   <g class="root">
@@ -197,49 +197,49 @@ marker path {
 
     </g>
     <g class="state-node" id="state-Error">
-      <path d="M 86.69964975487358 284 H 128.25433725487358 A 5 5 0 0 1 133.25433725487358 289 V 319 A 5 5 0 0 1 128.25433725487358 324 H 86.69964975487358 A 5 5 0 0 1 81.69964975487358 319 V 289 A 5 5 0 0 1 86.69964975487358 284 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="107.47699350487358" y="309" class="state-label" font-size="16" text-anchor="middle">Error</text>
+      <path d="M 87.153921183764 276 H 124.708608683764 A 5 5 0 0 1 129.708608683764 281 V 307 A 5 5 0 0 1 124.708608683764 312 H 87.153921183764 A 5 5 0 0 1 82.153921183764 307 V 281 A 5 5 0 0 1 87.153921183764 276 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
+      <text x="105.931264933764" y="299" class="state-label" text-anchor="middle" font-size="16">Error</text>
     </g>
     <g class="state-node" id="state-Idle">
-      <path d="M 79.67816537987358 64 H 111.47504037987358 A 5 5 0 0 1 116.47504037987358 69 V 99 A 5 5 0 0 1 111.47504037987358 104 H 79.67816537987358 A 5 5 0 0 1 74.67816537987358 99 V 69 A 5 5 0 0 1 79.67816537987358 64 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
-      <text x="95.57660287987358" y="89" class="state-label" text-anchor="middle" font-size="16">Idle</text>
+      <path d="M 81.132436808764 64 H 108.929311808764 A 5 5 0 0 1 113.929311808764 69 V 95 A 5 5 0 0 1 108.929311808764 100 H 81.132436808764 A 5 5 0 0 1 76.132436808764 95 V 69 A 5 5 0 0 1 81.132436808764 64 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="95.030874308764" y="87" class="state-label" text-anchor="middle" font-size="16">Idle</text>
     </g>
     <g class="state-node" id="state-Running">
-      <path d="M 21.77582162987357 174 H 87.37738412987358 A 5 5 0 0 1 92.37738412987358 179 V 209 A 5 5 0 0 1 87.37738412987358 214 H 21.77582162987357 A 5 5 0 0 1 16.77582162987357 209 V 179 A 5 5 0 0 1 21.77582162987357 174 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
-      <text x="54.57660287987357" y="199" class="state-label" text-anchor="middle" font-size="16">Running</text>
+      <path d="M 23.230093058763998 170 H 84.831655558764 A 5 5 0 0 1 89.831655558764 175 V 201 A 5 5 0 0 1 84.831655558764 206 H 23.230093058763998 A 5 5 0 0 1 18.230093058763998 201 V 175 A 5 5 0 0 1 23.230093058763998 170 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <text x="54.030874308764" y="193" class="state-label" text-anchor="middle" font-size="16">Running</text>
     </g>
     <g class="state-node" id="state-root_end">
-      <path d="M 100.47699350487358 381 A 7 7 0 1 0 114.47699350487358 381 A 7 7 0 1 0 100.47699350487358 381 Z" class="state-end-outer" stroke="#9370DB" fill="none" stroke-width="2"/>
-      <path d="M 104.95699350487358 381 A 2.52 2.52 0 1 0 109.99699350487357 381 A 2.52 2.52 0 1 0 104.95699350487358 381 Z" class="state-end-inner" stroke="#9370DB" stroke-width="2" fill="#9370DB"/>
+      <path d="M 98.931264933764 369 A 7 7 0 1 0 112.931264933764 369 A 7 7 0 1 0 98.931264933764 369 Z" class="state-end-outer" fill="none" stroke="#9370DB" stroke-width="2"/>
+      <path d="M 103.411264933764 369 A 2.52 2.52 0 1 0 108.451264933764 369 A 2.52 2.52 0 1 0 103.411264933764 369 Z" class="state-end-inner" stroke-width="2" stroke="#9370DB" fill="#9370DB"/>
     </g>
     <g class="state-node" id="state-root_start">
-      <circle cx="95.57660287987358" cy="7" r="7" class="state-start" fill="#333333"/>
+      <circle cx="95.030874308764" cy="7" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="transition">
-      <path d="M 95.58 14.00 C 95.58 22.33, 95.58 30.67, 95.58 39.00 C 95.58 47.33, 95.58 55.67, 95.58 64.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 95.03 14.00 C 95.03 22.33, 95.03 30.67, 95.03 39.00 C 95.03 47.33, 95.03 55.67, 95.03 64.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 74.68 98.02 C 54.31 111.68, 33.94 125.34, 28.11 138.00 C 22.27 150.67, 30.97 162.33, 39.67 174.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
-      <path d="M 6 119.8672336389396 H 46 A 2 2 0 0 1 48 121.8672336389396 V 139.4672336389396 A 2 2 0 0 1 46 141.4672336389396 H 6 A 2 2 0 0 1 4 139.4672336389396 V 121.8672336389396 A 2 2 0 0 1 6 119.8672336389396 Z" class="transition-label-bg"/>
-      <text x="26" y="130.6672336389396" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">start</text>
+      <path d="M 76.13 94.21 C 55.10 107.81, 34.06 121.40, 28.06 134.04 C 22.06 146.67, 31.08 158.33, 40.11 170.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 6 115.8175163215182 H 46 A 2 2 0 0 1 48 117.8175163215182 V 135.4175163215182 A 2 2 0 0 1 46 137.4175163215182 H 6 A 2 2 0 0 1 4 135.4175163215182 V 117.8175163215182 A 2 2 0 0 1 6 115.8175163215182 Z" class="transition-label-bg"/>
+      <text x="26" y="126.6175163215182" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">start</text>
     </g>
     <g class="transition">
-      <path d="M 69.49 174.00 L 95.58 104.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
-      <path d="M 76.99028755737461 131.66944738384007 H 108.99028755737461 A 2 2 0 0 1 110.99028755737461 133.66944738384007 V 151.26944738384006 A 2 2 0 0 1 108.99028755737461 153.26944738384006 H 76.99028755737461 A 2 2 0 0 1 74.99028755737461 151.26944738384006 V 133.66944738384007 A 2 2 0 0 1 76.99028755737461 131.66944738384007 Z" class="transition-label-bg"/>
-      <text x="92.99028755737461" y="142.46944738384008" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">stop</text>
+      <path d="M 67.96 170.00 L 95.03 100.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 76.20090108319185 127.85825807208104 H 108.20090108319185 A 2 2 0 0 1 110.20090108319185 129.85825807208104 V 147.45825807208104 A 2 2 0 0 1 108.20090108319185 149.45825807208104 H 76.20090108319185 A 2 2 0 0 1 74.20090108319185 147.45825807208104 V 129.85825807208104 A 2 2 0 0 1 76.20090108319185 127.85825807208104 Z" class="transition-label-bg"/>
+      <text x="92.20090108319185" y="138.65825807208105" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">stop</text>
     </g>
     <g class="transition">
-      <path d="M 54.58 214.00 L 88.24 284.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-      <path d="M 39.27726323152043 243.08722892753832 H 79.27726323152044 A 2 2 0 0 1 81.27726323152044 245.08722892753832 V 262.68722892753834 A 2 2 0 0 1 79.27726323152044 264.68722892753834 H 39.27726323152043 A 2 2 0 0 1 37.27726323152043 262.68722892753834 V 245.08722892753832 A 2 2 0 0 1 39.27726323152043 243.08722892753832 Z" class="transition-label-bg"/>
-      <text x="59.27726323152043" y="253.88722892753833" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">error</text>
+      <path d="M 54.03 206.00 L 88.30 276.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 38.92381300441641 235.19660499172932 H 78.92381300441642 A 2 2 0 0 1 80.92381300441642 237.19660499172932 V 254.79660499172934 A 2 2 0 0 1 78.92381300441642 256.79660499172934 H 38.92381300441641 A 2 2 0 0 1 36.92381300441641 254.79660499172934 V 237.19660499172932 A 2 2 0 0 1 38.92381300441641 235.19660499172932 Z" class="transition-label-bg"/>
+      <text x="58.92381300441641" y="245.99660499172933" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">error</text>
     </g>
     <g class="transition">
-      <path d="M 131.30 284.00 C 145.19 272.33, 159.08 260.67, 166.03 236.50 C 172.98 212.33, 172.98 175.67, 163.56 150.64 C 135.31 112.23, 116.48 98.85, 116.48 98.85" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
-      <path d="M 152.97699350487358 175.75668993617893 H 192.97699350487358 A 2 2 0 0 1 194.97699350487358 177.75668993617893 V 195.35668993617892 A 2 2 0 0 1 192.97699350487358 197.35668993617892 H 152.97699350487358 A 2 2 0 0 1 150.97699350487358 195.35668993617892 V 177.75668993617893 A 2 2 0 0 1 152.97699350487358 175.75668993617893 Z" class="transition-label-bg"/>
-      <text x="172.97699350487358" y="186.55668993617894" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">reset</text>
+      <path d="M 128.18 276.00 C 142.59 264.33, 157.01 252.67, 164.22 229.17 C 171.43 205.67, 171.43 170.33, 161.85 146.02 C 133.10 108.41, 113.93 95.11, 113.93 95.11" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 151.431264933764 170.0290159304274 H 191.431264933764 A 2 2 0 0 1 193.431264933764 172.0290159304274 V 189.62901593042739 A 2 2 0 0 1 191.431264933764 191.62901593042739 H 151.431264933764 A 2 2 0 0 1 149.431264933764 189.62901593042739 V 172.0290159304274 A 2 2 0 0 1 151.431264933764 170.0290159304274 Z" class="transition-label-bg"/>
+      <text x="171.431264933764" y="180.8290159304274" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">reset</text>
     </g>
     <g class="transition">
-      <path d="M 107.48 324.00 C 107.48 332.33, 107.48 340.67, 107.48 349.00 C 107.48 357.33, 107.48 365.67, 107.48 374.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 105.93 312.00 C 105.93 320.33, 105.93 328.67, 105.93 337.00 C 105.93 345.33, 105.93 353.67, 105.93 362.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
   </g>
 </svg>

--- a/docs/images/state_complex.svg
+++ b/docs/images/state_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="271.4296875" height="1169" viewBox="-8 -8 271.4296875 1169" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="263.4296875" height="1145" viewBox="-8 -8 263.4296875 1145" class="mermaid">
   <style>
 
 .mermaid {
@@ -197,109 +197,109 @@ marker path {
 
     </g>
     <g class="composite-state" id="composite-Idle">
-      <rect x="43.39484375000002" y="64" width="168.63999999999996" height="293" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="44.39484375000002" y="85" width="166.63999999999996" height="268" rx="0" ry="0" class="state-composite-inner"/>
-      <path d="M 43.39484375000002 85 L 212.03484375 85" class="state-composite-divider"/>
-      <text x="127.71484375" y="80" class="state-composite-label" font-size="14" text-anchor="middle">Idle</text>
+      <rect x="39.39484375000002" y="64" width="168.63999999999996" height="285" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="40.39484375000002" y="85" width="166.63999999999996" height="260" rx="0" ry="0" class="state-composite-inner"/>
+      <path d="M 39.39484375000002 85 L 208.03484375 85" class="state-composite-divider"/>
+      <text x="123.71484375" y="80" class="state-composite-label" font-size="14" text-anchor="middle">Idle</text>
     </g>
     <g class="composite-state" id="composite-Processing">
-      <rect x="46.46484375" y="617" width="162.5" height="536" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="47.46484375" y="638" width="160.5" height="511" rx="0" ry="0" class="state-composite-inner"/>
-      <path d="M 46.46484375 638 L 208.96484375 638" class="state-composite-divider"/>
-      <text x="127.71484375" y="633" class="state-composite-label" text-anchor="middle" font-size="14">Processing</text>
+      <rect x="38.63484374999999" y="605" width="170.16" height="524" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="39.63484374999999" y="626" width="168.16" height="499" rx="0" ry="0" class="state-composite-inner"/>
+      <path d="M 38.63484374999999 626 L 208.79484374999998 626" class="state-composite-divider"/>
+      <text x="123.71484374999999" y="621" class="state-composite-label" font-size="14" text-anchor="middle">Processing</text>
     </g>
     <g class="composite-state" id="composite-Executing">
-      <rect x="72.31484375" y="838" width="110.80000000000001" height="303" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="73.31484375" y="859" width="108.80000000000001" height="278" rx="0" ry="0" class="state-composite-inner-alt"/>
-      <path d="M 72.31484375 859 L 183.11484375 859" class="state-composite-divider"/>
-      <text x="127.71484375" y="854" class="state-composite-label" text-anchor="middle" font-size="14">Executing</text>
+      <rect x="71.51484375" y="822" width="104.4" height="295" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="72.51484375" y="843" width="102.4" height="270" rx="0" ry="0" class="state-composite-inner-alt"/>
+      <path d="M 71.51484375 843 L 175.91484375 843" class="state-composite-divider"/>
+      <text x="123.71484375" y="838" class="state-composite-label" text-anchor="middle" font-size="14">Executing</text>
     </g>
     <g class="state-node" id="state-Active">
-      <path d="M 102.9296875 305 H 152.5 A 5 5 0 0 1 157.5 310 V 340 A 5 5 0 0 1 152.5 345 H 102.9296875 A 5 5 0 0 1 97.9296875 340 V 310 A 5 5 0 0 1 102.9296875 305 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
-      <text x="127.71484375" y="330" class="state-label" text-anchor="middle" font-size="16">Active</text>
+      <path d="M 100.9296875 301 H 146.5 A 5 5 0 0 1 151.5 306 V 332 A 5 5 0 0 1 146.5 337 H 100.9296875 A 5 5 0 0 1 95.9296875 332 V 306 A 5 5 0 0 1 100.9296875 301 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="123.71484375" y="324" class="state-label" text-anchor="middle" font-size="16">Active</text>
     </g>
     <g class="state-node" id="state-Done">
-      <path d="M 105.58984375 1089 H 149.83984375 A 5 5 0 0 1 154.83984375 1094 V 1124 A 5 5 0 0 1 149.83984375 1129 H 105.58984375 A 5 5 0 0 1 100.58984375 1124 V 1094 A 5 5 0 0 1 105.58984375 1089 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
-      <text x="127.71484375" y="1114" class="state-label" font-size="16" text-anchor="middle">Done</text>
+      <path d="M 103.58984375 1069 H 143.83984375 A 5 5 0 0 1 148.83984375 1074 V 1100 A 5 5 0 0 1 143.83984375 1105 H 103.58984375 A 5 5 0 0 1 98.58984375 1100 V 1074 A 5 5 0 0 1 103.58984375 1069 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
+      <text x="123.71484375" y="1092" class="state-label" text-anchor="middle" font-size="16">Done</text>
     </g>
     <g class="state-node" id="state-Executing_start">
-      <circle cx="127.71484375" cy="882" r="7" class="state-start" fill="#333333"/>
+      <circle cx="123.71484375" cy="866" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Idle_start">
-      <circle cx="127.71484375000001" cy="108" r="7" class="state-start" fill="#333333"/>
+      <circle cx="123.71484375000001" cy="108" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Init">
-      <path d="M 112.71484375 969 H 142.71484375 A 5 5 0 0 1 147.71484375 974 V 1004 A 5 5 0 0 1 142.71484375 1009 H 112.71484375 A 5 5 0 0 1 107.71484375 1004 V 974 A 5 5 0 0 1 112.71484375 969 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="127.71484375" y="994" class="state-label" text-anchor="middle" font-size="16">Init</text>
+      <path d="M 111.21484375 953 H 136.21484375 A 5 5 0 0 1 141.21484375 958 V 984 A 5 5 0 0 1 136.21484375 989 H 111.21484375 A 5 5 0 0 1 106.21484375 984 V 958 A 5 5 0 0 1 111.21484375 953 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="123.71484375" y="976" class="state-label" text-anchor="middle" font-size="16">Init</text>
     </g>
     <g class="state-node" id="state-Processing_start">
-      <circle cx="127.71484375" cy="661" r="7" class="state-start" fill="#333333"/>
+      <circle cx="123.71484375" cy="649" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Ready">
-      <path d="M 101.58984375 180 H 153.83984375 A 5 5 0 0 1 158.83984375 185 V 215 A 5 5 0 0 1 153.83984375 220 H 101.58984375 A 5 5 0 0 1 96.58984375 215 V 185 A 5 5 0 0 1 101.58984375 180 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="127.71484375" y="205" class="state-label" font-size="16" text-anchor="middle">Ready</text>
+      <path d="M 99.58984375 180 H 147.83984375 A 5 5 0 0 1 152.83984375 185 V 211 A 5 5 0 0 1 147.83984375 216 H 99.58984375 A 5 5 0 0 1 94.58984375 211 V 185 A 5 5 0 0 1 99.58984375 180 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <text x="123.71484375" y="203" class="state-label" text-anchor="middle" font-size="16">Ready</text>
     </g>
     <g class="state-node" id="state-ResourceAlloc">
-      <path d="M 141.2734375 467 H 250.4296875 A 5 5 0 0 1 255.4296875 472 V 502 A 5 5 0 0 1 250.4296875 507 H 141.2734375 A 5 5 0 0 1 136.2734375 502 V 472 A 5 5 0 0 1 141.2734375 467 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
-      <text x="195.8515625" y="492" class="state-label" text-anchor="middle" font-size="16">ResourceAlloc</text>
+      <path d="M 137.2734375 459 H 242.4296875 A 5 5 0 0 1 247.4296875 464 V 490 A 5 5 0 0 1 242.4296875 495 H 137.2734375 A 5 5 0 0 1 132.2734375 490 V 464 A 5 5 0 0 1 137.2734375 459 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="189.8515625" y="482" class="state-label" text-anchor="middle" font-size="16">ResourceAlloc</text>
     </g>
     <g class="state-node" id="state-Validating">
-      <path d="M 89.578125 733 H 165.8515625 A 5 5 0 0 1 170.8515625 738 V 768 A 5 5 0 0 1 165.8515625 773 H 89.578125 A 5 5 0 0 1 84.578125 768 V 738 A 5 5 0 0 1 89.578125 733 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
-      <text x="127.71484375" y="758" class="state-label" text-anchor="middle" font-size="16">Validating</text>
+      <path d="M 87.578125 721 H 159.8515625 A 5 5 0 0 1 164.8515625 726 V 752 A 5 5 0 0 1 159.8515625 757 H 87.578125 A 5 5 0 0 1 82.578125 752 V 726 A 5 5 0 0 1 87.578125 721 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
+      <text x="123.71484375" y="744" class="state-label" font-size="16" text-anchor="middle">Validating</text>
     </g>
     <g class="state-node" id="state-Validation">
-      <path d="M 5 467 H 81.2734375 A 5 5 0 0 1 86.2734375 472 V 502 A 5 5 0 0 1 81.2734375 507 H 5 A 5 5 0 0 1 0 502 V 472 A 5 5 0 0 1 5 467 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="43.13671875" y="492" class="state-label" font-size="16" text-anchor="middle">Validation</text>
+      <path d="M 5 459 H 77.2734375 A 5 5 0 0 1 82.2734375 464 V 490 A 5 5 0 0 1 77.2734375 495 H 5 A 5 5 0 0 1 0 490 V 464 A 5 5 0 0 1 5 459 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <text x="41.13671875" y="482" class="state-label" text-anchor="middle" font-size="16">Validation</text>
     </g>
     <g class="state-node" id="state-fork_state">
-      <path d="M 86.494140625 407 H 152.494140625 A 2 2 0 0 1 154.494140625 409 V 415 A 2 2 0 0 1 152.494140625 417 H 86.494140625 A 2 2 0 0 1 84.494140625 415 V 409 A 2 2 0 0 1 86.494140625 407 Z" class="state-fork-join" fill="#333333"/>
+      <path d="M 82.494140625 399 H 148.494140625 A 2 2 0 0 1 150.494140625 401 V 407 A 2 2 0 0 1 148.494140625 409 H 82.494140625 A 2 2 0 0 1 80.494140625 407 V 401 A 2 2 0 0 1 82.494140625 399 Z" class="state-fork-join" fill="#333333"/>
     </g>
     <g class="state-node" id="state-join_state">
-      <path d="M 86.494140625 557 H 152.494140625 A 2 2 0 0 1 154.494140625 559 V 565 A 2 2 0 0 1 152.494140625 567 H 86.494140625 A 2 2 0 0 1 84.494140625 565 V 559 A 2 2 0 0 1 86.494140625 557 Z" class="state-fork-join" fill="#333333"/>
+      <path d="M 82.494140625 545 H 148.494140625 A 2 2 0 0 1 150.494140625 547 V 553 A 2 2 0 0 1 148.494140625 555 H 82.494140625 A 2 2 0 0 1 80.494140625 553 V 547 A 2 2 0 0 1 82.494140625 545 Z" class="state-fork-join" fill="#333333"/>
     </g>
     <g class="state-node" id="state-root_start">
-      <circle cx="127.71484375" cy="7" r="7" class="state-start" fill="#333333"/>
+      <circle cx="123.71484375" cy="7" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="transition">
-      <path d="M 127.71 14.00 C 127.71 22.33, 127.71 30.67, 127.71 39.00 C 127.71 47.33, 127.71 55.67, 127.71 64.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 123.71 14.00 C 123.71 22.33, 123.71 30.67, 123.71 39.00 C 123.71 47.33, 123.71 55.67, 123.71 64.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 127.71 115.00 C 127.71 125.83, 127.71 136.67, 127.71 147.50 C 127.71 158.33, 127.71 169.17, 127.71 180.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 123.71 115.00 C 123.71 125.83, 123.71 136.67, 123.71 147.50 C 123.71 158.33, 123.71 169.17, 123.71 180.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 127.71 220.00 C 127.71 234.17, 127.71 248.33, 127.71 262.50 C 127.71 276.67, 127.71 290.83, 127.71 305.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
-      <path d="M 91.71484375000001 251.7 H 163.71484375 A 2 2 0 0 1 165.71484375 253.7 V 271.3 A 2 2 0 0 1 163.71484375 273.3 H 91.71484375000001 A 2 2 0 0 1 89.71484375000001 271.3 V 253.7 A 2 2 0 0 1 91.71484375000001 251.7 Z" class="transition-label-bg"/>
-      <text x="127.71484375000001" y="262.5" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Start Job</text>
+      <path d="M 123.71 216.00 C 123.71 230.17, 123.71 244.33, 123.71 258.50 C 123.71 272.67, 123.71 286.83, 123.71 301.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 87.71484375000001 247.7 H 159.71484375 A 2 2 0 0 1 161.71484375 249.7 V 267.3 A 2 2 0 0 1 159.71484375 269.3 H 87.71484375000001 A 2 2 0 0 1 85.71484375000001 267.3 V 249.7 A 2 2 0 0 1 87.71484375000001 247.7 Z" class="transition-label-bg"/>
+      <text x="123.71484375000001" y="258.5" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Start Job</text>
     </g>
     <g class="transition">
-      <path d="M 119.49 357.00 C 119.49 365.33, 119.49 373.67, 119.49 382.00 C 119.49 390.33, 119.49 398.67, 119.49 407.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 115.49 349.00 C 115.49 357.33, 115.49 365.67, 115.49 374.00 C 115.49 382.33, 115.49 390.67, 115.49 399.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 106.77 417.00 C 85.56 425.33, 64.35 433.67, 53.74 442.00 C 43.14 450.33, 43.14 458.67, 43.14 467.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 103.10 409.00 C 82.45 417.33, 61.79 425.67, 51.46 434.00 C 41.14 442.33, 41.14 450.67, 41.14 459.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 132.22 417.00 C 153.43 425.33, 174.64 433.67, 185.25 442.00 C 195.85 450.33, 195.85 458.67, 195.85 467.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 127.89 409.00 C 148.54 417.33, 169.20 425.67, 179.52 434.00 C 189.85 442.33, 189.85 450.67, 189.85 459.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 43.14 507.00 C 43.14 515.33, 43.14 523.67, 53.74 532.00 C 64.35 540.33, 85.56 548.67, 106.77 557.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 41.14 495.00 C 41.14 503.33, 41.14 511.67, 51.46 520.00 C 61.79 528.33, 82.45 536.67, 103.10 545.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 195.85 507.00 C 195.85 515.33, 195.85 523.67, 185.25 532.00 C 174.64 540.33, 153.43 548.67, 132.22 557.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 189.85 495.00 C 189.85 503.33, 189.85 511.67, 179.52 520.00 C 169.20 528.33, 148.54 536.67, 127.89 545.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 119.49 567.00 C 119.49 575.33, 119.49 583.67, 119.49 592.00 C 119.49 600.33, 119.49 608.67, 119.49 617.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 115.49 555.00 C 115.49 563.33, 115.49 571.67, 115.49 580.00 C 115.49 588.33, 115.49 596.67, 115.49 605.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 127.71 668.00 C 127.71 678.83, 127.71 689.67, 127.71 700.50 C 127.71 711.33, 127.71 722.17, 127.71 733.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 123.71 656.00 C 123.71 666.83, 123.71 677.67, 123.71 688.50 C 123.71 699.33, 123.71 710.17, 123.71 721.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 127.71 773.00 C 127.71 783.83, 127.71 794.67, 127.71 805.50 C 127.71 816.33, 127.71 827.17, 127.71 838.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 123.71 757.00 C 123.71 767.83, 123.71 778.67, 123.71 789.50 C 123.71 800.33, 123.71 811.17, 123.71 822.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 127.71 889.00 C 127.71 902.33, 127.71 915.67, 127.71 929.00 C 127.71 942.33, 127.71 955.67, 127.71 969.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 123.71 873.00 C 123.71 886.33, 123.71 899.67, 123.71 913.00 C 123.71 926.33, 123.71 939.67, 123.71 953.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 127.71 1009.00 C 127.71 1022.33, 127.71 1035.67, 127.71 1049.00 C 127.71 1062.33, 127.71 1075.67, 127.71 1089.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 123.71 989.00 C 123.71 1002.33, 123.71 1015.67, 123.71 1029.00 C 123.71 1042.33, 123.71 1055.67, 123.71 1069.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
   </g>
 </svg>

--- a/docs/images/state_complex2.svg
+++ b/docs/images/state_complex2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1066.641357421875" height="1960" viewBox="-8 -8 1066.641357421875 1960" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1285.8157187499999" height="1924" viewBox="-8 -8 1285.8157187499999 1924" class="mermaid">
   <style>
 
 .mermaid {
@@ -180,7 +180,7 @@ marker path {
   </style>
   <defs>
     <marker id="arrow" viewBox="0 0 20 14" refX="19" refY="7" markerWidth="20" markerHeight="14" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 19,7 L9,13 L14,7 L9,1 Z" fill="#333333" stroke="#333333" stroke-width="1"/>
+      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke-width="1" fill="#333333" stroke="#333333"/>
     </marker>
   </defs>
   <g class="root">
@@ -197,193 +197,193 @@ marker path {
 
     </g>
     <g class="composite-state" id="composite-Idle">
-      <rect x="138.448046875" y="64" width="967.641357421875" height="1706" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="139.448046875" y="85" width="965.641357421875" height="1681" rx="0" ry="0" class="state-composite-inner"/>
-      <path d="M 138.448046875 85 L 1106.089404296875 85" class="state-composite-divider"/>
-      <text x="622.2687255859375" y="80" class="state-composite-label" font-size="14" text-anchor="middle">Idle</text>
+      <rect x="136.84804687499997" y="64" width="1186.8157187499999" height="1674" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="137.84804687499997" y="85" width="1184.8157187499999" height="1649" rx="0" ry="0" class="state-composite-inner"/>
+      <path d="M 136.84804687499997 85 L 1323.6637656249998 85" class="state-composite-divider"/>
+      <text x="730.25590625" y="80" class="state-composite-label" font-size="14" text-anchor="middle">Idle</text>
     </g>
     <g class="composite-state" id="composite-Processing">
-      <rect x="106.36413574218747" y="305" width="754.9130859375" height="1453" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="107.36413574218747" y="326" width="752.9130859375" height="1428" rx="0" ry="0" class="state-composite-inner-alt"/>
-      <path d="M 106.36413574218747 326 L 861.2772216796875 326" class="state-composite-divider"/>
-      <text x="483.8206787109375" y="321" class="state-composite-label" text-anchor="middle" font-size="14">Processing</text>
+      <rect x="178.11653125" y="301" width="830.5826562499999" height="1425" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="179.11653125" y="322" width="828.5826562499999" height="1400" rx="0" ry="0" class="state-composite-inner-alt"/>
+      <path d="M 178.11653125 322 L 1008.6991874999999 322" class="state-composite-divider"/>
+      <text x="593.4078593749999" y="317" class="state-composite-label" font-size="14" text-anchor="middle">Processing</text>
     </g>
     <g class="composite-state" id="composite-Paused">
-      <rect x="368.6769287109375" y="1393" width="230.28750000000002" height="353" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="369.6769287109375" y="1414" width="228.28750000000002" height="328" rx="0" ry="0" class="state-composite-inner-alt"/>
-      <path d="M 368.6769287109375 1414 L 598.9644287109375 1414" class="state-composite-divider"/>
-      <text x="483.8206787109375" y="1409" class="state-composite-label" text-anchor="middle" font-size="14">Paused</text>
+      <rect x="481.4641093749999" y="1369" width="223.88750000000002" height="345" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="482.4641093749999" y="1390" width="221.88750000000002" height="320" rx="0" ry="0" class="state-composite-inner-alt"/>
+      <path d="M 481.4641093749999 1390 L 705.351609375 1390" class="state-composite-divider"/>
+      <text x="593.4078593749999" y="1385" class="state-composite-label" font-size="14" text-anchor="middle">Paused</text>
     </g>
     <g class="composite-state" id="composite-Running">
-      <rect x="402.8081787109375" y="716" width="162.025" height="577" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="403.8081787109375" y="737" width="160.025" height="552" rx="0" ry="0" class="state-composite-inner-alt"/>
-      <path d="M 402.8081787109375 737 L 564.8331787109375 737" class="state-composite-divider"/>
-      <text x="483.8206787109375" y="732" class="state-composite-label" font-size="14" text-anchor="middle">Running</text>
+      <rect x="515.5953593749999" y="704" width="155.625" height="565" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="516.5953593749999" y="725" width="153.625" height="540" rx="0" ry="0" class="state-composite-inner-alt"/>
+      <path d="M 515.5953593749999 725 L 671.2203593749999 725" class="state-composite-divider"/>
+      <text x="593.4078593749999" y="720" class="state-composite-label" font-size="14" text-anchor="middle">Running</text>
     </g>
     <g class="state-node" id="state-Cancelled">
-      <path d="M 445.2425537109375 1840 H 522.3988037109375 A 5 5 0 0 1 527.3988037109375 1845 V 1875 A 5 5 0 0 1 522.3988037109375 1880 H 445.2425537109375 A 5 5 0 0 1 440.2425537109375 1875 V 1845 A 5 5 0 0 1 445.2425537109375 1840 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="483.8206787109375" y="1865" class="state-label" font-size="16" text-anchor="middle">Cancelled</text>
+      <path d="M 556.8297343749999 1808 H 629.9859843749999 A 5 5 0 0 1 634.9859843749999 1813 V 1839 A 5 5 0 0 1 629.9859843749999 1844 H 556.8297343749999 A 5 5 0 0 1 551.8297343749999 1839 V 1813 A 5 5 0 0 1 556.8297343749999 1808 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
+      <text x="593.4078593749999" y="1831" class="state-label" font-size="16" text-anchor="middle">Cancelled</text>
     </g>
     <g class="state-node" id="state-Completed">
-      <path d="M 334.9034912109375 1549.5 H 418.2784912109375 A 5 5 0 0 1 423.2784912109375 1554.5 V 1584.5 A 5 5 0 0 1 418.2784912109375 1589.5 H 334.9034912109375 A 5 5 0 0 1 329.9034912109375 1584.5 V 1554.5 A 5 5 0 0 1 334.9034912109375 1549.5 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
-      <text x="376.5909912109375" y="1574.5" class="state-label" text-anchor="middle" font-size="16">Completed</text>
+      <path d="M 447.19067187499996 1523.5 H 526.5656718749999 A 5 5 0 0 1 531.5656718749999 1528.5 V 1554.5 A 5 5 0 0 1 526.5656718749999 1559.5 H 447.19067187499996 A 5 5 0 0 1 442.19067187499996 1554.5 V 1528.5 A 5 5 0 0 1 447.19067187499996 1523.5 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <text x="486.87817187499996" y="1546.5" class="state-label" text-anchor="middle" font-size="16">Completed</text>
     </g>
     <g class="state-node" id="state-Executing">
-      <path d="M 445.6878662109375 997 H 521.9534912109375 A 5 5 0 0 1 526.9534912109375 1002 V 1032 A 5 5 0 0 1 521.9534912109375 1037 H 445.6878662109375 A 5 5 0 0 1 440.6878662109375 1032 V 1002 A 5 5 0 0 1 445.6878662109375 997 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
-      <text x="483.8206787109375" y="1022" class="state-label" text-anchor="middle" font-size="16">Executing</text>
+      <path d="M 557.2750468749999 981 H 629.5406718749999 A 5 5 0 0 1 634.5406718749999 986 V 1012 A 5 5 0 0 1 629.5406718749999 1017 H 557.2750468749999 A 5 5 0 0 1 552.2750468749999 1012 V 986 A 5 5 0 0 1 557.2750468749999 981 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <text x="593.4078593749999" y="1004" class="state-label" text-anchor="middle" font-size="16">Executing</text>
     </g>
     <g class="state-node" id="state-Failed">
-      <path d="M 480.3120849609375 1549.5 H 529.8902099609375 A 5 5 0 0 1 534.8902099609375 1554.5 V 1584.5 A 5 5 0 0 1 529.8902099609375 1589.5 H 480.3120849609375 A 5 5 0 0 1 475.3120849609375 1584.5 V 1554.5 A 5 5 0 0 1 480.3120849609375 1549.5 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
-      <text x="505.1011474609375" y="1574.5" class="state-label" text-anchor="middle" font-size="16">Failed</text>
+      <path d="M 591.199265625 1523.5 H 636.777390625 A 5 5 0 0 1 641.777390625 1528.5 V 1554.5 A 5 5 0 0 1 636.777390625 1559.5 H 591.199265625 A 5 5 0 0 1 586.199265625 1554.5 V 1528.5 A 5 5 0 0 1 591.199265625 1523.5 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <text x="613.988328125" y="1546.5" class="state-label" text-anchor="middle" font-size="16">Failed</text>
     </g>
     <g class="state-node" id="state-Finalizing">
-      <path d="M 447.0277099609375 1132 H 520.6136474609375 A 5 5 0 0 1 525.6136474609375 1137 V 1167 A 5 5 0 0 1 520.6136474609375 1172 H 447.0277099609375 A 5 5 0 0 1 442.0277099609375 1167 V 1137 A 5 5 0 0 1 447.0277099609375 1132 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="483.8206787109375" y="1157" class="state-label" font-size="16" text-anchor="middle">Finalizing</text>
+      <path d="M 558.6148906249999 1112 H 628.2008281249999 A 5 5 0 0 1 633.2008281249999 1117 V 1143 A 5 5 0 0 1 628.2008281249999 1148 H 558.6148906249999 A 5 5 0 0 1 553.6148906249999 1143 V 1117 A 5 5 0 0 1 558.6148906249999 1112 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="593.4078593749999" y="1135" class="state-label" font-size="16" text-anchor="middle">Finalizing</text>
     </g>
     <g class="state-node" id="state-Idle_start">
-      <circle cx="483.8206787109375" cy="108" r="7" class="state-start" fill="#333333"/>
+      <circle cx="593.4078593749999" cy="108" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Initializing">
-      <path d="M 445.6917724609375 862 H 521.9495849609375 A 5 5 0 0 1 526.9495849609375 867 V 897 A 5 5 0 0 1 521.9495849609375 902 H 445.6917724609375 A 5 5 0 0 1 440.6917724609375 897 V 867 A 5 5 0 0 1 445.6917724609375 862 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="483.8206787109375" y="887" class="state-label" font-size="16" text-anchor="middle">Initializing</text>
+      <path d="M 557.2789531249999 850 H 629.5367656249999 A 5 5 0 0 1 634.5367656249999 855 V 881 A 5 5 0 0 1 629.5367656249999 886 H 557.2789531249999 A 5 5 0 0 1 552.2789531249999 881 V 855 A 5 5 0 0 1 557.2789531249999 850 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <text x="593.4078593749999" y="873" class="state-label" text-anchor="middle" font-size="16">Initializing</text>
     </g>
     <g class="state-node" id="state-Paused_start">
-      <circle cx="483.8206787109375" cy="1437" r="7" class="state-start" fill="#333333"/>
+      <circle cx="593.4078593749999" cy="1413" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Processing_start">
-      <circle cx="594.6011474609375" cy="349" r="7" class="state-start" fill="#333333"/>
+      <circle cx="703.488328125" cy="345" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Queued">
-      <path d="M 473.6323974609375 576 H 536.5698974609375 A 5 5 0 0 1 541.5698974609375 581 V 611 A 5 5 0 0 1 536.5698974609375 616 H 473.6323974609375 A 5 5 0 0 1 468.6323974609375 611 V 581 A 5 5 0 0 1 473.6323974609375 576 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
-      <text x="505.1011474609375" y="601" class="state-label" text-anchor="middle" font-size="16">Queued</text>
+      <path d="M 584.519578125 568 H 643.457078125 A 5 5 0 0 1 648.457078125 573 V 599 A 5 5 0 0 1 643.457078125 604 H 584.519578125 A 5 5 0 0 1 579.519578125 599 V 573 A 5 5 0 0 1 584.519578125 568 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <text x="613.988328125" y="591" class="state-label" text-anchor="middle" font-size="16">Queued</text>
     </g>
     <g class="state-node" id="state-Ready">
-      <path d="M 457.6956787109375 180 H 509.9456787109375 A 5 5 0 0 1 514.9456787109375 185 V 215 A 5 5 0 0 1 509.9456787109375 220 H 457.6956787109375 A 5 5 0 0 1 452.6956787109375 215 V 185 A 5 5 0 0 1 457.6956787109375 180 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
-      <text x="483.8206787109375" y="205" class="state-label" font-size="16" text-anchor="middle">Ready</text>
+      <path d="M 569.2828593749999 180 H 617.5328593749999 A 5 5 0 0 1 622.5328593749999 185 V 211 A 5 5 0 0 1 617.5328593749999 216 H 569.2828593749999 A 5 5 0 0 1 564.2828593749999 211 V 185 A 5 5 0 0 1 569.2828593749999 180 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
+      <text x="593.4078593749999" y="203" class="state-label" font-size="16" text-anchor="middle">Ready</text>
     </g>
     <g class="state-node" id="state-Running_end">
-      <path d="M 476.8206787109375 1274 A 7 7 0 1 0 490.8206787109375 1274 A 7 7 0 1 0 476.8206787109375 1274 Z" class="state-end-outer" stroke="#9370DB" stroke-width="2" fill="none"/>
-      <path d="M 481.3006787109375 1274 A 2.52 2.52 0 1 0 486.3406787109375 1274 A 2.52 2.52 0 1 0 481.3006787109375 1274 Z" class="state-end-inner" stroke="#9370DB" stroke-width="2" fill="#9370DB"/>
+      <path d="M 586.4078593749999 1250 A 7 7 0 1 0 600.4078593749999 1250 A 7 7 0 1 0 586.4078593749999 1250 Z" class="state-end-outer" fill="none" stroke-width="2" stroke="#9370DB"/>
+      <path d="M 590.887859375 1250 A 2.52 2.52 0 1 0 595.9278593749999 1250 A 2.52 2.52 0 1 0 590.887859375 1250 Z" class="state-end-inner" stroke-width="2" fill="#9370DB" stroke="#9370DB"/>
     </g>
     <g class="state-node" id="state-Running_start">
-      <circle cx="483.8206787109375" cy="760" r="7" class="state-start" fill="#333333"/>
+      <circle cx="593.4078593749999" cy="748" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Timeout">
-      <path d="M 451.9222412109375 1694 H 515.7191162109375 A 5 5 0 0 1 520.7191162109375 1699 V 1729 A 5 5 0 0 1 515.7191162109375 1734 H 451.9222412109375 A 5 5 0 0 1 446.9222412109375 1729 V 1699 A 5 5 0 0 1 451.9222412109375 1694 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
-      <text x="483.8206787109375" y="1719" class="state-label" font-size="16" text-anchor="middle">Timeout</text>
+      <path d="M 563.5094218749999 1666 H 623.3062968749999 A 5 5 0 0 1 628.3062968749999 1671 V 1697 A 5 5 0 0 1 623.3062968749999 1702 H 563.5094218749999 A 5 5 0 0 1 558.5094218749999 1697 V 1671 A 5 5 0 0 1 563.5094218749999 1666 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <text x="593.4078593749999" y="1689" class="state-label" font-size="16" text-anchor="middle">Timeout</text>
     </g>
     <g class="state-node" id="state-Validating">
-      <path d="M 556.4644287109375 436 H 632.7378662109375 A 5 5 0 0 1 637.7378662109375 441 V 471 A 5 5 0 0 1 632.7378662109375 476 H 556.4644287109375 A 5 5 0 0 1 551.4644287109375 471 V 441 A 5 5 0 0 1 556.4644287109375 436 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
-      <text x="594.6011474609375" y="461" class="state-label" text-anchor="middle" font-size="16">Validating</text>
+      <path d="M 667.351609375 432 H 739.625046875 A 5 5 0 0 1 744.625046875 437 V 463 A 5 5 0 0 1 739.625046875 468 H 667.351609375 A 5 5 0 0 1 662.351609375 463 V 437 A 5 5 0 0 1 667.351609375 432 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="703.488328125" y="455" class="state-label" font-size="16" text-anchor="middle">Validating</text>
     </g>
     <g class="state-node" id="state-WaitingResume">
-      <path d="M 424.3558349609375 1539 H 543.2855224609375 A 5 5 0 0 1 548.2855224609375 1544 V 1574 A 5 5 0 0 1 543.2855224609375 1579 H 424.3558349609375 A 5 5 0 0 1 419.3558349609375 1574 V 1544 A 5 5 0 0 1 424.3558349609375 1539 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
-      <text x="483.8206787109375" y="1564" class="state-label" text-anchor="middle" font-size="16">WaitingResume</text>
+      <path d="M 535.9430156249999 1515 H 650.8727031249999 A 5 5 0 0 1 655.8727031249999 1520 V 1546 A 5 5 0 0 1 650.8727031249999 1551 H 535.9430156249999 A 5 5 0 0 1 530.9430156249999 1546 V 1520 A 5 5 0 0 1 535.9430156249999 1515 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
+      <text x="593.4078593749999" y="1538" class="state-label" text-anchor="middle" font-size="16">WaitingResume</text>
     </g>
     <g class="state-node" id="state-root_end">
-      <path d="M 486.8206787109375 1937 A 7 7 0 1 0 500.8206787109375 1937 A 7 7 0 1 0 486.8206787109375 1937 Z" class="state-end-outer" fill="none" stroke="#9370DB" stroke-width="2"/>
-      <path d="M 491.3006787109375 1937 A 2.52 2.52 0 1 0 496.3406787109375 1937 A 2.52 2.52 0 1 0 491.3006787109375 1937 Z" class="state-end-inner" fill="#9370DB" stroke="#9370DB" stroke-width="2"/>
+      <path d="M 596.4078593749999 1901 A 7 7 0 1 0 610.4078593749999 1901 A 7 7 0 1 0 596.4078593749999 1901 Z" class="state-end-outer" fill="none" stroke="#9370DB" stroke-width="2"/>
+      <path d="M 600.887859375 1901 A 2.52 2.52 0 1 0 605.9278593749999 1901 A 2.52 2.52 0 1 0 600.887859375 1901 Z" class="state-end-inner" fill="#9370DB" stroke-width="2" stroke="#9370DB"/>
     </g>
     <g class="state-node" id="state-root_start">
-      <circle cx="622.2687255859375" cy="7" r="7" class="state-start" fill="#333333"/>
+      <circle cx="730.25590625" cy="7" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="transition">
-      <path d="M 622.27 14.00 C 622.27 22.33, 622.27 30.67, 622.27 39.00 C 622.27 47.33, 622.27 55.67, 622.27 64.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 730.26 14.00 C 730.26 22.33, 730.26 30.67, 730.26 39.00 C 730.26 47.33, 730.26 55.67, 730.26 64.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 483.82 115.00 C 483.82 125.83, 483.82 136.67, 483.82 147.50 C 483.82 158.33, 483.82 169.17, 483.82 180.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 593.41 115.00 C 593.41 125.83, 593.41 136.67, 593.41 147.50 C 593.41 158.33, 593.41 169.17, 593.41 180.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 483.82 220.00 C 483.82 234.17, 483.82 248.33, 483.82 262.50 C 483.82 276.67, 483.82 290.83, 483.82 305.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
-      <path d="M 447.8206787109375 251.7 H 519.8206787109375 A 2 2 0 0 1 521.8206787109375 253.7 V 271.3 A 2 2 0 0 1 519.8206787109375 273.3 H 447.8206787109375 A 2 2 0 0 1 445.8206787109375 271.3 V 253.7 A 2 2 0 0 1 447.8206787109375 251.7 Z" class="transition-label-bg"/>
-      <text x="483.8206787109375" y="262.5" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Start Job</text>
+      <path d="M 593.41 216.00 C 593.41 230.17, 593.41 244.33, 593.41 258.50 C 593.41 272.67, 593.41 286.83, 593.41 301.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 557.4078593749999 247.7 H 629.4078593749999 A 2 2 0 0 1 631.4078593749999 249.7 V 267.3 A 2 2 0 0 1 629.4078593749999 269.3 H 557.4078593749999 A 2 2 0 0 1 555.4078593749999 267.3 V 249.7 A 2 2 0 0 1 557.4078593749999 247.7 Z" class="transition-label-bg"/>
+      <text x="593.4078593749999" y="258.5" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Start Job</text>
     </g>
     <g class="transition">
-      <path d="M 594.60 356.00 C 594.60 369.33, 594.60 382.67, 594.60 396.00 C 594.60 409.33, 594.60 422.67, 594.60 436.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 703.49 352.00 C 703.49 365.33, 703.49 378.67, 703.49 392.00 C 703.49 405.33, 703.49 418.67, 703.49 432.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 569.03 476.00 C 547.72 492.67, 526.41 509.33, 515.76 526.00 C 505.10 542.67, 505.10 559.33, 505.10 576.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
-      <path d="M 497.37316607093203 505.6017731541942 H 537.373166070932 A 2 2 0 0 1 539.373166070932 507.6017731541942 V 525.2017731541941 A 2 2 0 0 1 537.373166070932 527.2017731541941 H 497.37316607093203 A 2 2 0 0 1 495.37316607093203 525.2017731541941 V 507.6017731541942 A 2 2 0 0 1 497.37316607093203 505.6017731541942 Z" class="transition-label-bg"/>
-      <text x="517.373166070932" y="516.4017731541942" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Valid</text>
+      <path d="M 679.80 468.00 C 657.86 484.67, 635.92 501.33, 624.96 518.00 C 613.99 534.67, 613.99 551.33, 613.99 568.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 606.986542286706 497.3242618659663 H 646.986542286706 A 2 2 0 0 1 648.986542286706 499.3242618659663 V 516.9242618659663 A 2 2 0 0 1 646.986542286706 518.9242618659663 H 606.986542286706 A 2 2 0 0 1 604.986542286706 516.9242618659663 V 499.3242618659663 A 2 2 0 0 1 606.986542286706 497.3242618659663 Z" class="transition-label-bg"/>
+      <text x="626.986542286706" y="508.12426186596633" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Valid</text>
     </g>
     <g class="transition">
-      <path d="M 637.74 466.62 C 718.17 486.41, 798.60 506.21, 838.82 652.27 C 879.03 798.33, 879.03 1070.67, 821.68 1241.58 C 649.60 1481.97, 534.89 1551.46, 534.89 1551.46" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
-      <path d="M 851.0339599609374 1000.6290772559483 H 907.0339599609374 A 2 2 0 0 1 909.0339599609374 1002.6290772559483 V 1020.2290772559484 A 2 2 0 0 1 907.0339599609374 1022.2290772559484 H 851.0339599609374 A 2 2 0 0 1 849.0339599609374 1020.2290772559484 V 1002.6290772559483 A 2 2 0 0 1 851.0339599609374 1000.6290772559483 Z" class="transition-label-bg"/>
-      <text x="879.0339599609374" y="1011.4290772559483" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Invalid</text>
+      <path d="M 744.63 460.02 C 823.99 479.35, 903.36 498.67, 943.04 641.84 C 982.72 785.00, 982.72 1052.00, 925.90 1219.79 C 755.43 1456.15, 641.78 1524.73, 641.78 1524.73" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 954.721140625 984.2758386278989 H 1010.721140625 A 2 2 0 0 1 1012.721140625 986.2758386278989 V 1003.8758386278989 A 2 2 0 0 1 1010.721140625 1005.8758386278989 H 954.721140625 A 2 2 0 0 1 952.721140625 1003.8758386278989 V 986.2758386278989 A 2 2 0 0 1 954.721140625 984.2758386278989 Z" class="transition-label-bg"/>
+      <text x="982.721140625" y="995.0758386278989" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Invalid</text>
     </g>
     <g class="transition">
-      <path d="M 505.10 616.00 L 483.82 716.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
-      <path d="M 441.1011474609375 655.2 H 569.1011474609375 A 2 2 0 0 1 571.1011474609375 657.2 V 674.8000000000001 A 2 2 0 0 1 569.1011474609375 676.8000000000001 H 441.1011474609375 A 2 2 0 0 1 439.1011474609375 674.8000000000001 V 657.2 A 2 2 0 0 1 441.1011474609375 655.2 Z" class="transition-label-bg"/>
-      <text x="505.1011474609375" y="666" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Worker Available</text>
+      <path d="M 613.99 604.00 L 593.41 704.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 549.988328125 643.2 H 677.988328125 A 2 2 0 0 1 679.988328125 645.2 V 662.8000000000001 A 2 2 0 0 1 677.988328125 664.8000000000001 H 549.988328125 A 2 2 0 0 1 547.988328125 662.8000000000001 V 645.2 A 2 2 0 0 1 549.988328125 643.2 Z" class="transition-label-bg"/>
+      <text x="613.988328125" y="654" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Worker Available</text>
     </g>
     <g class="transition">
-      <path d="M 483.82 1293.00 C 448.08 1309.67, 412.33 1326.33, 394.46 1369.08 C 376.59 1411.83, 376.59 1480.67, 376.59 1549.50" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
-      <path d="M 348.5909912109375 1368.538418910764 H 404.5909912109375 A 2 2 0 0 1 406.5909912109375 1370.538418910764 V 1388.138418910764 A 2 2 0 0 1 404.5909912109375 1390.138418910764 H 348.5909912109375 A 2 2 0 0 1 346.5909912109375 1388.138418910764 V 1370.538418910764 A 2 2 0 0 1 348.5909912109375 1368.538418910764 Z" class="transition-label-bg"/>
-      <text x="376.5909912109375" y="1379.338418910764" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Success</text>
+      <path d="M 593.41 1269.00 C 557.90 1285.67, 522.39 1302.33, 504.63 1344.75 C 486.88 1387.17, 486.88 1455.33, 486.88 1523.50" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 458.87817187499996 1341.4217243105106 H 514.8781718749999 A 2 2 0 0 1 516.8781718749999 1343.4217243105106 V 1361.0217243105105 A 2 2 0 0 1 514.8781718749999 1363.0217243105105 H 458.87817187499996 A 2 2 0 0 1 456.87817187499996 1361.0217243105105 V 1343.4217243105106 A 2 2 0 0 1 458.87817187499996 1341.4217243105106 Z" class="transition-label-bg"/>
+      <text x="486.87817187499996" y="1352.2217243105106" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Success</text>
     </g>
     <g class="transition">
-      <path d="M 483.82 1293.00 L 504.92 1549.50" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
-      <path d="M 483.7701137220509 1410.4505564433387 H 523.7701137220508 A 2 2 0 0 1 525.7701137220508 1412.4505564433387 V 1430.0505564433386 A 2 2 0 0 1 523.7701137220508 1432.0505564433386 H 483.7701137220509 A 2 2 0 0 1 481.7701137220509 1430.0505564433386 V 1412.4505564433387 A 2 2 0 0 1 483.7701137220509 1410.4505564433387 Z" class="transition-label-bg"/>
-      <text x="503.7701137220509" y="1421.2505564433386" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Error</text>
+      <path d="M 593.41 1269.00 L 613.61 1523.50" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 590.9635387927733 1385.4529924434096 H 630.9635387927733 A 2 2 0 0 1 632.9635387927733 1387.4529924434096 V 1405.0529924434095 A 2 2 0 0 1 630.9635387927733 1407.0529924434095 H 590.9635387927733 A 2 2 0 0 1 588.9635387927733 1405.0529924434095 V 1387.4529924434096 A 2 2 0 0 1 590.9635387927733 1385.4529924434096 Z" class="transition-label-bg"/>
+      <text x="610.9635387927733" y="1396.2529924434095" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Error</text>
     </g>
     <g class="transition">
-      <path d="M 483.82 1293.00 C 542.39 1309.67, 600.96 1326.33, 600.96 1343.00 C 600.96 1359.67, 542.39 1376.33, 483.82 1393.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
-      <path d="M 581.5702941850383 1275.29045647186 H 685.5702941850383 A 2 2 0 0 1 687.5702941850383 1277.29045647186 V 1294.8904564718598 A 2 2 0 0 1 685.5702941850383 1296.8904564718598 H 581.5702941850383 A 2 2 0 0 1 579.5702941850383 1294.8904564718598 V 1277.29045647186 A 2 2 0 0 1 581.5702941850383 1275.29045647186 Z" class="transition-label-bg"/>
-      <text x="633.5702941850383" y="1286.0904564718599" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Pause Request</text>
+      <path d="M 593.41 1269.00 C 650.01 1285.67, 706.62 1302.33, 706.62 1319.00 C 706.62 1335.67, 650.01 1352.33, 593.41 1369.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 686.1254630559454 1252.2852674963112 H 790.1254630559454 A 2 2 0 0 1 792.1254630559454 1254.2852674963112 V 1271.8852674963111 A 2 2 0 0 1 790.1254630559454 1273.8852674963111 H 686.1254630559454 A 2 2 0 0 1 684.1254630559454 1271.8852674963111 V 1254.2852674963112 A 2 2 0 0 1 686.1254630559454 1252.2852674963112 Z" class="transition-label-bg"/>
+      <text x="738.1254630559454" y="1263.0852674963112" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Pause Request</text>
     </g>
     <g class="transition">
-      <path d="M 622.27 767.00 C 622.27 782.83, 622.27 798.67, 622.27 814.50 C 622.27 830.33, 622.27 846.17, 622.27 862.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 593.41 755.00 C 593.41 770.83, 593.41 786.67, 593.41 802.50 C 593.41 818.33, 593.41 834.17, 593.41 850.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 622.27 902.00 C 622.27 917.83, 622.27 933.67, 622.27 949.50 C 622.27 965.33, 622.27 981.17, 622.27 997.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 593.41 886.00 C 593.41 901.83, 593.41 917.67, 593.41 933.50 C 593.41 949.33, 593.41 965.17, 593.41 981.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 622.27 1037.00 C 622.27 1052.83, 622.27 1068.67, 622.27 1084.50 C 622.27 1100.33, 622.27 1116.17, 622.27 1132.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 593.41 1017.00 C 593.41 1032.83, 593.41 1048.67, 593.41 1064.50 C 593.41 1080.33, 593.41 1096.17, 593.41 1112.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 622.27 1172.00 C 622.27 1187.83, 622.27 1203.67, 622.27 1219.50 C 622.27 1235.33, 622.27 1251.17, 622.27 1267.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 593.41 1148.00 C 593.41 1163.83, 593.41 1179.67, 593.41 1195.50 C 593.41 1211.33, 593.41 1227.17, 593.41 1243.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 622.27 1444.00 C 622.27 1459.83, 622.27 1475.67, 622.27 1491.50 C 622.27 1507.33, 622.27 1523.17, 622.27 1539.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 730.26 1420.00 C 730.26 1435.83, 730.26 1451.67, 730.26 1467.50 C 730.26 1483.33, 730.26 1499.17, 730.26 1515.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 622.27 1579.00 C 622.27 1598.17, 622.27 1617.33, 622.27 1636.50 C 622.27 1655.67, 622.27 1674.83, 622.27 1694.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
-      <path d="M 598.2687255859375 1625.7 H 646.2687255859375 A 2 2 0 0 1 648.2687255859375 1627.7 V 1645.3 A 2 2 0 0 1 646.2687255859375 1647.3 H 598.2687255859375 A 2 2 0 0 1 596.2687255859375 1645.3 V 1627.7 A 2 2 0 0 1 598.2687255859375 1625.7 Z" class="transition-label-bg"/>
-      <text x="622.2687255859375" y="1636.5" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">1 hour</text>
+      <path d="M 730.26 1551.00 C 730.26 1570.17, 730.26 1589.33, 730.26 1608.50 C 730.26 1627.67, 730.26 1646.83, 730.26 1666.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 706.25590625 1597.7 H 754.25590625 A 2 2 0 0 1 756.25590625 1599.7 V 1617.3 A 2 2 0 0 1 754.25590625 1619.3 H 706.25590625 A 2 2 0 0 1 704.25590625 1617.3 V 1599.7 A 2 2 0 0 1 706.25590625 1597.7 Z" class="transition-label-bg"/>
+      <text x="730.25590625" y="1608.5" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">1 hour</text>
     </g>
     <g class="transition">
-      <path d="M 483.82 1746.00 C 583.06 1611.67, 682.30 1477.33, 682.30 1305.67 C 682.30 1134.00, 583.06 925.00, 483.82 716.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
-      <path d="M 676.200294433256 1232.604566548625 H 724.200294433256 A 2 2 0 0 1 726.200294433256 1234.604566548625 V 1252.2045665486248 A 2 2 0 0 1 724.200294433256 1254.2045665486248 H 676.200294433256 A 2 2 0 0 1 674.200294433256 1252.2045665486248 V 1234.604566548625 A 2 2 0 0 1 676.200294433256 1232.604566548625 Z" class="transition-label-bg"/>
-      <text x="700.200294433256" y="1243.4045665486249" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Resume</text>
+      <path d="M 593.41 1714.00 C 690.68 1582.33, 787.95 1450.67, 787.95 1282.33 C 787.95 1114.00, 690.68 909.00, 593.41 704.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 780.8966707323762 1209.7315072202136 H 828.8966707323762 A 2 2 0 0 1 830.8966707323762 1211.7315072202136 V 1229.3315072202136 A 2 2 0 0 1 828.8966707323762 1231.3315072202136 H 780.8966707323762 A 2 2 0 0 1 778.8966707323762 1229.3315072202136 V 1211.7315072202136 A 2 2 0 0 1 780.8966707323762 1209.7315072202136 Z" class="transition-label-bg"/>
+      <text x="804.8966707323762" y="1220.5315072202136" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Resume</text>
     </g>
     <g class="transition">
-      <path d="M 483.82 1746.00 C 483.82 1761.67, 483.82 1777.33, 483.82 1793.00 C 483.82 1808.67, 483.82 1824.33, 483.82 1840.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-      <path d="M 427.8206787109375 1782.2 H 539.8206787109375 A 2 2 0 0 1 541.8206787109375 1784.2 V 1801.8 A 2 2 0 0 1 539.8206787109375 1803.8 H 427.8206787109375 A 2 2 0 0 1 425.8206787109375 1801.8 V 1784.2 A 2 2 0 0 1 427.8206787109375 1782.2 Z" class="transition-label-bg"/>
-      <text x="483.8206787109375" y="1793" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Cancel Request</text>
+      <path d="M 593.41 1714.00 C 593.41 1729.67, 593.41 1745.33, 593.41 1761.00 C 593.41 1776.67, 593.41 1792.33, 593.41 1808.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 537.4078593749999 1750.2 H 649.4078593749999 A 2 2 0 0 1 651.4078593749999 1752.2 V 1769.8 A 2 2 0 0 1 649.4078593749999 1771.8 H 537.4078593749999 A 2 2 0 0 1 535.4078593749999 1769.8 V 1752.2 A 2 2 0 0 1 537.4078593749999 1750.2 Z" class="transition-label-bg"/>
+      <text x="593.4078593749999" y="1761" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Cancel Request</text>
     </g>
     <g class="transition">
-      <path d="M 483.82 1734.00 C 483.82 1751.67, 483.82 1769.33, 483.82 1787.00 C 483.82 1804.67, 483.82 1822.33, 483.82 1840.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 593.41 1702.00 C 593.41 1719.67, 593.41 1737.33, 593.41 1755.00 C 593.41 1772.67, 593.41 1790.33, 593.41 1808.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 376.59 1549.50 C 394.46 1586.25, 412.33 1623.00, 430.21 1659.75 C 448.08 1696.50, 465.95 1733.25, 483.82 1770.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
-      <path d="M 410.2058349609375 1648.95 H 450.2058349609375 A 2 2 0 0 1 452.2058349609375 1650.95 V 1668.55 A 2 2 0 0 1 450.2058349609375 1670.55 H 410.2058349609375 A 2 2 0 0 1 408.2058349609375 1668.55 V 1650.95 A 2 2 0 0 1 410.2058349609375 1648.95 Z" class="transition-label-bg"/>
-      <text x="430.2058349609375" y="1659.75" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Reset</text>
+      <path d="M 486.88 1523.50 C 504.63 1559.25, 522.39 1595.00, 540.14 1630.75 C 557.90 1666.50, 575.65 1702.25, 593.41 1738.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 520.143015625 1619.95 H 560.143015625 A 2 2 0 0 1 562.143015625 1621.95 V 1639.55 A 2 2 0 0 1 560.143015625 1641.55 H 520.143015625 A 2 2 0 0 1 518.143015625 1639.55 V 1621.95 A 2 2 0 0 1 520.143015625 1619.95 Z" class="transition-label-bg"/>
+      <text x="540.143015625" y="1630.75" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Reset</text>
     </g>
     <g class="transition">
-      <path d="M 505.10 1549.50 C 501.55 1586.25, 498.01 1623.00, 494.46 1659.75 C 490.91 1696.50, 487.37 1733.25, 483.82 1770.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
-      <path d="M 474.4609130859375 1648.95 H 514.4609130859375 A 2 2 0 0 1 516.4609130859375 1650.95 V 1668.55 A 2 2 0 0 1 514.4609130859375 1670.55 H 474.4609130859375 A 2 2 0 0 1 472.4609130859375 1668.55 V 1650.95 A 2 2 0 0 1 474.4609130859375 1648.95 Z" class="transition-label-bg"/>
-      <text x="494.4609130859375" y="1659.75" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Retry</text>
+      <path d="M 613.99 1523.50 C 610.56 1559.25, 607.13 1595.00, 603.70 1630.75 C 600.27 1666.50, 596.84 1702.25, 593.41 1738.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 583.69809375 1619.95 H 623.69809375 A 2 2 0 0 1 625.69809375 1621.95 V 1639.55 A 2 2 0 0 1 623.69809375 1641.55 H 583.69809375 A 2 2 0 0 1 581.69809375 1639.55 V 1621.95 A 2 2 0 0 1 583.69809375 1619.95 Z" class="transition-label-bg"/>
+      <text x="603.69809375" y="1630.75" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Retry</text>
     </g>
     <g class="transition">
-      <path d="M 497.09 1840.00 C 504.84 1828.33, 512.58 1816.67, 533.44 1520.67 C 554.30 1224.67, 588.29 644.33, 622.27 64.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
-      <path d="M 498.39185526655456 1797.1064462860566 H 538.3918552665546 A 2 2 0 0 1 540.3918552665546 1799.1064462860566 V 1816.7064462860565 A 2 2 0 0 1 538.3918552665546 1818.7064462860565 H 498.39185526655456 A 2 2 0 0 1 496.39185526655456 1816.7064462860565 V 1799.1064462860566 A 2 2 0 0 1 498.39185526655456 1797.1064462860566 Z" class="transition-label-bg"/>
-      <text x="518.3918552665546" y="1807.9064462860565" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Reset</text>
+      <path d="M 605.80 1808.00 C 613.84 1796.33, 621.87 1784.67, 642.62 1494.00 C 663.36 1203.33, 696.81 633.67, 730.26 64.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 607.7904565700014 1765.2745848949294 H 647.7904565700014 A 2 2 0 0 1 649.7904565700014 1767.2745848949294 V 1784.8745848949293 A 2 2 0 0 1 647.7904565700014 1786.8745848949293 H 607.7904565700014 A 2 2 0 0 1 605.7904565700014 1784.8745848949293 V 1767.2745848949294 A 2 2 0 0 1 607.7904565700014 1765.2745848949294 Z" class="transition-label-bg"/>
+      <text x="627.7904565700014" y="1776.0745848949293" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Reset</text>
     </g>
     <g class="transition">
-      <path d="M 376.59 1589.50 C 395.77 1646.31, 414.96 1703.11, 434.14 1759.92 C 453.33 1816.72, 472.51 1873.53, 491.69 1930.33" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 486.88 1559.50 C 505.94 1615.31, 525.00 1671.11, 544.06 1726.92 C 563.13 1782.73, 582.19 1838.53, 601.25 1894.34" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 483.82 1880.00 C 483.82 1888.33, 483.82 1896.67, 485.14 1905.05 C 486.46 1913.44, 489.10 1921.88, 491.73 1930.32" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 593.41 1844.00 C 593.41 1852.33, 593.41 1860.67, 594.73 1869.05 C 596.05 1877.44, 598.68 1885.88, 601.32 1894.32" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
   </g>
 </svg>

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -203,8 +203,8 @@ fn compute_level_layout(
             // Apply width expansion to match mermaid's getBBox() behavior.
             // Mermaid measures the full rendered cluster including internal padding and margins.
             // Leaf composites need more expansion for visual padding balance.
-            // Non-leaf composites need moderate expansion since they inherit child sizes.
-            let expansion_factor = if is_leaf_composite { 1.6 } else { 1.25 };
+            // Non-leaf composites also need significant expansion to match mermaid's wider sizing.
+            let expansion_factor = if is_leaf_composite { 1.6 } else { 1.4 };
             let original_width = inner_layout.width;
             let expanded_width = original_width * expansion_factor;
             let width_offset = (expanded_width - original_width) / 2.0;
@@ -229,12 +229,15 @@ fn compute_level_layout(
     }
 
     // Now create layout graph for this level
+    // Mermaid's state nodes use 10px font (g.stateGroup text) and 24px height.
+    // We use 16px font for better readability, but reduce min dimensions to
+    // get closer to mermaid's overall sizing.
     let config = NodeSizeConfig {
-        font_size: 16.0,
-        padding_horizontal: 8.0,
-        padding_vertical: 8.0,
-        min_width: 40.0,
-        min_height: 26.0,
+        font_size: 16.0,         // Keep readable font size
+        padding_horizontal: 6.0, // Reduced from 8.0 to tighten horizontal spacing
+        padding_vertical: 6.0,   // Reduced from 8.0 to get closer to mermaid's 24px height
+        min_width: 35.0,         // Reduced from 40.0 to allow narrower nodes
+        min_height: 24.0,        // Match mermaid's node height
         max_width: Some(200.0),
     };
 
@@ -479,13 +482,15 @@ impl ToLayoutGraph for StateDb {
     fn to_layout_graph(&self, size_estimator: &dyn SizeEstimator) -> Result<LayoutGraph> {
         use std::collections::HashSet;
 
-        // State-specific config: mermaid uses 16px font-size for node labels
+        // Mermaid's state nodes use 10px font (g.stateGroup text) and 24px height.
+        // We use 16px font for better readability, but reduce min dimensions to
+        // get closer to mermaid's overall sizing.
         let config = NodeSizeConfig {
-            font_size: 16.0, // Matches mermaid base font-size
-            padding_horizontal: 8.0,
-            padding_vertical: 8.0,
-            min_width: 40.0,
-            min_height: 26.0,
+            font_size: 16.0,         // Keep readable font size
+            padding_horizontal: 6.0, // Reduced from 8.0 to tighten horizontal spacing
+            padding_vertical: 6.0,   // Reduced from 8.0 to get closer to mermaid's 24px height
+            min_width: 35.0,         // Reduced from 40.0 to allow narrower nodes
+            min_height: 24.0,        // Match mermaid's node height
             max_width: Some(200.0),
         };
         let mut graph = LayoutGraph::new("state");


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Reduces state diagram node dimensions (padding, min_width, min_height) to better match mermaid reference sizing
- Increases non-leaf composite expansion factor from 1.25 to 1.4 to improve composite state width matching
- Width difference improved from 16% to 15% for simple state diagrams
- Structural similarity remains high at 96%+

## Changes
- **NodeSizeConfig adjustments**: Reduced padding (8→6), min_width (40→35), min_height (26→24)
- **Composite expansion**: Increased non-leaf factor (1.25→1.4) to better match mermaid's wider composites
- **Regenerated SVGs**: Updated docs/images/state*.svg with new rendering

## Analysis
Visual similarity remains around 30% primarily due to edge position differences (17-30px off) rather than overall dimensions. The edge positions are calculated based on node positions from dagre layout and attachment point calculation. Further improvements would require investigating edge attachment point calculation to match mermaid's approach.

## Test plan
- [x] All existing tests pass (107 unit + 98 integration)
- [x] Clippy passes without warnings
- [x] Eval shows improved dimension matching
- [x] SVG images regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)