### PR TITLE
docs(class): regenerate class diagram SVGs

### DIFF
--- a/docs/images/class.svg
+++ b/docs/images/class.svg
@@ -135,28 +135,28 @@ marker path {
       <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" fill="none" stroke="#333333" stroke-width="1"/>
     </marker>
     <marker id="inheritance-start" viewBox="0 0 20 14" refX="1" refY="7" markerWidth="20" markerHeight="28" orient="auto">
-      <path d="M 1 7 L 18 13 V 1 Z" stroke-width="1" stroke="#333333" fill="#ECECFF"/>
+      <path d="M 1 7 L 18 13 V 1 Z" stroke="#333333" fill="#ECECFF" stroke-width="1"/>
     </marker>
     <marker id="inheritance-end" viewBox="0 0 20 14" refX="18" refY="7" markerWidth="20" markerHeight="28" orient="auto">
-      <path d="M 18 7 L 1 13 V 1 Z" stroke-width="1" fill="#ECECFF" stroke="#333333"/>
+      <path d="M 18 7 L 1 13 V 1 Z" stroke="#333333" fill="#ECECFF" stroke-width="1"/>
     </marker>
     <marker id="composition-start" viewBox="0 0 20 14" refX="18" refY="7" markerWidth="18" markerHeight="14" orient="auto">
-      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" fill="#333333" stroke="#333333" stroke-width="1"/>
+      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" stroke="#333333" fill="#333333" stroke-width="1"/>
     </marker>
     <marker id="composition-end" viewBox="0 0 20 14" refX="1" refY="7" markerWidth="18" markerHeight="14" orient="auto">
-      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" fill="#333333" stroke="#333333" stroke-width="1"/>
+      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" stroke="#333333" fill="#333333" stroke-width="1"/>
     </marker>
     <marker id="dependency-start" viewBox="0 0 20 20" refX="0" refY="10" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M 0 10 L 20 0 L 20 20 Z" stroke="#333333" stroke-width="1" fill="none"/>
+      <path d="M 0 10 L 20 0 L 20 20 Z" fill="none" stroke="#333333" stroke-width="1"/>
     </marker>
     <marker id="dependency-end" viewBox="0 0 20 20" refX="20" refY="10" markerWidth="10" markerHeight="10" orient="auto">
       <path d="M 20 10 L 0 0 L 0 20 Z" stroke="#333333" fill="none" stroke-width="1"/>
     </marker>
     <marker id="lollipop-start" viewBox="0 0 20 20" refX="13" refY="10" markerWidth="14" markerHeight="14" orient="auto">
-      <circle cx="10" cy="10" r="8" stroke="#333333" stroke-width="1" fill="#FFFFFF"/>
+      <circle cx="10" cy="10" r="8" stroke-width="1" fill="#FFFFFF" stroke="#333333"/>
     </marker>
     <marker id="lollipop-end" viewBox="0 0 20 20" refX="1" refY="10" markerWidth="14" markerHeight="14" orient="auto">
-      <circle cx="10" cy="10" r="8" stroke="#333333" stroke-width="1" fill="#FFFFFF"/>
+      <circle cx="10" cy="10" r="8" stroke-width="1" fill="#FFFFFF" stroke="#333333"/>
     </marker>
   </defs>
   <g class="root">
@@ -164,62 +164,62 @@ marker path {
 
     </g>
     <g class="edgePaths">
-      <path d="M 234.00 96.00 C 184.40 141.33, 134.80 186.67, 110.00 216.00 C 85.20 245.33, 85.20 258.67, 85.20 272.00" class="relation relation-line" stroke="#333333" fill="none" marker-start="url(#inheritance-start)" stroke-width="1"/>
-      <path d="M 308.40 192.00 C 308.40 205.33, 308.40 218.67, 308.40 234.00 C 308.40 249.33, 308.40 266.67, 308.40 284.00" class="relation relation-line" marker-start="url(#inheritance-start)" fill="none" stroke-width="1" stroke="#333333"/>
-      <path d="M 382.80 96.00 C 427.60 141.33, 472.40 186.67, 494.80 218.00 C 517.20 249.33, 517.20 266.67, 517.20 284.00" class="relation relation-line" stroke-width="1" fill="none" stroke="#333333" marker-start="url(#inheritance-start)"/>
-      <path d="M 85.20 440.00 C 85.20 456.67, 85.20 473.33, 85.20 490.00 C 85.20 506.67, 85.20 523.33, 85.20 540.00" class="relation relation-line" stroke="#333333" fill="none" stroke-width="1" marker-start="url(#composition-start)"/>
+      <path d="M 234.00 96.00 C 184.40 141.33, 134.80 186.67, 110.00 216.00 C 85.20 245.33, 85.20 258.67, 85.20 272.00" class="relation relation-line" marker-start="url(#inheritance-start)" stroke="#333333" fill="none" stroke-width="1"/>
+      <path d="M 308.40 192.00 C 308.40 205.33, 308.40 218.67, 308.40 234.00 C 308.40 249.33, 308.40 266.67, 308.40 284.00" class="relation relation-line" stroke-width="1" marker-start="url(#inheritance-start)" stroke="#333333" fill="none"/>
+      <path d="M 382.80 96.00 C 427.60 141.33, 472.40 186.67, 494.80 218.00 C 517.20 249.33, 517.20 266.67, 517.20 284.00" class="relation relation-line" marker-start="url(#inheritance-start)" fill="none" stroke-width="1" stroke="#333333"/>
+      <path d="M 85.20 440.00 C 85.20 456.67, 85.20 473.33, 85.20 490.00 C 85.20 506.67, 85.20 523.33, 85.20 540.00" class="relation relation-line" fill="none" stroke="#333333" marker-start="url(#composition-start)" stroke-width="1"/>
     </g>
     <g class="edgeLabels">
-      <text x="73.20000000000005" y="460" class="cardinality-label" font-size="11" text-anchor="middle">1</text>
-      <text x="73.20000000000005" y="520" class="cardinality-label" font-size="11" text-anchor="middle">many</text>
-      <text x="85.20000000000005" y="490" class="relation-label" font-size="11" text-anchor="middle" dominant-baseline="central">has</text>
+      <text x="73.19999999999999" y="460" class="cardinality-label" font-size="11" text-anchor="middle">1</text>
+      <text x="73.19999999999999" y="520" class="cardinality-label" text-anchor="middle" font-size="11">many</text>
+      <text x="85.19999999999999" y="490" class="relation-label" font-size="11" dominant-baseline="central" text-anchor="middle">has</text>
     </g>
     <g class="nodes">
-      <g class="class-node" id="class-Duck">
-        <path d="M 3.000000000000057 272 H 167.40000000000003 A 3 3 0 0 1 170.40000000000003 275 V 437 A 3 3 0 0 1 167.40000000000003 440 H 3.000000000000057 A 3 3 0 0 1 0.00000000000005684341886080802 437 V 275 A 3 3 0 0 1 3.000000000000057 272 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
-        <path d="M 3.000000000000057 272 H 167.40000000000003 A 3 3 0 0 1 170.40000000000003 275 V 437 A 3 3 0 0 1 167.40000000000003 440 H 3.000000000000057 A 3 3 0 0 1 0.00000000000005684341886080802 437 V 275 A 3 3 0 0 1 3.000000000000057 272 Z" class="class-box" stroke="#333333" stroke-width="1" fill="none"/>
-        <path d="M 0.00000000000005684341886080802 320 L 170.40000000000003 320" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <path d="M 0.00000000000005684341886080802 368 L 170.40000000000003 368" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <text x="85.20000000000005" y="296" text-anchor="middle" font-size="16" font-weight="bold" dominant-baseline="middle">Duck</text>
-        <text x="24.000000000000057" y="332" text-anchor="start" dominant-baseline="middle" font-size="16">+String beakColor</text>
-        <text x="24.000000000000057" y="380" font-size="16" text-anchor="start" dominant-baseline="middle">+swim()</text>
-        <text x="24.000000000000057" y="404" text-anchor="start" dominant-baseline="middle" font-size="16">+quack()</text>
-      </g>
-      <g class="class-node" id="class-Fish">
-        <path d="M 233.40000000000003 284 H 383.40000000000003 A 3 3 0 0 1 386.40000000000003 287 V 425 A 3 3 0 0 1 383.40000000000003 428 H 233.40000000000003 A 3 3 0 0 1 230.40000000000003 425 V 287 A 3 3 0 0 1 233.40000000000003 284 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
-        <path d="M 233.40000000000003 284 H 383.40000000000003 A 3 3 0 0 1 386.40000000000003 287 V 425 A 3 3 0 0 1 383.40000000000003 428 H 233.40000000000003 A 3 3 0 0 1 230.40000000000003 425 V 287 A 3 3 0 0 1 233.40000000000003 284 Z" class="class-box" fill="none" stroke-width="1" stroke="#333333"/>
-        <path d="M 230.40000000000003 332 L 386.40000000000003 332" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <path d="M 230.40000000000003 380 L 386.40000000000003 380" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <text x="308.40000000000003" y="308" text-anchor="middle" font-weight="bold" dominant-baseline="middle" font-size="16">Fish</text>
-        <text x="254.40000000000003" y="344" text-anchor="start" dominant-baseline="middle" font-size="16">-int sizeInFeet</text>
-        <text x="254.40000000000003" y="392" dominant-baseline="middle" font-size="16" text-anchor="start">-canEat()</text>
-      </g>
-      <g class="class-node" id="class-Zebra">
-        <path d="M 449.40000000000003 284 H 585 A 3 3 0 0 1 588 287 V 425 A 3 3 0 0 1 585 428 H 449.40000000000003 A 3 3 0 0 1 446.40000000000003 425 V 287 A 3 3 0 0 1 449.40000000000003 284 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
-        <path d="M 449.40000000000003 284 H 585 A 3 3 0 0 1 588 287 V 425 A 3 3 0 0 1 585 428 H 449.40000000000003 A 3 3 0 0 1 446.40000000000003 425 V 287 A 3 3 0 0 1 449.40000000000003 284 Z" class="class-box" stroke="#333333" stroke-width="1" fill="none"/>
-        <path d="M 446.40000000000003 332 L 588 332" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <path d="M 446.40000000000003 380 L 588 380" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <text x="517.2" y="308" dominant-baseline="middle" font-size="16" font-weight="bold" text-anchor="middle">Zebra</text>
-        <text x="470.40000000000003" y="344" text-anchor="start" dominant-baseline="middle" font-size="16">+bool is_wild</text>
-        <text x="470.40000000000003" y="392" dominant-baseline="middle" font-size="16" text-anchor="start">+run()</text>
+      <g class="class-node" id="class-Egg">
+        <path d="M 38.19999999999999 540 H 132.2 A 3 3 0 0 1 135.2 543 V 633 A 3 3 0 0 1 132.2 636 H 38.19999999999999 A 3 3 0 0 1 35.19999999999999 633 V 543 A 3 3 0 0 1 38.19999999999999 540 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
+        <path d="M 38.19999999999999 540 H 132.2 A 3 3 0 0 1 135.2 543 V 633 A 3 3 0 0 1 132.2 636 H 38.19999999999999 A 3 3 0 0 1 35.19999999999999 633 V 543 A 3 3 0 0 1 38.19999999999999 540 Z" class="class-box" fill="none" stroke="#333333" stroke-width="1"/>
+        <path d="M 35.19999999999999 588 L 135.2 588" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <path d="M 35.19999999999999 636 L 135.2 636" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="85.19999999999999" y="564" dominant-baseline="middle" font-weight="bold" font-size="16" text-anchor="middle">Egg</text>
       </g>
       <g class="class-node" id="class-Animal">
-        <path d="M 237.00000000000003 0 H 379.80000000000007 A 3 3 0 0 1 382.80000000000007 3 V 189 A 3 3 0 0 1 379.80000000000007 192 H 237.00000000000003 A 3 3 0 0 1 234.00000000000003 189 V 3 A 3 3 0 0 1 237.00000000000003 0 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
-        <path d="M 237.00000000000003 0 H 379.80000000000007 A 3 3 0 0 1 382.80000000000007 3 V 189 A 3 3 0 0 1 379.80000000000007 192 H 237.00000000000003 A 3 3 0 0 1 234.00000000000003 189 V 3 A 3 3 0 0 1 237.00000000000003 0 Z" class="class-box" stroke-width="1" fill="none" stroke="#333333"/>
-        <path d="M 234.00000000000003 48 L 382.80000000000007 48" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <path d="M 234.00000000000003 120 L 382.80000000000007 120" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <text x="308.40000000000003" y="24" text-anchor="middle" font-weight="bold" font-size="16" dominant-baseline="middle">Animal</text>
-        <text x="258" y="60" text-anchor="start" dominant-baseline="middle" font-size="16">+int age</text>
-        <text x="258" y="84" font-size="16" dominant-baseline="middle" text-anchor="start">+String gender</text>
-        <text x="258" y="132" dominant-baseline="middle" font-size="16" text-anchor="start">+isMammal()</text>
+        <path d="M 236.99999999999997 0 H 379.79999999999995 A 3 3 0 0 1 382.79999999999995 3 V 189 A 3 3 0 0 1 379.79999999999995 192 H 236.99999999999997 A 3 3 0 0 1 233.99999999999997 189 V 3 A 3 3 0 0 1 236.99999999999997 0 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
+        <path d="M 236.99999999999997 0 H 379.79999999999995 A 3 3 0 0 1 382.79999999999995 3 V 189 A 3 3 0 0 1 379.79999999999995 192 H 236.99999999999997 A 3 3 0 0 1 233.99999999999997 189 V 3 A 3 3 0 0 1 236.99999999999997 0 Z" class="class-box" fill="none" stroke="#333333" stroke-width="1"/>
+        <path d="M 233.99999999999997 48 L 382.79999999999995 48" class="class-divider" stroke-width="1" stroke="#333333"/>
+        <path d="M 233.99999999999997 120 L 382.79999999999995 120" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="308.4" y="24" dominant-baseline="middle" text-anchor="middle" font-size="16" font-weight="bold">Animal</text>
+        <text x="258" y="60" text-anchor="start" font-size="16" dominant-baseline="middle">+int age</text>
+        <text x="258" y="84" font-size="16" text-anchor="start" dominant-baseline="middle">+String gender</text>
+        <text x="258" y="132" font-size="16" text-anchor="start" dominant-baseline="middle">+isMammal()</text>
         <text x="258" y="156" text-anchor="start" dominant-baseline="middle" font-size="16">+mate()</text>
       </g>
-      <g class="class-node" id="class-Egg">
-        <path d="M 38.200000000000045 540 H 132.20000000000005 A 3 3 0 0 1 135.20000000000005 543 V 633 A 3 3 0 0 1 132.20000000000005 636 H 38.200000000000045 A 3 3 0 0 1 35.200000000000045 633 V 543 A 3 3 0 0 1 38.200000000000045 540 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
-        <path d="M 38.200000000000045 540 H 132.20000000000005 A 3 3 0 0 1 135.20000000000005 543 V 633 A 3 3 0 0 1 132.20000000000005 636 H 38.200000000000045 A 3 3 0 0 1 35.200000000000045 633 V 543 A 3 3 0 0 1 38.200000000000045 540 Z" class="class-box" stroke="#333333" stroke-width="1" fill="none"/>
-        <path d="M 35.200000000000045 588 L 135.20000000000005 588" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <path d="M 35.200000000000045 636 L 135.20000000000005 636" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <text x="85.20000000000005" y="564" font-weight="bold" text-anchor="middle" font-size="16" dominant-baseline="middle">Egg</text>
+      <g class="class-node" id="class-Duck">
+        <path d="M 3 272 H 167.39999999999998 A 3 3 0 0 1 170.39999999999998 275 V 437 A 3 3 0 0 1 167.39999999999998 440 H 3 A 3 3 0 0 1 0 437 V 275 A 3 3 0 0 1 3 272 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
+        <path d="M 3 272 H 167.39999999999998 A 3 3 0 0 1 170.39999999999998 275 V 437 A 3 3 0 0 1 167.39999999999998 440 H 3 A 3 3 0 0 1 0 437 V 275 A 3 3 0 0 1 3 272 Z" class="class-box" fill="none" stroke="#333333" stroke-width="1"/>
+        <path d="M 0 320 L 170.39999999999998 320" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <path d="M 0 368 L 170.39999999999998 368" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="85.19999999999999" y="296" font-weight="bold" text-anchor="middle" font-size="16" dominant-baseline="middle">Duck</text>
+        <text x="24" y="332" text-anchor="start" dominant-baseline="middle" font-size="16">+String beakColor</text>
+        <text x="24" y="380" font-size="16" dominant-baseline="middle" text-anchor="start">+swim()</text>
+        <text x="24" y="404" dominant-baseline="middle" text-anchor="start" font-size="16">+quack()</text>
+      </g>
+      <g class="class-node" id="class-Fish">
+        <path d="M 233.39999999999998 284 H 383.4 A 3 3 0 0 1 386.4 287 V 425 A 3 3 0 0 1 383.4 428 H 233.39999999999998 A 3 3 0 0 1 230.39999999999998 425 V 287 A 3 3 0 0 1 233.39999999999998 284 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
+        <path d="M 233.39999999999998 284 H 383.4 A 3 3 0 0 1 386.4 287 V 425 A 3 3 0 0 1 383.4 428 H 233.39999999999998 A 3 3 0 0 1 230.39999999999998 425 V 287 A 3 3 0 0 1 233.39999999999998 284 Z" class="class-box" stroke="#333333" fill="none" stroke-width="1"/>
+        <path d="M 230.39999999999998 332 L 386.4 332" class="class-divider" stroke-width="1" stroke="#333333"/>
+        <path d="M 230.39999999999998 380 L 386.4 380" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="308.4" y="308" text-anchor="middle" dominant-baseline="middle" font-size="16" font-weight="bold">Fish</text>
+        <text x="254.39999999999998" y="344" dominant-baseline="middle" font-size="16" text-anchor="start">-int sizeInFeet</text>
+        <text x="254.39999999999998" y="392" text-anchor="start" font-size="16" dominant-baseline="middle">-canEat()</text>
+      </g>
+      <g class="class-node" id="class-Zebra">
+        <path d="M 449.40000000000003 284 H 585 A 3 3 0 0 1 588 287 V 425 A 3 3 0 0 1 585 428 H 449.40000000000003 A 3 3 0 0 1 446.40000000000003 425 V 287 A 3 3 0 0 1 449.40000000000003 284 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
+        <path d="M 449.40000000000003 284 H 585 A 3 3 0 0 1 588 287 V 425 A 3 3 0 0 1 585 428 H 449.40000000000003 A 3 3 0 0 1 446.40000000000003 425 V 287 A 3 3 0 0 1 449.40000000000003 284 Z" class="class-box" fill="none" stroke="#333333" stroke-width="1"/>
+        <path d="M 446.40000000000003 332 L 588 332" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <path d="M 446.40000000000003 380 L 588 380" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="517.2" y="308" font-weight="bold" dominant-baseline="middle" text-anchor="middle" font-size="16">Zebra</text>
+        <text x="470.40000000000003" y="344" font-size="16" dominant-baseline="middle" text-anchor="start">+bool is_wild</text>
+        <text x="470.40000000000003" y="392" text-anchor="start" dominant-baseline="middle" font-size="16">+run()</text>
       </g>
     </g>
   </g>

--- a/docs/images/class_complex.svg
+++ b/docs/images/class_complex.svg
@@ -129,10 +129,10 @@ marker path {
   </style>
   <defs>
     <marker id="aggregation-start" viewBox="0 0 20 14" refX="18" refY="7" markerWidth="18" markerHeight="14" orient="auto">
-      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" stroke-width="1" stroke="#333333" fill="none"/>
+      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" fill="none" stroke="#333333" stroke-width="1"/>
     </marker>
     <marker id="aggregation-end" viewBox="0 0 20 14" refX="1" refY="7" markerWidth="18" markerHeight="14" orient="auto">
-      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" stroke-width="1" stroke="#333333" fill="none"/>
+      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" fill="none" stroke="#333333" stroke-width="1"/>
     </marker>
     <marker id="inheritance-start" viewBox="0 0 20 14" refX="1" refY="7" markerWidth="20" markerHeight="28" orient="auto">
       <path d="M 1 7 L 18 13 V 1 Z" stroke-width="1" fill="#ECECFF" stroke="#333333"/>
@@ -141,22 +141,22 @@ marker path {
       <path d="M 18 7 L 1 13 V 1 Z" stroke="#333333" fill="#ECECFF" stroke-width="1"/>
     </marker>
     <marker id="composition-start" viewBox="0 0 20 14" refX="18" refY="7" markerWidth="18" markerHeight="14" orient="auto">
-      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" fill="#333333" stroke="#333333" stroke-width="1"/>
+      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" stroke-width="1" fill="#333333" stroke="#333333"/>
     </marker>
     <marker id="composition-end" viewBox="0 0 20 14" refX="1" refY="7" markerWidth="18" markerHeight="14" orient="auto">
-      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" fill="#333333" stroke="#333333" stroke-width="1"/>
+      <path d="M 18 7 L 9 13 L 1 7 L 9 1 Z" stroke-width="1" fill="#333333" stroke="#333333"/>
     </marker>
     <marker id="dependency-start" viewBox="0 0 20 20" refX="0" refY="10" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M 0 10 L 20 0 L 20 20 Z" stroke="#333333" stroke-width="1" fill="none"/>
+      <path d="M 0 10 L 20 0 L 20 20 Z" fill="none" stroke="#333333" stroke-width="1"/>
     </marker>
     <marker id="dependency-end" viewBox="0 0 20 20" refX="20" refY="10" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M 20 10 L 0 0 L 0 20 Z" fill="none" stroke="#333333" stroke-width="1"/>
+      <path d="M 20 10 L 0 0 L 0 20 Z" stroke-width="1" fill="none" stroke="#333333"/>
     </marker>
     <marker id="lollipop-start" viewBox="0 0 20 20" refX="13" refY="10" markerWidth="14" markerHeight="14" orient="auto">
-      <circle cx="10" cy="10" r="8" fill="#FFFFFF" stroke-width="1" stroke="#333333"/>
+      <circle cx="10" cy="10" r="8" fill="#FFFFFF" stroke="#333333" stroke-width="1"/>
     </marker>
     <marker id="lollipop-end" viewBox="0 0 20 20" refX="1" refY="10" markerWidth="14" markerHeight="14" orient="auto">
-      <circle cx="10" cy="10" r="8" fill="#FFFFFF" stroke-width="1" stroke="#333333"/>
+      <circle cx="10" cy="10" r="8" fill="#FFFFFF" stroke="#333333" stroke-width="1"/>
     </marker>
   </defs>
   <g class="root">
@@ -164,151 +164,151 @@ marker path {
 
     </g>
     <g class="edgePaths">
-      <path d="M 196.80 216.00 C 158.40 229.33, 120.00 242.67, 100.80 260.00 C 81.60 277.33, 81.60 298.67, 81.60 320.00" class="relation relation-line" fill="none" marker-end="url(#dependency-end)" stroke-width="1" stroke="#333333"/>
-      <path d="M 196.80 216.00 C 235.20 229.33, 273.60 242.67, 292.80 256.00 C 312.00 269.33, 312.00 282.67, 312.00 296.00" class="relation relation-line" stroke-width="1" fill="none" marker-end="url(#dependency-end)" stroke="#333333"/>
-      <path d="M 296.40 108.00 C 391.60 157.33, 486.80 206.67, 534.40 240.00 C 582.00 273.33, 582.00 290.67, 582.00 308.00" class="relation relation-line" fill="none" marker-end="url(#dependency-end)" stroke-width="1" stroke="#333333"/>
-      <path d="M 582.00 524.00 L 572.00 640.00" class="relation relation-line" stroke="#333333" fill="none" marker-end="url(#dependency-end)" stroke-width="1"/>
-      <path d="M 582.00 524.00 C 629.40 541.33, 676.80 558.67, 707.00 592.00 C 737.20 625.33, 750.20 674.67, 763.20 724.00" class="relation relation-line" stroke="#333333" stroke-width="1" fill="none" marker-end="url(#dependency-end)"/>
-      <path d="M 895.20 488.00 C 895.20 517.33, 895.20 546.67, 895.20 574.33 C 895.20 602.00, 895.20 628.00, 895.20 654.00" class="relation relation-line" stroke="#333333" fill="none" stroke-dasharray="5,5" marker-end="url(#inheritance-end)" stroke-width="1"/>
-      <path d="M 1219.20 500.00 C 1219.20 525.33, 1219.20 550.67, 1187.20 588.00 C 1155.20 625.33, 1091.20 674.67, 1027.20 724.00" class="relation relation-line" stroke-dasharray="5,5" fill="none" stroke-width="1" marker-end="url(#inheritance-end)" stroke="#333333"/>
-      <path d="M 572.00 808.00 C 572.00 829.33, 572.00 850.67, 573.67 874.33 C 575.33 898.00, 578.67 924.00, 582.00 950.00" class="relation relation-line" stroke-width="1" marker-end="url(#dependency-end)" stroke="#333333" fill="none"/>
-      <path d="M 1087.20 724.00 L 703.20 1020.00" class="relation relation-line" stroke-dasharray="5,5" stroke-width="1" marker-end="url(#inheritance-end)" stroke="#333333" fill="none"/>
-      <path d="M 1212.00 832.00 C 1213.20 845.33, 1214.40 858.67, 1215.00 872.00 C 1215.60 885.33, 1215.60 898.67, 1215.60 912.00" class="relation relation-line" fill="none" stroke-width="1" stroke="#333333" marker-end="url(#dependency-end)"/>
-      <path d="M 1215.60 1128.00 C 1215.60 1141.33, 1215.60 1154.67, 1215.60 1168.00 C 1215.60 1181.33, 1215.60 1194.67, 1215.60 1208.00" class="relation relation-line" stroke="#333333" stroke-width="1" marker-end="url(#dependency-end)" fill="none"/>
+      <path d="M 196.80 216.00 C 158.40 229.33, 120.00 242.67, 100.80 260.00 C 81.60 277.33, 81.60 298.67, 81.60 320.00" class="relation relation-line" stroke-width="1" stroke="#333333" fill="none" marker-end="url(#dependency-end)"/>
+      <path d="M 196.80 216.00 C 235.20 229.33, 273.60 242.67, 292.80 256.00 C 312.00 269.33, 312.00 282.67, 312.00 296.00" class="relation relation-line" marker-end="url(#dependency-end)" stroke="#333333" stroke-width="1" fill="none"/>
+      <path d="M 296.40 108.00 C 391.60 157.33, 486.80 206.67, 534.40 240.00 C 582.00 273.33, 582.00 290.67, 582.00 308.00" class="relation relation-line" marker-end="url(#dependency-end)" stroke-width="1" fill="none" stroke="#333333"/>
+      <path d="M 582.00 524.00 L 572.00 640.00" class="relation relation-line" stroke="#333333" stroke-width="1" fill="none" marker-end="url(#dependency-end)"/>
+      <path d="M 582.00 524.00 C 629.40 541.33, 676.80 558.67, 707.00 592.00 C 737.20 625.33, 750.20 674.67, 763.20 724.00" class="relation relation-line" marker-end="url(#dependency-end)" fill="none" stroke="#333333" stroke-width="1"/>
+      <path d="M 895.20 488.00 C 895.20 517.33, 895.20 546.67, 895.20 574.33 C 895.20 602.00, 895.20 628.00, 895.20 654.00" class="relation relation-line" stroke-width="1" stroke-dasharray="5,5" stroke="#333333" fill="none" marker-end="url(#inheritance-end)"/>
+      <path d="M 1219.20 500.00 C 1219.20 525.33, 1219.20 550.67, 1187.20 588.00 C 1155.20 625.33, 1091.20 674.67, 1027.20 724.00" class="relation relation-line" stroke-width="1" marker-end="url(#inheritance-end)" stroke-dasharray="5,5" stroke="#333333" fill="none"/>
+      <path d="M 572.00 808.00 C 572.00 829.33, 572.00 850.67, 573.67 874.33 C 575.33 898.00, 578.67 924.00, 582.00 950.00" class="relation relation-line" stroke-width="1" stroke="#333333" fill="none" marker-end="url(#dependency-end)"/>
+      <path d="M 1087.20 724.00 L 703.20 1020.00" class="relation relation-line" stroke="#333333" stroke-dasharray="5,5" stroke-width="1" marker-end="url(#inheritance-end)" fill="none"/>
+      <path d="M 1212.00 832.00 C 1213.20 845.33, 1214.40 858.67, 1215.00 872.00 C 1215.60 885.33, 1215.60 898.67, 1215.60 912.00" class="relation relation-line" marker-end="url(#dependency-end)" stroke="#333333" stroke-width="1" fill="none"/>
+      <path d="M 1215.60 1128.00 C 1215.60 1141.33, 1215.60 1154.67, 1215.60 1168.00 C 1215.60 1181.33, 1215.60 1194.67, 1215.60 1208.00" class="relation relation-line" stroke-width="1" fill="none" stroke="#333333" marker-end="url(#dependency-end)"/>
     </g>
     <g class="edgeLabels">
 
     </g>
     <g class="nodes">
-      <g class="class-node" id="class-Logger">
-        <path d="M 226.19999999999976 296 H 397.7999999999997 A 3 3 0 0 1 400.7999999999997 299 V 533 A 3 3 0 0 1 397.7999999999997 536 H 226.19999999999976 A 3 3 0 0 1 223.19999999999976 533 V 299 A 3 3 0 0 1 226.19999999999976 296 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
-        <path d="M 226.19999999999976 296 H 397.7999999999997 A 3 3 0 0 1 400.7999999999997 299 V 533 A 3 3 0 0 1 397.7999999999997 536 H 226.19999999999976 A 3 3 0 0 1 223.19999999999976 533 V 299 A 3 3 0 0 1 226.19999999999976 296 Z" class="class-box" fill="none" stroke="#333333" stroke-width="1"/>
-        <path d="M 223.19999999999976 344 L 400.7999999999997 344" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <path d="M 223.19999999999976 416 L 400.7999999999997 416" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <text x="311.9999999999998" y="320" dominant-baseline="middle" text-anchor="middle" font-weight="bold" font-size="16">Logger</text>
-        <text x="247.19999999999976" y="356" dominant-baseline="middle" text-anchor="start" font-size="16">-level: LogLevel</text>
-        <text x="247.19999999999976" y="380" dominant-baseline="middle" font-size="16" text-anchor="start">-outputs: Output[]</text>
-        <text x="247.19999999999976" y="428" font-size="16" text-anchor="start" dominant-baseline="middle">+debug(msg)</text>
-        <text x="247.19999999999976" y="452" font-size="16" text-anchor="start" dominant-baseline="middle">+info(msg)</text>
-        <text x="247.19999999999976" y="476" font-size="16" dominant-baseline="middle" text-anchor="start">+warn(msg)</text>
-        <text x="247.19999999999976" y="500" text-anchor="start" dominant-baseline="middle" font-size="16">+error(msg)</text>
-      </g>
-      <g class="class-node" id="class-RateLimitMiddleware">
-        <path d="M 1090.1999999999998 332 H 1348.1999999999998 A 3 3 0 0 1 1351.1999999999998 335 V 497 A 3 3 0 0 1 1348.1999999999998 500 H 1090.1999999999998 A 3 3 0 0 1 1087.1999999999998 497 V 335 A 3 3 0 0 1 1090.1999999999998 332 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
-        <path d="M 1090.1999999999998 332 H 1348.1999999999998 A 3 3 0 0 1 1351.1999999999998 335 V 497 A 3 3 0 0 1 1348.1999999999998 500 H 1090.1999999999998 A 3 3 0 0 1 1087.1999999999998 497 V 335 A 3 3 0 0 1 1090.1999999999998 332 Z" class="class-box" stroke-width="1" stroke="#333333" fill="none"/>
-        <path d="M 1087.1999999999998 380 L 1351.1999999999998 380" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <path d="M 1087.1999999999998 452 L 1351.1999999999998 452" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <text x="1219.1999999999998" y="356" text-anchor="middle" dominant-baseline="middle" font-weight="bold" font-size="16">RateLimitMiddleware</text>
-        <text x="1111.1999999999998" y="392" font-size="16" text-anchor="start" dominant-baseline="middle">-limit: int</text>
-        <text x="1111.1999999999998" y="416" dominant-baseline="middle" text-anchor="start" font-size="16">-window: Duration</text>
-        <text x="1111.1999999999998" y="464" text-anchor="start" font-size="16" dominant-baseline="middle">+process(req, next) : Response</text>
-      </g>
-      <g class="class-node" id="class-UserService">
-        <path d="M 1097.3999999999996 912 H 1333.7999999999997 A 3 3 0 0 1 1336.7999999999997 915 V 1125 A 3 3 0 0 1 1333.7999999999997 1128 H 1097.3999999999996 A 3 3 0 0 1 1094.3999999999996 1125 V 915 A 3 3 0 0 1 1097.3999999999996 912 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
-        <path d="M 1097.3999999999996 912 H 1333.7999999999997 A 3 3 0 0 1 1336.7999999999997 915 V 1125 A 3 3 0 0 1 1333.7999999999997 1128 H 1097.3999999999996 A 3 3 0 0 1 1094.3999999999996 1125 V 915 A 3 3 0 0 1 1097.3999999999996 912 Z" class="class-box" stroke-width="1" stroke="#333333" fill="none"/>
-        <path d="M 1094.3999999999996 960 L 1336.7999999999997 960" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <path d="M 1094.3999999999996 1032 L 1336.7999999999997 1032" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <text x="1215.5999999999997" y="936" font-size="16" dominant-baseline="middle" text-anchor="middle" font-weight="bold">UserService</text>
-        <text x="1118.3999999999996" y="972" text-anchor="start" dominant-baseline="middle" font-size="16">-repository: UserRepository</text>
-        <text x="1118.3999999999996" y="996" text-anchor="start" font-size="16" dominant-baseline="middle">-cache: Cache</text>
-        <text x="1118.3999999999996" y="1044" font-size="16" text-anchor="start" dominant-baseline="middle">+findById(id) : User</text>
-        <text x="1118.3999999999996" y="1068" dominant-baseline="middle" font-size="16" text-anchor="start">+save(user) : User</text>
-        <text x="1118.3999999999996" y="1092" text-anchor="start" dominant-baseline="middle" font-size="16">+delete(id) : void</text>
-      </g>
-      <g class="class-node" id="class-UserRepository">
-        <path d="M 1127.3999999999996 1208 H 1303.7999999999997 A 3 3 0 0 1 1306.7999999999997 1211 V 1393 A 3 3 0 0 1 1303.7999999999997 1396 H 1127.3999999999996 A 3 3 0 0 1 1124.3999999999996 1393 V 1211 A 3 3 0 0 1 1127.3999999999996 1208 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
-        <path d="M 1127.3999999999996 1208 H 1303.7999999999997 A 3 3 0 0 1 1306.7999999999997 1211 V 1393 A 3 3 0 0 1 1303.7999999999997 1396 H 1127.3999999999996 A 3 3 0 0 1 1124.3999999999996 1393 V 1211 A 3 3 0 0 1 1127.3999999999996 1208 Z" class="class-box" fill="none" stroke="#333333" stroke-width="1"/>
-        <path d="M 1124.3999999999996 1276 L 1306.7999999999997 1276" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <path d="M 1124.3999999999996 1324 L 1306.7999999999997 1324" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <text x="1215.5999999999997" y="1230.6666666666667" font-size="16" font-style="italic" dominant-baseline="middle" text-anchor="middle">«interface»</text>
-        <text x="1215.5999999999997" y="1253.3333333333335" dominant-baseline="middle" font-weight="bold" text-anchor="middle" font-size="16">UserRepository</text>
-        <text x="1148.3999999999996" y="1336" dominant-baseline="middle" font-size="16" text-anchor="start">+find(id) : User</text>
-        <text x="1148.3999999999996" y="1360" dominant-baseline="middle" font-size="16" text-anchor="start">+save(user) : User</text>
-        <text x="1148.3999999999996" y="1384" dominant-baseline="middle" font-size="16" text-anchor="start">+delete(id) : void</text>
-      </g>
-      <g class="class-node" id="class-Router">
-        <path d="M 463.7999999999998 308 H 700.1999999999998 A 3 3 0 0 1 703.1999999999998 311 V 521 A 3 3 0 0 1 700.1999999999998 524 H 463.7999999999998 A 3 3 0 0 1 460.7999999999998 521 V 311 A 3 3 0 0 1 463.7999999999998 308 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
-        <path d="M 463.7999999999998 308 H 700.1999999999998 A 3 3 0 0 1 703.1999999999998 311 V 521 A 3 3 0 0 1 700.1999999999998 524 H 463.7999999999998 A 3 3 0 0 1 460.7999999999998 521 V 311 A 3 3 0 0 1 463.7999999999998 308 Z" class="class-box" stroke="#333333" fill="none" stroke-width="1"/>
-        <path d="M 460.7999999999998 356 L 703.1999999999998 356" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <path d="M 460.7999999999998 428 L 703.1999999999998 428" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <text x="581.9999999999998" y="332" font-size="16" font-weight="bold" dominant-baseline="middle" text-anchor="middle">Router</text>
-        <text x="484.7999999999998" y="368" font-size="16" text-anchor="start" dominant-baseline="middle">-routes: Route[]</text>
-        <text x="484.7999999999998" y="392" dominant-baseline="middle" font-size="16" text-anchor="start">-middleware: Middleware[]</text>
-        <text x="484.7999999999998" y="440" dominant-baseline="middle" font-size="16" text-anchor="start">+addRoute(route)</text>
-        <text x="484.7999999999998" y="464" dominant-baseline="middle" font-size="16" text-anchor="start">+use(middleware)</text>
-        <text x="484.7999999999998" y="488" dominant-baseline="middle" font-size="16" text-anchor="start">+handle(request) : Response</text>
-      </g>
-      <g class="class-node" id="class-Config">
-        <path d="M 2.9999999999999147 320 H 160.1999999999999 A 3 3 0 0 1 163.1999999999999 323 V 509 A 3 3 0 0 1 160.1999999999999 512 H 2.9999999999999147 A 3 3 0 0 1 -0.00000000000008526512829121202 509 V 323 A 3 3 0 0 1 2.9999999999999147 320 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
-        <path d="M 2.9999999999999147 320 H 160.1999999999999 A 3 3 0 0 1 163.1999999999999 323 V 509 A 3 3 0 0 1 160.1999999999999 512 H 2.9999999999999147 A 3 3 0 0 1 -0.00000000000008526512829121202 509 V 323 A 3 3 0 0 1 2.9999999999999147 320 Z" class="class-box" fill="none" stroke-width="1" stroke="#333333"/>
-        <path d="M -0.00000000000008526512829121202 368 L 163.1999999999999 368" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <path d="M -0.00000000000008526512829121202 416 L 163.1999999999999 416" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <text x="81.59999999999991" y="344" text-anchor="middle" font-size="16" font-weight="bold" dominant-baseline="middle">Config</text>
-        <text x="23.999999999999915" y="380" text-anchor="start" dominant-baseline="middle" font-size="16">-settings: Map</text>
-        <text x="23.999999999999915" y="428" text-anchor="start" font-size="16" dominant-baseline="middle">+get(key) : any</text>
-        <text x="23.999999999999915" y="452" font-size="16" text-anchor="start" dominant-baseline="middle">+set(key, value)</text>
-        <text x="23.999999999999915" y="476" dominant-baseline="middle" font-size="16" text-anchor="start">+load(path)</text>
-      </g>
       <g class="class-node" id="class-Handler">
         <path d="M 463.7999999999998 950 H 700.1999999999998 A 3 3 0 0 1 703.1999999999998 953 V 1087 A 3 3 0 0 1 700.1999999999998 1090 H 463.7999999999998 A 3 3 0 0 1 460.7999999999998 1087 V 953 A 3 3 0 0 1 463.7999999999998 950 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
-        <path d="M 463.7999999999998 950 H 700.1999999999998 A 3 3 0 0 1 703.1999999999998 953 V 1087 A 3 3 0 0 1 700.1999999999998 1090 H 463.7999999999998 A 3 3 0 0 1 460.7999999999998 1087 V 953 A 3 3 0 0 1 463.7999999999998 950 Z" class="class-box" fill="none" stroke="#333333" stroke-width="1"/>
-        <path d="M 460.7999999999998 1018 L 703.1999999999998 1018" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <path d="M 460.7999999999998 1066 L 703.1999999999998 1066" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <text x="581.9999999999998" y="972.6666666666666" font-style="italic" font-size="16" dominant-baseline="middle" text-anchor="middle">«interface»</text>
-        <text x="581.9999999999998" y="995.3333333333333" font-size="16" text-anchor="middle" dominant-baseline="middle" font-weight="bold">Handler</text>
-        <text x="484.7999999999998" y="1078" font-size="16" text-anchor="start" dominant-baseline="middle">+handle(request) : Response</text>
-      </g>
-      <g class="class-node" id="class-Application">
-        <path d="M 100.19999999999996 0 H 293.4 A 3 3 0 0 1 296.4 3 V 213 A 3 3 0 0 1 293.4 216 H 100.19999999999996 A 3 3 0 0 1 97.19999999999996 213 V 3 A 3 3 0 0 1 100.19999999999996 0 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
-        <path d="M 100.19999999999996 0 H 293.4 A 3 3 0 0 1 296.4 3 V 213 A 3 3 0 0 1 293.4 216 H 100.19999999999996 A 3 3 0 0 1 97.19999999999996 213 V 3 A 3 3 0 0 1 100.19999999999996 0 Z" class="class-box" fill="none" stroke-width="1" stroke="#333333"/>
-        <path d="M 97.19999999999996 48 L 296.4 48" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <path d="M 97.19999999999996 120 L 296.4 120" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <text x="196.79999999999995" y="24" text-anchor="middle" font-weight="bold" font-size="16" dominant-baseline="middle">Application</text>
-        <text x="121.19999999999996" y="60" font-size="16" dominant-baseline="middle" text-anchor="start">-config: Config</text>
-        <text x="121.19999999999996" y="84" dominant-baseline="middle" text-anchor="start" font-size="16">-logger: Logger</text>
-        <text x="121.19999999999996" y="132" text-anchor="start" dominant-baseline="middle" font-size="16">+start()</text>
-        <text x="121.19999999999996" y="156" font-size="16" dominant-baseline="middle" text-anchor="start">+stop()</text>
-        <text x="121.19999999999996" y="180" font-size="16" text-anchor="start" dominant-baseline="middle">+getStatus() : Status</text>
-      </g>
-      <g class="class-node" id="class-AuthMiddleware">
-        <path d="M 766.1999999999998 344 H 1024.1999999999998 A 3 3 0 0 1 1027.1999999999998 347 V 485 A 3 3 0 0 1 1024.1999999999998 488 H 766.1999999999998 A 3 3 0 0 1 763.1999999999998 485 V 347 A 3 3 0 0 1 766.1999999999998 344 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
-        <path d="M 766.1999999999998 344 H 1024.1999999999998 A 3 3 0 0 1 1027.1999999999998 347 V 485 A 3 3 0 0 1 1024.1999999999998 488 H 766.1999999999998 A 3 3 0 0 1 763.1999999999998 485 V 347 A 3 3 0 0 1 766.1999999999998 344 Z" class="class-box" fill="none" stroke="#333333" stroke-width="1"/>
-        <path d="M 763.1999999999998 392 L 1027.1999999999998 392" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <path d="M 763.1999999999998 440 L 1027.1999999999998 440" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <text x="895.1999999999998" y="368" text-anchor="middle" font-size="16" dominant-baseline="middle" font-weight="bold">AuthMiddleware</text>
-        <text x="787.1999999999998" y="404" text-anchor="start" font-size="16" dominant-baseline="middle">-tokenService: TokenService</text>
-        <text x="787.1999999999998" y="452" dominant-baseline="middle" font-size="16" text-anchor="start">+process(req, next) : Response</text>
-      </g>
-      <g class="class-node" id="class-Route">
-        <path d="M 482.5999999999998 640 H 661.3999999999997 A 3 3 0 0 1 664.3999999999997 643 V 805 A 3 3 0 0 1 661.3999999999997 808 H 482.5999999999998 A 3 3 0 0 1 479.5999999999998 805 V 643 A 3 3 0 0 1 482.5999999999998 640 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
-        <path d="M 482.5999999999998 640 H 661.3999999999997 A 3 3 0 0 1 664.3999999999997 643 V 805 A 3 3 0 0 1 661.3999999999997 808 H 482.5999999999998 A 3 3 0 0 1 479.5999999999998 805 V 643 A 3 3 0 0 1 482.5999999999998 640 Z" class="class-box" fill="none" stroke-width="1" stroke="#333333"/>
-        <path d="M 479.5999999999998 688 L 664.3999999999997 688" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <path d="M 479.5999999999998 784 L 664.3999999999997 784" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <text x="571.9999999999998" y="664" text-anchor="middle" font-weight="bold" font-size="16" dominant-baseline="middle">Route</text>
-        <text x="503.5999999999998" y="700" text-anchor="start" font-size="16" dominant-baseline="middle">+path: string</text>
-        <text x="503.5999999999998" y="724" text-anchor="start" font-size="16" dominant-baseline="middle">+method: HttpMethod</text>
-        <text x="503.5999999999998" y="748" dominant-baseline="middle" font-size="16" text-anchor="start">+handler: Handler</text>
+        <path d="M 463.7999999999998 950 H 700.1999999999998 A 3 3 0 0 1 703.1999999999998 953 V 1087 A 3 3 0 0 1 700.1999999999998 1090 H 463.7999999999998 A 3 3 0 0 1 460.7999999999998 1087 V 953 A 3 3 0 0 1 463.7999999999998 950 Z" class="class-box" stroke-width="1" fill="none" stroke="#333333"/>
+        <path d="M 460.7999999999998 1018 L 703.1999999999998 1018" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <path d="M 460.7999999999998 1066 L 703.1999999999998 1066" class="class-divider" stroke-width="1" stroke="#333333"/>
+        <text x="581.9999999999998" y="972.6666666666666" dominant-baseline="middle" font-size="16" text-anchor="middle" font-style="italic">«interface»</text>
+        <text x="581.9999999999998" y="995.3333333333333" font-size="16" font-weight="bold" text-anchor="middle" dominant-baseline="middle">Handler</text>
+        <text x="484.7999999999998" y="1078" text-anchor="start" dominant-baseline="middle" font-size="16">+handle(request) : Response</text>
       </g>
       <g class="class-node" id="class-Middleware">
         <path d="M 766.1999999999998 654 H 1024.1999999999998 A 3 3 0 0 1 1027.1999999999998 657 V 791 A 3 3 0 0 1 1024.1999999999998 794 H 766.1999999999998 A 3 3 0 0 1 763.1999999999998 791 V 657 A 3 3 0 0 1 766.1999999999998 654 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
-        <path d="M 766.1999999999998 654 H 1024.1999999999998 A 3 3 0 0 1 1027.1999999999998 657 V 791 A 3 3 0 0 1 1024.1999999999998 794 H 766.1999999999998 A 3 3 0 0 1 763.1999999999998 791 V 657 A 3 3 0 0 1 766.1999999999998 654 Z" class="class-box" fill="none" stroke-width="1" stroke="#333333"/>
+        <path d="M 766.1999999999998 654 H 1024.1999999999998 A 3 3 0 0 1 1027.1999999999998 657 V 791 A 3 3 0 0 1 1024.1999999999998 794 H 766.1999999999998 A 3 3 0 0 1 763.1999999999998 791 V 657 A 3 3 0 0 1 766.1999999999998 654 Z" class="class-box" stroke-width="1" stroke="#333333" fill="none"/>
         <path d="M 763.1999999999998 722 L 1027.1999999999998 722" class="class-divider" stroke="#333333" stroke-width="1"/>
         <path d="M 763.1999999999998 770 L 1027.1999999999998 770" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <text x="895.1999999999998" y="676.6666666666666" font-style="italic" dominant-baseline="middle" font-size="16" text-anchor="middle">«interface»</text>
-        <text x="895.1999999999998" y="699.3333333333333" dominant-baseline="middle" font-size="16" text-anchor="middle" font-weight="bold">Middleware</text>
-        <text x="787.1999999999998" y="782" font-size="16" text-anchor="start" dominant-baseline="middle">+process(req, next) : Response</text>
+        <text x="895.1999999999998" y="676.6666666666666" dominant-baseline="middle" text-anchor="middle" font-size="16" font-style="italic">«interface»</text>
+        <text x="895.1999999999998" y="699.3333333333333" text-anchor="middle" font-weight="bold" dominant-baseline="middle" font-size="16">Middleware</text>
+        <text x="787.1999999999998" y="782" dominant-baseline="middle" font-size="16" text-anchor="start">+process(req, next) : Response</text>
+      </g>
+      <g class="class-node" id="class-RateLimitMiddleware">
+        <path d="M 1090.1999999999998 332 H 1348.1999999999998 A 3 3 0 0 1 1351.1999999999998 335 V 497 A 3 3 0 0 1 1348.1999999999998 500 H 1090.1999999999998 A 3 3 0 0 1 1087.1999999999998 497 V 335 A 3 3 0 0 1 1090.1999999999998 332 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
+        <path d="M 1090.1999999999998 332 H 1348.1999999999998 A 3 3 0 0 1 1351.1999999999998 335 V 497 A 3 3 0 0 1 1348.1999999999998 500 H 1090.1999999999998 A 3 3 0 0 1 1087.1999999999998 497 V 335 A 3 3 0 0 1 1090.1999999999998 332 Z" class="class-box" fill="none" stroke-width="1" stroke="#333333"/>
+        <path d="M 1087.1999999999998 380 L 1351.1999999999998 380" class="class-divider" stroke-width="1" stroke="#333333"/>
+        <path d="M 1087.1999999999998 452 L 1351.1999999999998 452" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="1219.1999999999998" y="356" dominant-baseline="middle" text-anchor="middle" font-size="16" font-weight="bold">RateLimitMiddleware</text>
+        <text x="1111.1999999999998" y="392" dominant-baseline="middle" font-size="16" text-anchor="start">-limit: int</text>
+        <text x="1111.1999999999998" y="416" font-size="16" text-anchor="start" dominant-baseline="middle">-window: Duration</text>
+        <text x="1111.1999999999998" y="464" dominant-baseline="middle" font-size="16" text-anchor="start">+process(req, next) : Response</text>
+      </g>
+      <g class="class-node" id="class-Logger">
+        <path d="M 226.19999999999976 296 H 397.7999999999997 A 3 3 0 0 1 400.7999999999997 299 V 533 A 3 3 0 0 1 397.7999999999997 536 H 226.19999999999976 A 3 3 0 0 1 223.19999999999976 533 V 299 A 3 3 0 0 1 226.19999999999976 296 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
+        <path d="M 226.19999999999976 296 H 397.7999999999997 A 3 3 0 0 1 400.7999999999997 299 V 533 A 3 3 0 0 1 397.7999999999997 536 H 226.19999999999976 A 3 3 0 0 1 223.19999999999976 533 V 299 A 3 3 0 0 1 226.19999999999976 296 Z" class="class-box" stroke="#333333" stroke-width="1" fill="none"/>
+        <path d="M 223.19999999999976 344 L 400.7999999999997 344" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <path d="M 223.19999999999976 416 L 400.7999999999997 416" class="class-divider" stroke-width="1" stroke="#333333"/>
+        <text x="311.9999999999998" y="320" dominant-baseline="middle" font-weight="bold" font-size="16" text-anchor="middle">Logger</text>
+        <text x="247.19999999999976" y="356" dominant-baseline="middle" text-anchor="start" font-size="16">-level: LogLevel</text>
+        <text x="247.19999999999976" y="380" text-anchor="start" dominant-baseline="middle" font-size="16">-outputs: Output[]</text>
+        <text x="247.19999999999976" y="428" font-size="16" text-anchor="start" dominant-baseline="middle">+debug(msg)</text>
+        <text x="247.19999999999976" y="452" text-anchor="start" dominant-baseline="middle" font-size="16">+info(msg)</text>
+        <text x="247.19999999999976" y="476" font-size="16" text-anchor="start" dominant-baseline="middle">+warn(msg)</text>
+        <text x="247.19999999999976" y="500" dominant-baseline="middle" text-anchor="start" font-size="16">+error(msg)</text>
       </g>
       <g class="class-node" id="class-UserController">
         <path d="M 1090.1999999999998 616 H 1333.7999999999997 A 3 3 0 0 1 1336.7999999999997 619 V 829 A 3 3 0 0 1 1333.7999999999997 832 H 1090.1999999999998 A 3 3 0 0 1 1087.1999999999998 829 V 619 A 3 3 0 0 1 1090.1999999999998 616 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
-        <path d="M 1090.1999999999998 616 H 1333.7999999999997 A 3 3 0 0 1 1336.7999999999997 619 V 829 A 3 3 0 0 1 1333.7999999999997 832 H 1090.1999999999998 A 3 3 0 0 1 1087.1999999999998 829 V 619 A 3 3 0 0 1 1090.1999999999998 616 Z" class="class-box" fill="none" stroke-width="1" stroke="#333333"/>
-        <path d="M 1087.1999999999998 664 L 1336.7999999999997 664" class="class-divider" stroke-width="1" stroke="#333333"/>
-        <path d="M 1087.1999999999998 712 L 1336.7999999999997 712" class="class-divider" stroke="#333333" stroke-width="1"/>
-        <text x="1211.9999999999998" y="640" font-weight="bold" text-anchor="middle" dominant-baseline="middle" font-size="16">UserController</text>
-        <text x="1111.1999999999998" y="676" text-anchor="start" dominant-baseline="middle" font-size="16">-userService: UserService</text>
-        <text x="1111.1999999999998" y="724" font-size="16" text-anchor="start" dominant-baseline="middle">+getUser(id) : User</text>
-        <text x="1111.1999999999998" y="748" font-size="16" text-anchor="start" dominant-baseline="middle">+createUser(data) : User</text>
-        <text x="1111.1999999999998" y="772" dominant-baseline="middle" font-size="16" text-anchor="start">+updateUser(id, data) : User</text>
-        <text x="1111.1999999999998" y="796" dominant-baseline="middle" text-anchor="start" font-size="16">+deleteUser(id) : void</text>
+        <path d="M 1090.1999999999998 616 H 1333.7999999999997 A 3 3 0 0 1 1336.7999999999997 619 V 829 A 3 3 0 0 1 1333.7999999999997 832 H 1090.1999999999998 A 3 3 0 0 1 1087.1999999999998 829 V 619 A 3 3 0 0 1 1090.1999999999998 616 Z" class="class-box" fill="none" stroke="#333333" stroke-width="1"/>
+        <path d="M 1087.1999999999998 664 L 1336.7999999999997 664" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <path d="M 1087.1999999999998 712 L 1336.7999999999997 712" class="class-divider" stroke-width="1" stroke="#333333"/>
+        <text x="1211.9999999999998" y="640" font-size="16" text-anchor="middle" font-weight="bold" dominant-baseline="middle">UserController</text>
+        <text x="1111.1999999999998" y="676" dominant-baseline="middle" text-anchor="start" font-size="16">-userService: UserService</text>
+        <text x="1111.1999999999998" y="724" dominant-baseline="middle" font-size="16" text-anchor="start">+getUser(id) : User</text>
+        <text x="1111.1999999999998" y="748" font-size="16" dominant-baseline="middle" text-anchor="start">+createUser(data) : User</text>
+        <text x="1111.1999999999998" y="772" dominant-baseline="middle" text-anchor="start" font-size="16">+updateUser(id, data) : User</text>
+        <text x="1111.1999999999998" y="796" text-anchor="start" dominant-baseline="middle" font-size="16">+deleteUser(id) : void</text>
+      </g>
+      <g class="class-node" id="class-AuthMiddleware">
+        <path d="M 766.1999999999998 344 H 1024.1999999999998 A 3 3 0 0 1 1027.1999999999998 347 V 485 A 3 3 0 0 1 1024.1999999999998 488 H 766.1999999999998 A 3 3 0 0 1 763.1999999999998 485 V 347 A 3 3 0 0 1 766.1999999999998 344 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
+        <path d="M 766.1999999999998 344 H 1024.1999999999998 A 3 3 0 0 1 1027.1999999999998 347 V 485 A 3 3 0 0 1 1024.1999999999998 488 H 766.1999999999998 A 3 3 0 0 1 763.1999999999998 485 V 347 A 3 3 0 0 1 766.1999999999998 344 Z" class="class-box" fill="none" stroke-width="1" stroke="#333333"/>
+        <path d="M 763.1999999999998 392 L 1027.1999999999998 392" class="class-divider" stroke-width="1" stroke="#333333"/>
+        <path d="M 763.1999999999998 440 L 1027.1999999999998 440" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="895.1999999999998" y="368" font-weight="bold" font-size="16" text-anchor="middle" dominant-baseline="middle">AuthMiddleware</text>
+        <text x="787.1999999999998" y="404" text-anchor="start" font-size="16" dominant-baseline="middle">-tokenService: TokenService</text>
+        <text x="787.1999999999998" y="452" text-anchor="start" dominant-baseline="middle" font-size="16">+process(req, next) : Response</text>
+      </g>
+      <g class="class-node" id="class-Router">
+        <path d="M 463.7999999999998 308 H 700.1999999999998 A 3 3 0 0 1 703.1999999999998 311 V 521 A 3 3 0 0 1 700.1999999999998 524 H 463.7999999999998 A 3 3 0 0 1 460.7999999999998 521 V 311 A 3 3 0 0 1 463.7999999999998 308 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
+        <path d="M 463.7999999999998 308 H 700.1999999999998 A 3 3 0 0 1 703.1999999999998 311 V 521 A 3 3 0 0 1 700.1999999999998 524 H 463.7999999999998 A 3 3 0 0 1 460.7999999999998 521 V 311 A 3 3 0 0 1 463.7999999999998 308 Z" class="class-box" fill="none" stroke="#333333" stroke-width="1"/>
+        <path d="M 460.7999999999998 356 L 703.1999999999998 356" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <path d="M 460.7999999999998 428 L 703.1999999999998 428" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="581.9999999999998" y="332" font-size="16" font-weight="bold" text-anchor="middle" dominant-baseline="middle">Router</text>
+        <text x="484.7999999999998" y="368" dominant-baseline="middle" text-anchor="start" font-size="16">-routes: Route[]</text>
+        <text x="484.7999999999998" y="392" dominant-baseline="middle" font-size="16" text-anchor="start">-middleware: Middleware[]</text>
+        <text x="484.7999999999998" y="440" text-anchor="start" dominant-baseline="middle" font-size="16">+addRoute(route)</text>
+        <text x="484.7999999999998" y="464" text-anchor="start" dominant-baseline="middle" font-size="16">+use(middleware)</text>
+        <text x="484.7999999999998" y="488" font-size="16" text-anchor="start" dominant-baseline="middle">+handle(request) : Response</text>
+      </g>
+      <g class="class-node" id="class-Application">
+        <path d="M 100.19999999999996 0 H 293.4 A 3 3 0 0 1 296.4 3 V 213 A 3 3 0 0 1 293.4 216 H 100.19999999999996 A 3 3 0 0 1 97.19999999999996 213 V 3 A 3 3 0 0 1 100.19999999999996 0 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
+        <path d="M 100.19999999999996 0 H 293.4 A 3 3 0 0 1 296.4 3 V 213 A 3 3 0 0 1 293.4 216 H 100.19999999999996 A 3 3 0 0 1 97.19999999999996 213 V 3 A 3 3 0 0 1 100.19999999999996 0 Z" class="class-box" stroke-width="1" stroke="#333333" fill="none"/>
+        <path d="M 97.19999999999996 48 L 296.4 48" class="class-divider" stroke-width="1" stroke="#333333"/>
+        <path d="M 97.19999999999996 120 L 296.4 120" class="class-divider" stroke-width="1" stroke="#333333"/>
+        <text x="196.79999999999995" y="24" text-anchor="middle" dominant-baseline="middle" font-size="16" font-weight="bold">Application</text>
+        <text x="121.19999999999996" y="60" text-anchor="start" dominant-baseline="middle" font-size="16">-config: Config</text>
+        <text x="121.19999999999996" y="84" text-anchor="start" font-size="16" dominant-baseline="middle">-logger: Logger</text>
+        <text x="121.19999999999996" y="132" dominant-baseline="middle" font-size="16" text-anchor="start">+start()</text>
+        <text x="121.19999999999996" y="156" font-size="16" dominant-baseline="middle" text-anchor="start">+stop()</text>
+        <text x="121.19999999999996" y="180" dominant-baseline="middle" font-size="16" text-anchor="start">+getStatus() : Status</text>
+      </g>
+      <g class="class-node" id="class-UserRepository">
+        <path d="M 1127.3999999999996 1208 H 1303.7999999999997 A 3 3 0 0 1 1306.7999999999997 1211 V 1393 A 3 3 0 0 1 1303.7999999999997 1396 H 1127.3999999999996 A 3 3 0 0 1 1124.3999999999996 1393 V 1211 A 3 3 0 0 1 1127.3999999999996 1208 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
+        <path d="M 1127.3999999999996 1208 H 1303.7999999999997 A 3 3 0 0 1 1306.7999999999997 1211 V 1393 A 3 3 0 0 1 1303.7999999999997 1396 H 1127.3999999999996 A 3 3 0 0 1 1124.3999999999996 1393 V 1211 A 3 3 0 0 1 1127.3999999999996 1208 Z" class="class-box" stroke-width="1" fill="none" stroke="#333333"/>
+        <path d="M 1124.3999999999996 1276 L 1306.7999999999997 1276" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <path d="M 1124.3999999999996 1324 L 1306.7999999999997 1324" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="1215.5999999999997" y="1230.6666666666667" dominant-baseline="middle" font-size="16" text-anchor="middle" font-style="italic">«interface»</text>
+        <text x="1215.5999999999997" y="1253.3333333333335" dominant-baseline="middle" font-size="16" font-weight="bold" text-anchor="middle">UserRepository</text>
+        <text x="1148.3999999999996" y="1336" font-size="16" text-anchor="start" dominant-baseline="middle">+find(id) : User</text>
+        <text x="1148.3999999999996" y="1360" text-anchor="start" dominant-baseline="middle" font-size="16">+save(user) : User</text>
+        <text x="1148.3999999999996" y="1384" font-size="16" text-anchor="start" dominant-baseline="middle">+delete(id) : void</text>
+      </g>
+      <g class="class-node" id="class-UserService">
+        <path d="M 1097.3999999999996 912 H 1333.7999999999997 A 3 3 0 0 1 1336.7999999999997 915 V 1125 A 3 3 0 0 1 1333.7999999999997 1128 H 1097.3999999999996 A 3 3 0 0 1 1094.3999999999996 1125 V 915 A 3 3 0 0 1 1097.3999999999996 912 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
+        <path d="M 1097.3999999999996 912 H 1333.7999999999997 A 3 3 0 0 1 1336.7999999999997 915 V 1125 A 3 3 0 0 1 1333.7999999999997 1128 H 1097.3999999999996 A 3 3 0 0 1 1094.3999999999996 1125 V 915 A 3 3 0 0 1 1097.3999999999996 912 Z" class="class-box" stroke="#333333" stroke-width="1" fill="none"/>
+        <path d="M 1094.3999999999996 960 L 1336.7999999999997 960" class="class-divider" stroke-width="1" stroke="#333333"/>
+        <path d="M 1094.3999999999996 1032 L 1336.7999999999997 1032" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="1215.5999999999997" y="936" font-size="16" font-weight="bold" text-anchor="middle" dominant-baseline="middle">UserService</text>
+        <text x="1118.3999999999996" y="972" dominant-baseline="middle" text-anchor="start" font-size="16">-repository: UserRepository</text>
+        <text x="1118.3999999999996" y="996" font-size="16" text-anchor="start" dominant-baseline="middle">-cache: Cache</text>
+        <text x="1118.3999999999996" y="1044" font-size="16" text-anchor="start" dominant-baseline="middle">+findById(id) : User</text>
+        <text x="1118.3999999999996" y="1068" text-anchor="start" font-size="16" dominant-baseline="middle">+save(user) : User</text>
+        <text x="1118.3999999999996" y="1092" font-size="16" dominant-baseline="middle" text-anchor="start">+delete(id) : void</text>
+      </g>
+      <g class="class-node" id="class-Route">
+        <path d="M 482.5999999999998 640 H 661.3999999999997 A 3 3 0 0 1 664.3999999999997 643 V 805 A 3 3 0 0 1 661.3999999999997 808 H 482.5999999999998 A 3 3 0 0 1 479.5999999999998 805 V 643 A 3 3 0 0 1 482.5999999999998 640 Z" class="class-box-bg" stroke="none" fill="#ECECFF"/>
+        <path d="M 482.5999999999998 640 H 661.3999999999997 A 3 3 0 0 1 664.3999999999997 643 V 805 A 3 3 0 0 1 661.3999999999997 808 H 482.5999999999998 A 3 3 0 0 1 479.5999999999998 805 V 643 A 3 3 0 0 1 482.5999999999998 640 Z" class="class-box" stroke="#333333" stroke-width="1" fill="none"/>
+        <path d="M 479.5999999999998 688 L 664.3999999999997 688" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <path d="M 479.5999999999998 784 L 664.3999999999997 784" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="571.9999999999998" y="664" text-anchor="middle" font-size="16" font-weight="bold" dominant-baseline="middle">Route</text>
+        <text x="503.5999999999998" y="700" dominant-baseline="middle" font-size="16" text-anchor="start">+path: string</text>
+        <text x="503.5999999999998" y="724" font-size="16" text-anchor="start" dominant-baseline="middle">+method: HttpMethod</text>
+        <text x="503.5999999999998" y="748" dominant-baseline="middle" text-anchor="start" font-size="16">+handler: Handler</text>
+      </g>
+      <g class="class-node" id="class-Config">
+        <path d="M 2.9999999999999147 320 H 160.1999999999999 A 3 3 0 0 1 163.1999999999999 323 V 509 A 3 3 0 0 1 160.1999999999999 512 H 2.9999999999999147 A 3 3 0 0 1 -0.00000000000008526512829121202 509 V 323 A 3 3 0 0 1 2.9999999999999147 320 Z" class="class-box-bg" fill="#ECECFF" stroke="none"/>
+        <path d="M 2.9999999999999147 320 H 160.1999999999999 A 3 3 0 0 1 163.1999999999999 323 V 509 A 3 3 0 0 1 160.1999999999999 512 H 2.9999999999999147 A 3 3 0 0 1 -0.00000000000008526512829121202 509 V 323 A 3 3 0 0 1 2.9999999999999147 320 Z" class="class-box" stroke-width="1" fill="none" stroke="#333333"/>
+        <path d="M -0.00000000000008526512829121202 368 L 163.1999999999999 368" class="class-divider" stroke-width="1" stroke="#333333"/>
+        <path d="M -0.00000000000008526512829121202 416 L 163.1999999999999 416" class="class-divider" stroke="#333333" stroke-width="1"/>
+        <text x="81.59999999999991" y="344" font-size="16" font-weight="bold" text-anchor="middle" dominant-baseline="middle">Config</text>
+        <text x="23.999999999999915" y="380" dominant-baseline="middle" font-size="16" text-anchor="start">-settings: Map</text>
+        <text x="23.999999999999915" y="428" font-size="16" text-anchor="start" dominant-baseline="middle">+get(key) : any</text>
+        <text x="23.999999999999915" y="452" dominant-baseline="middle" font-size="16" text-anchor="start">+set(key, value)</text>
+        <text x="23.999999999999915" y="476" font-size="16" text-anchor="start" dominant-baseline="middle">+load(path)</text>
       </g>
     </g>
   </g>


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Regenerate class diagram SVGs with latest rendering
- Verified z-order is already correct (shapes before text) in class renderer

The z-order task (#26) was based on stale analysis - the class renderer already has correct z-order at `src/render/class.rs` lines 449-451. Eval confirms no z_order issues detected.

## Changes
- `docs/images/class.svg`: Regenerated with latest rendering  
- `docs/images/class_complex.svg`: Regenerated with latest rendering

## Test plan
- [x] `cargo test --features all-formats` passes
- [x] `cargo clippy --features all-formats -- -D warnings` passes
- [x] Class diagram eval shows no z_order issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)