### PR TITLE
docs(er): regenerate ER diagram SVGs

### DIFF
--- a/docs/images/er.svg
+++ b/docs/images/er.svg
@@ -184,57 +184,57 @@ marker path {
 
     </g>
     <g class="relationship">
-      <path d="M 107.10 187.00 C 107.10 202.00, 107.10 217.00, 107.10 232.00 C 107.10 247.00, 107.10 262.00, 107.10 277.00" class="relationshipLine" marker-end="url(#er-zeroOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
-      <rect x="82.10000000000001" y="220" width="50" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="107.10000000000001" y="236" class="relationship-label" text-anchor="middle" font-size="14">places</text>
+      <path d="M 107.10 187.00 C 107.10 202.00, 107.10 217.00, 107.10 232.00 C 107.10 247.00, 107.10 262.00, 107.10 277.00" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrMoreEnd)"/>
+      <rect x="82.10000000000002" y="220" width="50" height="23" rx="0" ry="0" class="relationship-label-background"/>
+      <text x="107.10000000000002" y="236" class="relationship-label" text-anchor="middle" font-size="14">places</text>
     </g>
     <g class="relationship">
-      <path d="M 107.10 464.00 C 107.10 479.00, 107.10 494.00, 118.42 513.90 C 129.75 533.79, 152.40 558.58, 175.05 583.38" class="relationshipLine" marker-end="url(#er-oneOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
-      <rect x="93.89877665158487" y="517.5762915888392" width="64" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="125.89877665158487" y="533.5762915888392" class="relationship-label" font-size="14" text-anchor="middle">contains</text>
+      <path d="M 107.10 464.00 C 107.10 479.00, 107.10 494.00, 118.43 513.90 C 129.75 533.79, 152.40 558.58, 175.05 583.38" class="relationshipLine" marker-end="url(#er-oneOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
+      <rect x="93.89877665158488" y="517.5762915888392" width="64" height="23" rx="0" ry="0" class="relationship-label-background"/>
+      <text x="125.89877665158488" y="533.5762915888392" class="relationship-label" font-size="14" text-anchor="middle">contains</text>
     </g>
     <g class="relationship">
-      <path d="M 372.90 464.00 C 372.90 479.00, 372.90 494.00, 361.58 513.90 C 350.25 533.79, 327.60 558.58, 304.95 583.38" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrMoreEnd)"/>
-      <rect x="322.10122334841515" y="517.5762915888392" width="64" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="354.10122334841515" y="533.5762915888392" class="relationship-label" font-size="14" text-anchor="middle">includes</text>
+      <path d="M 372.90 464.00 C 372.90 479.00, 372.90 494.00, 361.58 513.90 C 350.25 533.79, 327.60 558.58, 304.95 583.38" class="relationshipLine" marker-end="url(#er-zeroOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
+      <rect x="322.1012233484152" y="517.5762915888392" width="64" height="23" rx="0" ry="0" class="relationship-label-background"/>
+      <text x="354.1012233484152" y="533.5762915888392" class="relationship-label" font-size="14" text-anchor="middle">includes</text>
     </g>
     <g class="entity-node" id="entity-CUSTOMER-0">
-      <rect x="15.599999999999994" y="0" width="183.00000000000003" height="187" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
-      <rect x="15.599999999999994" y="42.75" width="183.00000000000003" height="42.75" rx="0" ry="0" class="row-rect-odd" stroke-width="1.3"/>
-      <rect x="15.599999999999994" y="85.5" width="183.00000000000003" height="42.75" rx="0" ry="0" class="row-rect-even" stroke-width="1.3"/>
-      <rect x="15.599999999999994" y="128.25" width="183.00000000000003" height="42.75" rx="0" ry="0" class="row-rect-odd" stroke-width="1.3"/>
-      <line x1="15.599999999999994" y1="42.75" x2="198.60000000000002" y2="42.75" class="divider" stroke-width="1.3"/>
-      <line x1="84.4" y1="42.75" x2="84.4" y2="187" class="divider" stroke-width="1.3"/>
-      <line x1="161" y1="42.75" x2="161" y2="187" class="divider" stroke-width="1.3"/>
-      <text x="107.10000000000001" y="26.375" class="entity-name" text-anchor="middle" font-size="14">CUSTOMER</text>
-      <text x="27.599999999999994" y="68.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="96.4" y="68.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">name</text>
-      <text x="27.599999999999994" y="110.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
-      <text x="96.4" y="110.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">email</text>
-      <text x="173" y="110.875" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
-      <text x="27.599999999999994" y="153.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="96.4" y="153.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">address</text>
+      <rect x="15.600000000000009" y="0" width="183.00000000000003" height="187" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
+      <rect x="15.600000000000009" y="42.75" width="183.00000000000003" height="42.75" rx="0" ry="0" class="row-rect-odd" stroke-width="1.3"/>
+      <rect x="15.600000000000009" y="85.5" width="183.00000000000003" height="42.75" rx="0" ry="0" class="row-rect-even" stroke-width="1.3"/>
+      <rect x="15.600000000000009" y="128.25" width="183.00000000000003" height="42.75" rx="0" ry="0" class="row-rect-odd" stroke-width="1.3"/>
+      <line x1="15.600000000000009" y1="42.75" x2="198.60000000000002" y2="42.75" class="divider" stroke-width="1.3"/>
+      <line x1="84.40000000000002" y1="42.75" x2="84.40000000000002" y2="187" class="divider" stroke-width="1.3"/>
+      <line x1="161.00000000000003" y1="42.75" x2="161.00000000000003" y2="187" class="divider" stroke-width="1.3"/>
+      <text x="107.10000000000002" y="26.375" class="entity-name" text-anchor="middle" font-size="14">CUSTOMER</text>
+      <text x="27.60000000000001" y="68.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
+      <text x="96.40000000000002" y="68.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">name</text>
+      <text x="27.60000000000001" y="110.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
+      <text x="96.40000000000002" y="110.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">email</text>
+      <text x="173.00000000000003" y="110.875" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
+      <text x="27.60000000000001" y="153.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
+      <text x="96.40000000000002" y="153.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">address</text>
     </g>
     <g class="entity-node" id="entity-LINE-ITEM-2">
-      <rect x="175.05" y="554" width="129.89999999999998" height="58.75" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
-      <text x="240" y="588.375" class="entity-name" font-size="14" text-anchor="middle">LINE-ITEM</text>
+      <rect x="175.05000000000004" y="554" width="129.89999999999998" height="58.75" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
+      <text x="240.00000000000003" y="588.375" class="entity-name" font-size="14" text-anchor="middle">LINE-ITEM</text>
     </g>
     <g class="entity-node" id="entity-ORDER-1">
-      <rect x="0" y="277" width="214.20000000000002" height="187" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
-      <rect x="0" y="319.75" width="214.20000000000002" height="42.75" rx="0" ry="0" class="row-rect-odd" stroke-width="1.3"/>
-      <rect x="0" y="362.5" width="214.20000000000002" height="42.75" rx="0" ry="0" class="row-rect-even" stroke-width="1.3"/>
-      <rect x="0" y="405.25" width="214.20000000000002" height="42.75" rx="0" ry="0" class="row-rect-odd" stroke-width="1.3"/>
-      <line x1="0" y1="319.75" x2="214.20000000000002" y2="319.75" class="divider" stroke-width="1.3"/>
-      <line x1="68.80000000000001" y1="319.75" x2="68.80000000000001" y2="464" class="divider" stroke-width="1.3"/>
+      <rect x="0.000000000000014210854715202004" y="277" width="214.20000000000002" height="187" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
+      <rect x="0.000000000000014210854715202004" y="319.75" width="214.20000000000002" height="42.75" rx="0" ry="0" class="row-rect-odd" stroke-width="1.3"/>
+      <rect x="0.000000000000014210854715202004" y="362.5" width="214.20000000000002" height="42.75" rx="0" ry="0" class="row-rect-even" stroke-width="1.3"/>
+      <rect x="0.000000000000014210854715202004" y="405.25" width="214.20000000000002" height="42.75" rx="0" ry="0" class="row-rect-odd" stroke-width="1.3"/>
+      <line x1="0.000000000000014210854715202004" y1="319.75" x2="214.20000000000005" y2="319.75" class="divider" stroke-width="1.3"/>
+      <line x1="68.80000000000003" y1="319.75" x2="68.80000000000003" y2="464" class="divider" stroke-width="1.3"/>
       <line x1="176.60000000000002" y1="319.75" x2="176.60000000000002" y2="464" class="divider" stroke-width="1.3"/>
-      <text x="107.10000000000001" y="303.375" class="entity-name" font-size="14" text-anchor="middle">ORDER</text>
-      <text x="12" y="345.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">int</text>
-      <text x="80.80000000000001" y="345.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">orderNumber</text>
+      <text x="107.10000000000002" y="303.375" class="entity-name" text-anchor="middle" font-size="14">ORDER</text>
+      <text x="12.000000000000014" y="345.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">int</text>
+      <text x="80.80000000000003" y="345.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">orderNumber</text>
       <text x="188.60000000000002" y="345.125" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
-      <text x="12" y="387.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">date</text>
-      <text x="80.80000000000001" y="387.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">orderDate</text>
-      <text x="12" y="430.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="80.80000000000001" y="430.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">status</text>
+      <text x="12.000000000000014" y="387.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">date</text>
+      <text x="80.80000000000003" y="387.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">orderDate</text>
+      <text x="12.000000000000014" y="430.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
+      <text x="80.80000000000003" y="430.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">status</text>
     </g>
     <g class="entity-node" id="entity-PRODUCT-3">
       <rect x="289.20000000000005" y="277" width="167.4" height="187" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -246,12 +246,12 @@ marker path {
       <line x1="419.00000000000006" y1="319.75" x2="419.00000000000006" y2="464" class="divider" stroke-width="1.3"/>
       <text x="372.90000000000003" y="303.375" class="entity-name" text-anchor="middle" font-size="14">PRODUCT</text>
       <text x="301.20000000000005" y="345.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">int</text>
-      <text x="370.00000000000006" y="345.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
-      <text x="431.00000000000006" y="345.125" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
+      <text x="370.00000000000006" y="345.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">id</text>
+      <text x="431.00000000000006" y="345.125" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
       <text x="301.20000000000005" y="387.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
       <text x="370.00000000000006" y="387.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">name</text>
       <text x="301.20000000000005" y="430.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">float</text>
-      <text x="370.00000000000006" y="430.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">price</text>
+      <text x="370.00000000000006" y="430.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">price</text>
     </g>
   </g>
 </svg>

--- a/docs/images/er_complex.svg
+++ b/docs/images/er_complex.svg
@@ -184,19 +184,19 @@ marker path {
 
     </g>
     <g class="relationship">
-      <path d="M 402.35 315.25 C 371.77 330.25, 341.18 345.25, 344.39 386.52 C 347.60 427.79, 384.60 495.33, 421.60 562.88" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrMoreEnd)"/>
+      <path d="M 402.35 315.25 C 371.77 330.25, 341.18 345.25, 344.39 386.52 C 347.60 427.79, 384.60 495.33, 421.60 562.88" class="relationshipLine" marker-end="url(#er-zeroOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
       <rect x="316.5514289110196" y="404.75029984770583" width="50" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="341.5514289110196" y="420.75029984770583" class="relationship-label" font-size="14" text-anchor="middle">places</text>
+      <text x="341.5514289110196" y="420.75029984770583" class="relationship-label" text-anchor="middle" font-size="14">places</text>
     </g>
     <g class="relationship">
       <path d="M 310.60 720.50 C 244.07 735.50, 177.53 750.50, 162.12 798.90 C 146.70 847.29, 182.40 929.08, 218.10 1010.88" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-oneOrMoreEnd)"/>
       <rect x="91.62497313238042" y="782.4248625803721" width="64" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="123.62497313238042" y="798.4248625803721" class="relationship-label" text-anchor="middle" font-size="14">contains</text>
+      <text x="123.62497313238042" y="798.4248625803721" class="relationship-label" font-size="14" text-anchor="middle">contains</text>
     </g>
     <g class="relationship">
       <path d="M 111.00 1147.12 C 111.00 1183.50, 111.00 1219.88, 111.00 1245.56 C 111.00 1271.25, 111.00 1286.25, 111.00 1301.25" class="relationshipLine" marker-start="url(#er-oneOrMoreStart)" marker-end="url(#er-onlyOneEnd)"/>
       <rect x="72" y="1212.1875" width="78" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="111" y="1228.1875" class="relationship-label" text-anchor="middle" font-size="14">references</text>
+      <text x="111" y="1228.1875" class="relationship-label" font-size="14" text-anchor="middle">references</text>
     </g>
     <g class="relationship">
       <path d="M 111.00 1659.25 L 55.00 1821.38" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrMoreEnd)"/>
@@ -204,12 +204,12 @@ marker path {
       <text x="92.70544891558119" y="1746.5133802814742" class="relationship-label" text-anchor="middle" font-size="14">belongs_to</text>
     </g>
     <g class="relationship">
-      <path d="M 400.20 1595.12 C 400.20 1631.50, 400.20 1667.88, 379.67 1705.58 C 359.13 1743.29, 318.07 1782.33, 277.00 1821.38" class="relationshipLine" marker-end="url(#er-zeroOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
+      <path d="M 400.20 1595.12 C 400.20 1631.50, 400.20 1667.88, 379.67 1705.58 C 359.13 1743.29, 318.07 1782.33, 277.00 1821.38" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrMoreEnd)"/>
       <rect x="346.14415547206784" y="1713.218269402062" width="64" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="378.14415547206784" y="1729.218269402062" class="relationship-label" text-anchor="middle" font-size="14">contains</text>
+      <text x="378.14415547206784" y="1729.218269402062" class="relationship-label" font-size="14" text-anchor="middle">contains</text>
     </g>
     <g class="relationship">
-      <path d="M 402.35 315.25 C 511.52 330.25, 620.68 345.25, 675.27 420.29 C 729.85 495.33, 729.85 630.42, 674.91 705.46 C 510.08 795.50, 400.20 810.50, 400.20 810.50" class="relationshipLine" marker-end="url(#er-zeroOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
+      <path d="M 402.35 315.25 C 511.52 330.25, 620.68 345.25, 675.27 420.29 C 729.85 495.33, 729.85 630.42, 674.91 705.46 C 510.08 795.50, 400.20 810.50, 400.20 810.50" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrMoreEnd)"/>
       <rect x="715.35" y="551.9400578245252" width="29" height="23" rx="0" ry="0" class="relationship-label-background"/>
       <text x="729.85" y="567.9400578245252" class="relationship-label" font-size="14" text-anchor="middle">has</text>
     </g>
@@ -219,9 +219,9 @@ marker path {
       <text x="303.45062112118006" y="869.7445052794545" class="relationship-label" text-anchor="middle" font-size="14">ships_to</text>
     </g>
     <g class="relationship">
-      <path d="M 310.60 720.50 C 409.60 735.50, 508.60 750.50, 553.88 798.90 C 599.17 847.29, 590.73 929.08, 582.30 1010.88" class="relationshipLine" marker-end="url(#er-zeroOrOneEnd)" marker-start="url(#er-onlyOneStart)"/>
+      <path d="M 310.60 720.50 C 409.60 735.50, 508.60 750.50, 553.88 798.90 C 599.17 847.29, 590.73 929.08, 582.30 1010.88" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrOneEnd)"/>
       <rect x="552.5461243697141" y="749.4766855105627" width="57" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="581.0461243697141" y="765.4766855105627" class="relationship-label" font-size="14" text-anchor="middle">paid_by</text>
+      <text x="581.0461243697141" y="765.4766855105627" class="relationship-label" text-anchor="middle" font-size="14">paid_by</text>
     </g>
     <g class="entity-node" id="entity-ADDRESS-6">
       <rect x="293.1" y="810.5" width="214.20000000000002" height="400.75" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -236,25 +236,25 @@ marker path {
       <line x1="293.1" y1="853.25" x2="507.30000000000007" y2="853.25" class="divider" stroke-width="1.3"/>
       <line x1="361.90000000000003" y1="853.25" x2="361.90000000000003" y2="1211.25" class="divider" stroke-width="1.3"/>
       <line x1="469.70000000000005" y1="853.25" x2="469.70000000000005" y2="1211.25" class="divider" stroke-width="1.3"/>
-      <text x="400.20000000000005" y="836.875" class="entity-name" font-size="14" text-anchor="middle">ADDRESS</text>
+      <text x="400.20000000000005" y="836.875" class="entity-name" text-anchor="middle" font-size="14">ADDRESS</text>
       <text x="305.1" y="878.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
       <text x="373.90000000000003" y="878.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
-      <text x="481.70000000000005" y="878.625" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
-      <text x="305.1" y="921.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
-      <text x="373.90000000000003" y="921.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">customer_id</text>
-      <text x="481.70000000000005" y="921.375" class="entity-attr attribute-key" text-anchor="start" font-size="12">FK</text>
-      <text x="305.1" y="964.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
+      <text x="481.70000000000005" y="878.625" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
+      <text x="305.1" y="921.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
+      <text x="373.90000000000003" y="921.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">customer_id</text>
+      <text x="481.70000000000005" y="921.375" class="entity-attr attribute-key" font-size="12" text-anchor="start">FK</text>
+      <text x="305.1" y="964.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
       <text x="373.90000000000003" y="964.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">type</text>
       <text x="305.1" y="1006.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="373.90000000000003" y="1006.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">street</text>
-      <text x="305.1" y="1049.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="373.90000000000003" y="1049.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">city</text>
+      <text x="373.90000000000003" y="1006.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">street</text>
+      <text x="305.1" y="1049.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
+      <text x="373.90000000000003" y="1049.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">city</text>
       <text x="305.1" y="1092.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
-      <text x="373.90000000000003" y="1092.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">state</text>
+      <text x="373.90000000000003" y="1092.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">state</text>
       <text x="305.1" y="1135.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="373.90000000000003" y="1135.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">zip</text>
+      <text x="373.90000000000003" y="1135.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">zip</text>
       <text x="305.1" y="1177.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="373.90000000000003" y="1177.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">country</text>
+      <text x="373.90000000000003" y="1177.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">country</text>
     </g>
     <g class="entity-node" id="entity-CATEGORY-5">
       <rect x="297" y="1365.375" width="206.4" height="229.75" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -265,16 +265,16 @@ marker path {
       <line x1="297" y1="1408.125" x2="503.4" y2="1408.125" class="divider" stroke-width="1.3"/>
       <line x1="365.8" y1="1408.125" x2="365.8" y2="1595.125" class="divider" stroke-width="1.3"/>
       <line x1="465.8" y1="1408.125" x2="465.8" y2="1595.125" class="divider" stroke-width="1.3"/>
-      <text x="400.2" y="1391.75" class="entity-name" font-size="14" text-anchor="middle">CATEGORY</text>
-      <text x="309" y="1433.5" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
+      <text x="400.2" y="1391.75" class="entity-name" text-anchor="middle" font-size="14">CATEGORY</text>
+      <text x="309" y="1433.5" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
       <text x="377.8" y="1433.5" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
       <text x="477.8" y="1433.5" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
-      <text x="309" y="1476.25" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
-      <text x="377.8" y="1476.25" class="entity-attr attribute-name" text-anchor="start" font-size="12">name</text>
-      <text x="477.8" y="1476.25" class="entity-attr attribute-key" font-size="12" text-anchor="start">UK</text>
+      <text x="309" y="1476.25" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
+      <text x="377.8" y="1476.25" class="entity-attr attribute-name" font-size="12" text-anchor="start">name</text>
+      <text x="477.8" y="1476.25" class="entity-attr attribute-key" text-anchor="start" font-size="12">UK</text>
       <text x="309" y="1519" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
       <text x="377.8" y="1519" class="entity-attr attribute-name" text-anchor="start" font-size="12">parent_id</text>
-      <text x="477.8" y="1519" class="entity-attr attribute-key" font-size="12" text-anchor="start">FK</text>
+      <text x="477.8" y="1519" class="entity-attr attribute-key" text-anchor="start" font-size="12">FK</text>
       <text x="309" y="1561.75" class="entity-attr attribute-type" font-size="12" text-anchor="start">int</text>
       <text x="377.8" y="1561.75" class="entity-attr attribute-name" font-size="12" text-anchor="start">sort_order</text>
     </g>
@@ -290,19 +290,19 @@ marker path {
       <line x1="371.85" y1="42.75" x2="371.85" y2="315.25" class="divider" stroke-width="1.3"/>
       <line x1="471.85" y1="42.75" x2="471.85" y2="315.25" class="divider" stroke-width="1.3"/>
       <text x="402.35" y="26.375" class="entity-name" text-anchor="middle" font-size="14">CUSTOMER</text>
-      <text x="307.25" y="68.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
+      <text x="307.25" y="68.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
       <text x="383.85" y="68.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
-      <text x="483.85" y="68.125" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
+      <text x="483.85" y="68.125" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
       <text x="307.25" y="110.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="383.85" y="110.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">email</text>
+      <text x="383.85" y="110.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">email</text>
       <text x="483.85" y="110.875" class="entity-attr attribute-key" text-anchor="start" font-size="12">UK</text>
       <text x="307.25" y="153.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="383.85" y="153.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">name</text>
-      <text x="307.25" y="196.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
-      <text x="383.85" y="196.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">phone</text>
-      <text x="307.25" y="239.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">date</text>
+      <text x="383.85" y="153.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">name</text>
+      <text x="307.25" y="196.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
+      <text x="383.85" y="196.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">phone</text>
+      <text x="307.25" y="239.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">date</text>
       <text x="383.85" y="239.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">created_at</text>
-      <text x="307.25" y="281.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">boolean</text>
+      <text x="307.25" y="281.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">boolean</text>
       <text x="383.85" y="281.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">active</text>
     </g>
     <g class="entity-node" id="entity-ORDER-1">
@@ -318,19 +318,19 @@ marker path {
       <line x1="384.00000000000006" y1="448" x2="384.00000000000006" y2="720.5" class="divider" stroke-width="1.3"/>
       <text x="310.6" y="431.625" class="entity-name" text-anchor="middle" font-size="14">ORDER</text>
       <text x="211.60000000000002" y="473.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
-      <text x="288.20000000000005" y="473.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
-      <text x="396.00000000000006" y="473.375" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
-      <text x="211.60000000000002" y="516.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
-      <text x="288.20000000000005" y="516.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">customer_id</text>
-      <text x="396.00000000000006" y="516.125" class="entity-attr attribute-key" font-size="12" text-anchor="start">FK</text>
-      <text x="211.60000000000002" y="558.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">decimal</text>
-      <text x="288.20000000000005" y="558.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">total</text>
+      <text x="288.20000000000005" y="473.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">id</text>
+      <text x="396.00000000000006" y="473.375" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
+      <text x="211.60000000000002" y="516.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
+      <text x="288.20000000000005" y="516.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">customer_id</text>
+      <text x="396.00000000000006" y="516.125" class="entity-attr attribute-key" text-anchor="start" font-size="12">FK</text>
+      <text x="211.60000000000002" y="558.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">decimal</text>
+      <text x="288.20000000000005" y="558.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">total</text>
       <text x="211.60000000000002" y="601.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
-      <text x="288.20000000000005" y="601.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">status</text>
+      <text x="288.20000000000005" y="601.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">status</text>
       <text x="211.60000000000002" y="644.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">date</text>
-      <text x="288.20000000000005" y="644.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">ordered_at</text>
-      <text x="211.60000000000002" y="687.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">date</text>
-      <text x="288.20000000000005" y="687.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">shipped_at</text>
+      <text x="288.20000000000005" y="644.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">ordered_at</text>
+      <text x="211.60000000000002" y="687.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">date</text>
+      <text x="288.20000000000005" y="687.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">shipped_at</text>
     </g>
     <g class="entity-node" id="entity-ORDER_ITEM-2">
       <rect x="3.8999999999999915" y="874.625" width="214.20000000000002" height="272.5" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -342,17 +342,17 @@ marker path {
       <line x1="3.8999999999999915" y1="917.375" x2="218.10000000000002" y2="917.375" class="divider" stroke-width="1.3"/>
       <line x1="80.5" y1="917.375" x2="80.5" y2="1147.125" class="divider" stroke-width="1.3"/>
       <line x1="180.5" y1="917.375" x2="180.5" y2="1147.125" class="divider" stroke-width="1.3"/>
-      <text x="111" y="901" class="entity-name" font-size="14" text-anchor="middle">ORDER_ITEM</text>
-      <text x="15.899999999999991" y="942.75" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
+      <text x="111" y="901" class="entity-name" text-anchor="middle" font-size="14">ORDER_ITEM</text>
+      <text x="15.899999999999991" y="942.75" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
       <text x="92.5" y="942.75" class="entity-attr attribute-name" font-size="12" text-anchor="start">id</text>
       <text x="192.5" y="942.75" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
       <text x="15.899999999999991" y="985.5" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
-      <text x="92.5" y="985.5" class="entity-attr attribute-name" font-size="12" text-anchor="start">order_id</text>
-      <text x="192.5" y="985.5" class="entity-attr attribute-key" text-anchor="start" font-size="12">FK</text>
-      <text x="15.899999999999991" y="1028.25" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
+      <text x="92.5" y="985.5" class="entity-attr attribute-name" text-anchor="start" font-size="12">order_id</text>
+      <text x="192.5" y="985.5" class="entity-attr attribute-key" font-size="12" text-anchor="start">FK</text>
+      <text x="15.899999999999991" y="1028.25" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
       <text x="92.5" y="1028.25" class="entity-attr attribute-name" text-anchor="start" font-size="12">product_id</text>
       <text x="192.5" y="1028.25" class="entity-attr attribute-key" text-anchor="start" font-size="12">FK</text>
-      <text x="15.899999999999991" y="1071" class="entity-attr attribute-type" text-anchor="start" font-size="12">int</text>
+      <text x="15.899999999999991" y="1071" class="entity-attr attribute-type" font-size="12" text-anchor="start">int</text>
       <text x="92.5" y="1071" class="entity-attr attribute-name" text-anchor="start" font-size="12">quantity</text>
       <text x="15.899999999999991" y="1113.75" class="entity-attr attribute-type" font-size="12" text-anchor="start">decimal</text>
       <text x="92.5" y="1113.75" class="entity-attr attribute-name" text-anchor="start" font-size="12">price</text>
@@ -373,16 +373,16 @@ marker path {
       <text x="670.9000000000001" y="921.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
       <text x="786.5000000000001" y="921.375" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
       <text x="594.3000000000001" y="964.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
-      <text x="670.9000000000001" y="964.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">order_id</text>
-      <text x="786.5000000000001" y="964.125" class="entity-attr attribute-key" text-anchor="start" font-size="12">FK</text>
+      <text x="670.9000000000001" y="964.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">order_id</text>
+      <text x="786.5000000000001" y="964.125" class="entity-attr attribute-key" font-size="12" text-anchor="start">FK</text>
       <text x="594.3000000000001" y="1006.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
-      <text x="670.9000000000001" y="1006.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">method</text>
+      <text x="670.9000000000001" y="1006.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">method</text>
       <text x="594.3000000000001" y="1049.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">decimal</text>
-      <text x="670.9000000000001" y="1049.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">amount</text>
-      <text x="594.3000000000001" y="1092.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="670.9000000000001" y="1092.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">status</text>
-      <text x="594.3000000000001" y="1135.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">date</text>
-      <text x="670.9000000000001" y="1135.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">processed_at</text>
+      <text x="670.9000000000001" y="1049.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">amount</text>
+      <text x="594.3000000000001" y="1092.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
+      <text x="670.9000000000001" y="1092.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">status</text>
+      <text x="594.3000000000001" y="1135.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">date</text>
+      <text x="670.9000000000001" y="1135.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">processed_at</text>
     </g>
     <g class="entity-node" id="entity-PRODUCT-3">
       <rect x="-0.000000000000014210854715202004" y="1301.25" width="222.00000000000003" height="358" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -398,21 +398,21 @@ marker path {
       <line x1="184.4" y1="1344" x2="184.4" y2="1659.25" class="divider" stroke-width="1.3"/>
       <text x="111" y="1327.625" class="entity-name" text-anchor="middle" font-size="14">PRODUCT</text>
       <text x="11.999999999999986" y="1369.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
-      <text x="88.6" y="1369.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
+      <text x="88.6" y="1369.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">id</text>
       <text x="196.4" y="1369.375" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
-      <text x="11.999999999999986" y="1412.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="88.6" y="1412.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">sku</text>
-      <text x="196.4" y="1412.125" class="entity-attr attribute-key" font-size="12" text-anchor="start">UK</text>
-      <text x="11.999999999999986" y="1454.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
+      <text x="11.999999999999986" y="1412.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
+      <text x="88.6" y="1412.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">sku</text>
+      <text x="196.4" y="1412.125" class="entity-attr attribute-key" text-anchor="start" font-size="12">UK</text>
+      <text x="11.999999999999986" y="1454.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
       <text x="88.6" y="1454.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">name</text>
-      <text x="11.999999999999986" y="1497.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">text</text>
-      <text x="88.6" y="1497.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">description</text>
+      <text x="11.999999999999986" y="1497.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">text</text>
+      <text x="88.6" y="1497.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">description</text>
       <text x="11.999999999999986" y="1540.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">decimal</text>
-      <text x="88.6" y="1540.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">price</text>
+      <text x="88.6" y="1540.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">price</text>
       <text x="11.999999999999986" y="1583.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">int</text>
       <text x="88.6" y="1583.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">stock</text>
       <text x="11.999999999999986" y="1625.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">boolean</text>
-      <text x="88.6" y="1625.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">available</text>
+      <text x="88.6" y="1625.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">available</text>
     </g>
     <g class="entity-node" id="entity-PRODUCT_CATEGORY-4">
       <rect x="55" y="1749.25" width="222" height="144.25" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -421,12 +421,12 @@ marker path {
       <line x1="55" y1="1792" x2="277" y2="1792" class="divider" stroke-width="1.3"/>
       <line x1="108.2" y1="1792" x2="108.2" y2="1893.5" class="divider" stroke-width="1.3"/>
       <line x1="216" y1="1792" x2="216" y2="1893.5" class="divider" stroke-width="1.3"/>
-      <text x="166" y="1775.625" class="entity-name" font-size="14" text-anchor="middle">PRODUCT_CATEGORY</text>
-      <text x="67" y="1817.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
-      <text x="120.2" y="1817.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">product_id</text>
-      <text x="228" y="1817.375" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK,FK</text>
+      <text x="166" y="1775.625" class="entity-name" text-anchor="middle" font-size="14">PRODUCT_CATEGORY</text>
+      <text x="67" y="1817.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
+      <text x="120.2" y="1817.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">product_id</text>
+      <text x="228" y="1817.375" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK,FK</text>
       <text x="67" y="1860.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
-      <text x="120.2" y="1860.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">category_id</text>
+      <text x="120.2" y="1860.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">category_id</text>
       <text x="228" y="1860.125" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK,FK</text>
     </g>
   </g>


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Regenerate ER diagram SVGs with latest rendering
- Verified z-order is already correct (shapes before text) in ER renderer

The z-order task (#27) was based on stale analysis - the ER renderer already has correct z-order at `src/render/er.rs` lines 762-799. Eval confirms no z_order issues detected.

## Changes
- `docs/images/er.svg`: Regenerated with latest rendering  
- `docs/images/er_complex.svg`: Regenerated with latest rendering

## Test plan
- [x] `cargo test --features all-formats` passes
- [x] `cargo clippy --features all-formats -- -D warnings` passes
- [x] ER diagram eval shows no z_order issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)