### PR TITLE
fix: correct SVG z-order by rendering shapes before text

### DIFF
--- a/src/render/gantt.rs
+++ b/src/render/gantt.rs
@@ -89,19 +89,6 @@ pub fn render_gantt(db: &mut GanttDb, config: &RenderConfig) -> Result<String> {
         doc.add_style(&generate_gantt_css(&config.theme));
     }
 
-    // Render title
-    if !db.title.is_empty() {
-        let title_elem = SvgElement::Text {
-            x: total_width / 2.0,
-            y: TITLE_TOP_MARGIN,
-            content: db.title.clone(),
-            attrs: Attrs::new()
-                .with_attr("text-anchor", "middle")
-                .with_class("titleText"),
-        };
-        doc.add_element(title_elem);
-    }
-
     // Collect tasks grouped by section for rendering
     let sections = collect_sections(&tasks);
 
@@ -152,6 +139,19 @@ pub fn render_gantt(db: &mut GanttDb, config: &RenderConfig) -> Result<String> {
         chart_width,
         total_height,
     );
+
+    // Render title LAST (like mermaid.js does) so it appears on top of everything
+    if !db.title.is_empty() {
+        let title_elem = SvgElement::Text {
+            x: total_width / 2.0,
+            y: TITLE_TOP_MARGIN,
+            content: db.title.clone(),
+            attrs: Attrs::new()
+                .with_attr("text-anchor", "middle")
+                .with_class("titleText"),
+        };
+        doc.add_element(title_elem);
+    }
 
     Ok(doc.to_string())
 }
@@ -208,6 +208,8 @@ fn render_section_backgrounds(
 }
 
 /// Render task bars and labels
+/// Note: This function emits all task bar rects FIRST, then all text labels AFTER.
+/// This ensures correct SVG z-order (text appears on top of shapes).
 #[allow(clippy::too_many_arguments)]
 fn render_task_bars(
     doc: &mut SvgDocument,
@@ -224,6 +226,11 @@ fn render_task_bars(
 
     // Calculate pixels per day (time scale)
     let px_per_day = chart_width / days_range;
+
+    // Collect all rect elements first
+    let mut rect_elements: Vec<SvgElement> = Vec::new();
+    // Collect all text elements second (will be emitted after rects for correct z-order)
+    let mut text_elements: Vec<SvgElement> = Vec::new();
 
     for (task_idx, task) in tasks.iter().enumerate() {
         let Some(start) = task.start_time else {
@@ -297,7 +304,7 @@ fn render_task_bars(
                 .with_attr("id", &task.id)
                 .with_attr("transform-origin", &transform_origin),
         };
-        doc.add_element(bar_elem);
+        rect_elements.push(bar_elem);
 
         // Handle text positioning differently for vert markers
         if task.flags.vert {
@@ -312,7 +319,7 @@ fn render_task_bars(
                     .with_attr("font-size", &format!("{}", FONT_SIZE as i32))
                     .with_attr("id", &format!("{}-text", task.id)),
             };
-            doc.add_element(task_label);
+            text_elements.push(task_label);
         } else {
             // Standard task text positioning
             // Estimate text width (approx 0.5 * fontSize per character for typical fonts)
@@ -352,8 +359,18 @@ fn render_task_bars(
                     .with_attr("font-size", &format!("{}", FONT_SIZE as i32))
                     .with_attr("id", &format!("{}-text", task.id)),
             };
-            doc.add_element(task_label);
+            text_elements.push(task_label);
         }
+    }
+
+    // Emit all rect elements first (shapes behind text)
+    for elem in rect_elements {
+        doc.add_element(elem);
+    }
+
+    // Emit all text elements second (text on top of shapes)
+    for elem in text_elements {
+        doc.add_element(elem);
     }
 }
 
@@ -543,27 +560,30 @@ fn render_grid_and_axis(
         let day_offset = (*date - start_date).num_days() as f64;
         let x = day_offset * px_per_day + 0.5;
 
-        // Vertical grid line
-        grid_children.push(SvgElement::Line {
-            x1: x,
+        // Create tick group children (line + text) - positions are relative to tick group transform
+        let mut tick_children = Vec::new();
+
+        // Vertical grid line - x is 0 since group is already translated
+        tick_children.push(SvgElement::Line {
+            x1: 0.0,
             y1: 0.0,
-            x2: x,
+            x2: 0.0,
             y2: -grid_height,
             attrs: Attrs::new().with_attr("stroke", "currentColor"),
         });
 
         // Tick label - rotate if labels would overlap
+        // x is 0 since group is already translated; rotation point is relative
         let label = format!("{:04}-{:02}-{:02}", date.year(), date.month(), date.day());
         let label_attrs = if should_rotate {
-            // Rotate -45 degrees around the label position
-            // Use text-anchor: end so text extends up-left from the anchor point
+            // Rotate -45 degrees around (0, 3) relative to tick group
             Attrs::new()
                 .with_attr("fill", "#000")
                 .with_attr("dy", "0.5em")
                 .with_attr("stroke", "none")
                 .with_attr("font-size", "10")
                 .with_attr("style", "text-anchor: end;")
-                .with_attr("transform", &format!("rotate(-45 {} 3)", x))
+                .with_attr("transform", "rotate(-45 0 3)")
         } else {
             Attrs::new()
                 .with_attr("fill", "#000")
@@ -572,11 +592,20 @@ fn render_grid_and_axis(
                 .with_attr("font-size", "10")
                 .with_attr("style", "text-anchor: middle;")
         };
-        grid_children.push(SvgElement::Text {
-            x,
+        tick_children.push(SvgElement::Text {
+            x: 0.0,
             y: 3.0,
             content: label,
             attrs: label_attrs,
+        });
+
+        // Wrap in tick group (like mermaid/D3) - group is translated to the tick position
+        grid_children.push(SvgElement::Group {
+            children: tick_children,
+            attrs: Attrs::new()
+                .with_class("tick")
+                .with_attr("opacity", "1")
+                .with_attr("transform", &format!("translate({},0)", x)),
         });
     }
 

--- a/src/render/packet.rs
+++ b/src/render/packet.rs
@@ -96,12 +96,32 @@ pub fn render_packet(db: &PacketDb, config: &RenderConfig) -> Result<String> {
         doc.add_style(&generate_packet_css());
     }
 
-    // Render each word (row)
+    // Collect all shapes and text elements from all words
+    // This ensures correct z-order across all rows (all shapes before all text)
+    let mut all_rect_elements: Vec<SvgElement> = Vec::new();
+    let mut all_text_elements: Vec<SvgElement> = Vec::new();
+
     for (word_index, word) in words.iter().enumerate() {
-        draw_word(&mut doc, word, word_index, &packet_config);
+        collect_word_elements(
+            word,
+            word_index,
+            &packet_config,
+            &mut all_rect_elements,
+            &mut all_text_elements,
+        );
     }
 
-    // Render title at the bottom
+    // Emit all rect elements first (shapes behind text)
+    for elem in all_rect_elements {
+        doc.add_element(elem);
+    }
+
+    // Emit all text elements second (text on top of shapes)
+    for elem in all_text_elements {
+        doc.add_element(elem);
+    }
+
+    // Render title at the bottom (after all other content)
     if has_title {
         let title_y = svg_height - total_row_height / 2.0;
         let title_elem = SvgElement::Text {
@@ -119,12 +139,14 @@ pub fn render_packet(db: &PacketDb, config: &RenderConfig) -> Result<String> {
     Ok(doc.to_string())
 }
 
-/// Draw a word (row) of packet blocks
-fn draw_word(
-    doc: &mut SvgDocument,
+/// Collect elements for a word (row) of packet blocks into shape and text vectors.
+/// This allows the caller to batch all shapes before all text for correct z-order.
+fn collect_word_elements(
     word: &[crate::diagrams::packet::PacketBlock],
     row_number: usize,
     config: &PacketConfig,
+    rect_elements: &mut Vec<SvgElement>,
+    text_elements: &mut Vec<SvgElement>,
 ) {
     let PacketConfig {
         row_height,
@@ -155,7 +177,7 @@ fn draw_word(
             ry: None,
             attrs: Attrs::new().with_class("packetBlock"),
         };
-        doc.add_element(rect);
+        rect_elements.push(rect);
 
         // Block label (centered in the block)
         let label = SvgElement::Text {
@@ -167,7 +189,7 @@ fn draw_word(
                 .with_attr("dominant-baseline", "middle")
                 .with_attr("text-anchor", "middle"),
         };
-        doc.add_element(label);
+        text_elements.push(label);
 
         if show_bits {
             let is_single_block = block.end == block.start;
@@ -187,7 +209,7 @@ fn draw_word(
                         if is_single_block { "middle" } else { "start" },
                     ),
             };
-            doc.add_element(start_bit);
+            text_elements.push(start_bit);
 
             // End bit number (if different from start)
             if !is_single_block {
@@ -201,7 +223,7 @@ fn draw_word(
                         .with_attr("dominant-baseline", "auto")
                         .with_attr("text-anchor", "end"),
                 };
-                doc.add_element(end_bit);
+                text_elements.push(end_bit);
             }
         }
     }

--- a/src/render/quadrant.rs
+++ b/src/render/quadrant.rs
@@ -236,7 +236,20 @@ pub fn render_quadrant(db: &QuadrantDb, config: &RenderConfig) -> Result<String>
             .with_class("quadrant-border quadrant-border-horizontal"),
     });
 
-    // Render quadrant labels (part of quadrants group in reference)
+    // Render data point circles FIRST (shapes before text for correct z-order)
+    // This only renders the circles, not the labels
+    render_point_circles(
+        &mut doc,
+        db,
+        config,
+        chart_left,
+        chart_top,
+        chart_width,
+        chart_height,
+    );
+
+    // Now render ALL text elements (after all shapes)
+    // 1. Quadrant labels
     render_quadrant_labels(
         &mut doc,
         db,
@@ -248,8 +261,8 @@ pub fn render_quadrant(db: &QuadrantDb, config: &RenderConfig) -> Result<String>
         has_points,
     );
 
-    // Render data points (before axis labels per mermaid.js reference)
-    render_points(
+    // 2. Point labels
+    render_point_labels(
         &mut doc,
         db,
         config,
@@ -259,7 +272,7 @@ pub fn render_quadrant(db: &QuadrantDb, config: &RenderConfig) -> Result<String>
         chart_height,
     );
 
-    // Render axis labels (after data points per mermaid.js reference)
+    // 3. Axis labels
     render_axis_labels(
         &mut doc,
         db,
@@ -271,7 +284,7 @@ pub fn render_quadrant(db: &QuadrantDb, config: &RenderConfig) -> Result<String>
         has_points,
     );
 
-    // Render title last (matching mermaid.js reference - title appears on top)
+    // 4. Title last (matching mermaid.js reference - title appears on top)
     if !db.title.is_empty() {
         // Title y position matches mermaid.js: titlePadding (10)
         let title_y = TITLE_PADDING;
@@ -528,8 +541,9 @@ fn render_axis_labels(
     }
 }
 
-/// Render data points
-fn render_points(
+/// Render data point circles only (shapes)
+/// Called early in the render process so circles appear behind text.
+fn render_point_circles(
     doc: &mut SvgDocument,
     db: &QuadrantDb,
     config: &RenderConfig,
@@ -572,6 +586,24 @@ fn render_points(
             r: radius,
             attrs: point_attrs,
         });
+    }
+}
+
+/// Render data point labels only (text)
+/// Called after all shapes so text appears on top.
+fn render_point_labels(
+    doc: &mut SvgDocument,
+    db: &QuadrantDb,
+    config: &RenderConfig,
+    chart_left: f64,
+    chart_top: f64,
+    chart_width: f64,
+    chart_height: f64,
+) {
+    for point in db.get_points() {
+        // Convert normalized coordinates (0-1) to pixel coordinates
+        let px = chart_left + point.x * chart_width;
+        let py = chart_top + (1.0 - point.y) * chart_height;
 
         // Render point label (below the point per mermaid.js reference)
         if !point.text.is_empty() {

--- a/src/render/radar.rs
+++ b/src/render/radar.rs
@@ -79,7 +79,9 @@ pub fn render_radar(db: &RadarDb, config: &RenderConfig) -> Result<String> {
     // Create main group centered on chart
     let mut main_group_children: Vec<SvgElement> = Vec::new();
 
-    // Draw graticule (background grid)
+    // PHASE 1: Draw all shapes first (for correct z-order)
+
+    // Draw graticule (background grid) - shapes
     draw_graticule(
         &mut main_group_children,
         axes.len(),
@@ -88,10 +90,10 @@ pub fn render_radar(db: &RadarDb, config: &RenderConfig) -> Result<String> {
         &options.graticule,
     );
 
-    // Draw axes
-    draw_axes(&mut main_group_children, axes, radius, config);
+    // Draw axis lines - shapes
+    draw_axis_lines(&mut main_group_children, axes, radius);
 
-    // Draw curves
+    // Draw curves (paths/polygons) - shapes
     draw_curves(
         &mut main_group_children,
         axes,
@@ -102,12 +104,22 @@ pub fn render_radar(db: &RadarDb, config: &RenderConfig) -> Result<String> {
         radius,
     );
 
-    // Draw legend if enabled
+    // Draw legend boxes if enabled - shapes
     if options.show_legend {
-        draw_legend(&mut main_group_children, curves, chart_width, chart_height);
+        draw_legend_boxes(&mut main_group_children, curves, chart_width, chart_height);
     }
 
-    // Draw title
+    // PHASE 2: Draw all text after shapes (text appears on top)
+
+    // Draw axis labels - text
+    draw_axis_labels(&mut main_group_children, axes, radius, config);
+
+    // Draw legend labels if enabled - text
+    if options.show_legend {
+        draw_legend_labels(&mut main_group_children, curves, chart_width, chart_height);
+    }
+
+    // Draw title last - text
     if !title.is_empty() {
         let title_elem = SvgElement::Text {
             x: 0.0,
@@ -193,16 +205,15 @@ fn draw_graticule(
     }
 }
 
-/// Draw the radar axes
-fn draw_axes(
+/// Draw the radar axes (lines only - shapes)
+fn draw_axis_lines(
     children: &mut Vec<SvgElement>,
     axes: &[crate::diagrams::radar::RadarAxis],
     radius: f64,
-    config: &RenderConfig,
 ) {
     let num_axes = axes.len();
 
-    for (i, axis) in axes.iter().enumerate() {
+    for (i, _axis) in axes.iter().enumerate() {
         let angle = (2.0 * PI * i as f64) / num_axes as f64 - PI / 2.0;
 
         // Draw axis line
@@ -217,6 +228,20 @@ fn draw_axes(
                 .with_class("radarAxisLine"),
         };
         children.push(line);
+    }
+}
+
+/// Draw the radar axis labels (text only)
+fn draw_axis_labels(
+    children: &mut Vec<SvgElement>,
+    axes: &[crate::diagrams::radar::RadarAxis],
+    radius: f64,
+    config: &RenderConfig,
+) {
+    let num_axes = axes.len();
+
+    for (i, axis) in axes.iter().enumerate() {
+        let angle = (2.0 * PI * i as f64) / num_axes as f64 - PI / 2.0;
 
         // Draw axis label
         let label_x = radius * AXIS_LABEL_FACTOR * angle.cos();
@@ -347,8 +372,8 @@ fn closed_round_curve(points: &[(f64, f64)], tension: f64) -> String {
     d
 }
 
-/// Draw the legend
-fn draw_legend(
+/// Draw legend boxes (shapes only)
+fn draw_legend_boxes(
     children: &mut Vec<SvgElement>,
     curves: &[crate::diagrams::radar::RadarCurve],
     chart_width: f64,
@@ -358,7 +383,7 @@ fn draw_legend(
     let legend_y = -(chart_height / 2.0 + MARGIN_TOP) * 3.0 / 4.0;
     let line_height = 20.0;
 
-    for (index, curve) in curves.iter().enumerate() {
+    for (index, _curve) in curves.iter().enumerate() {
         let item_y = legend_y + (index as f64) * line_height;
         let color = RADAR_COLORS[index % RADAR_COLORS.len()];
 
@@ -375,6 +400,22 @@ fn draw_legend(
                 .with_class(&format!("radarLegendBox-{}", index)),
         };
         children.push(box_elem);
+    }
+}
+
+/// Draw legend labels (text only)
+fn draw_legend_labels(
+    children: &mut Vec<SvgElement>,
+    curves: &[crate::diagrams::radar::RadarCurve],
+    chart_width: f64,
+    chart_height: f64,
+) {
+    let legend_x = (chart_width / 2.0 + MARGIN_RIGHT) * 3.0 / 4.0;
+    let legend_y = -(chart_height / 2.0 + MARGIN_TOP) * 3.0 / 4.0;
+    let line_height = 20.0;
+
+    for (index, curve) in curves.iter().enumerate() {
+        let item_y = legend_y + (index as f64) * line_height;
 
         // Label text
         let text_elem = SvgElement::Text {


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary

Fixes z-order issues where text was being rendered before shapes in SVG output, which could cause text to appear behind shapes in certain diagram types.

**Changes:**
- **gantt**: Collect all task bar rects first, then all text labels; move title to end of SVG; wrap grid ticks in `<g class="tick">` groups
- **quadrant**: Split `render_points` into `render_point_circles` and `render_point_labels`; reorganize rendering order
- **radar**: Split `draw_axes` into `draw_axis_lines` and `draw_axis_labels`; split `draw_legend` into boxes and labels
- **packet**: Refactor to collect all rect elements from all rows first, then all text

**Results:**
- Reduced z-order warnings from 40+ to 4
- gantt: 3/3 passing (100%)
- quadrant: 1/2 passing (other issue is parsing)
- radar: visual similarity only (no z-order warnings)
- packet: 2/2 passing (100%)

**Remaining:** Sequence diagrams still have z-order issues but require significant refactoring due to complex timeline-based rendering.

## Test plan
- [x] All tests pass (`cargo test --features all-formats`)
- [x] Clippy passes with no warnings
- [x] Eval shows improvement for fixed diagram types

🤖 Generated with [Claude Code](https://claude.com/claude-code)