### PR TITLE
docs(treemap): regenerate treemap diagram SVGs

### DIFF
--- a/docs/images/treemap.svg
+++ b/docs/images/treemap.svg
@@ -47,51 +47,51 @@
       <g class="treemapContainer">
         <g class="treemapSections">
           <g class="treemapSection">
-            <rect x="0" y="0" width="960" height="25" class="treemapSectionHeader" fill-opacity="0.6" stroke-width="0.6" style="display: none;" fill="none"/>
+            <rect x="0" y="0" width="960" height="25" class="treemapSectionHeader" fill-opacity="0.6" style="display: none;" stroke-width="0.6" fill="none"/>
             <clipPath id="clip-section-0"><rect width="948" height="25"/></clipPath>
-            <rect x="0" y="0" width="960" height="371" class="treemapSection section0" stroke-width="2" stroke="transparent" style="display: none;" fill-opacity="0.6" fill="transparent" stroke-opacity="0.4"/>
+            <rect x="0" y="0" width="960" height="371" class="treemapSection section0" stroke-width="2" fill="transparent" fill-opacity="0.6" stroke="transparent" stroke-opacity="0.4" style="display: none;"/>
             <text x="6" y="12.5" class="treemapSectionLabel" font-weight="bold" dominant-baseline="middle" style="display: none;"></text>
-            <text x="950" y="12.5" class="treemapSectionValue" style="display: none;" font-style="italic" dominant-baseline="middle" text-anchor="end">70</text>
+            <text x="950" y="12.5" class="treemapSectionValue" font-style="italic" style="display: none;" dominant-baseline="middle" text-anchor="end">70</text>
           </g>
           <g class="treemapSection section-0">
-            <rect x="10" y="35" width="537.1428571428571" height="326" class="treemapSection section-0" stroke-width="2" fill="hsl(240, 100%, 76.2745098039%)" stroke-opacity="0.4" stroke="hsl(240, 100%, 61.2745098039%)" fill-opacity="0.6"/>
+            <rect x="10" y="35" width="537.1428571428571" height="326" class="treemapSection section-0" stroke-width="2" stroke="hsl(240, 100%, 61.2745098039%)" fill-opacity="0.6" fill="hsl(240, 100%, 76.2745098039%)" stroke-opacity="0.4"/>
             <rect x="10" y="35" width="537.1428571428571" height="25" class="treemapSectionHeader" fill="none" stroke-width="0"/>
             <clipPath id="clip-section-1"><rect width="525.1428571428571" height="25"/></clipPath>
-            <text x="16" y="47.5" class="treemapSectionLabel section-0" font-weight="bold" fill="#ffffff" font-size="12px" dominant-baseline="middle">Category B</text>
-            <text x="537.1428571428571" y="47.5" class="treemapSectionValue section-0" fill="#ffffff" font-style="italic" text-anchor="end" dominant-baseline="middle" font-size="10px">40</text>
+            <text x="16" y="47.5" class="treemapSectionLabel section-0" dominant-baseline="middle" fill="#ffffff" font-size="12px" font-weight="bold">Category B</text>
+            <text x="537.1428571428571" y="47.5" class="treemapSectionValue section-0" text-anchor="end" font-size="10px" font-style="italic" fill="#ffffff" dominant-baseline="middle">40</text>
           </g>
           <g class="treemapSection section-1">
-            <rect x="547.1428571428571" y="35" width="402.8571428571429" height="326" class="treemapSection section-1" fill-opacity="0.6" fill="hsl(60, 100%, 73.5294117647%)" stroke-width="2" stroke="hsl(60, 100%, 48.5294117647%)" stroke-opacity="0.4"/>
-            <rect x="547.1428571428571" y="35" width="402.8571428571429" height="25" class="treemapSectionHeader" fill="none" stroke-width="0"/>
+            <rect x="547.1428571428571" y="35" width="402.8571428571429" height="326" class="treemapSection section-1" fill-opacity="0.6" stroke-width="2" stroke-opacity="0.4" stroke="hsl(60, 100%, 48.5294117647%)" fill="hsl(60, 100%, 73.5294117647%)"/>
+            <rect x="547.1428571428571" y="35" width="402.8571428571429" height="25" class="treemapSectionHeader" stroke-width="0" fill="none"/>
             <clipPath id="clip-section-2"><rect width="390.8571428571429" height="25"/></clipPath>
-            <text x="553.1428571428571" y="47.5" class="treemapSectionLabel section-1" font-size="12px" dominant-baseline="middle" font-weight="bold" fill="#333">Category A</text>
-            <text x="940" y="47.5" class="treemapSectionValue section-1" dominant-baseline="middle" fill="#333" text-anchor="end" font-style="italic" font-size="10px">30</text>
+            <text x="553.1428571428571" y="47.5" class="treemapSectionLabel section-1" font-weight="bold" dominant-baseline="middle" fill="#333" font-size="12px">Category A</text>
+            <text x="940" y="47.5" class="treemapSectionValue section-1" text-anchor="end" fill="#333" dominant-baseline="middle" font-style="italic" font-size="10px">30</text>
           </g>
         </g>
         <g class="treemapLeaves">
           <g class="treemapNode treemapLeafGroup section-0">
-            <rect x="20" y="70" width="323.21428571428567" height="281" class="treemapLeaf section-0" fill-opacity="0.3" stroke="hsl(240, 100%, 76.2745098039%)" stroke-width="3" fill="hsl(240, 100%, 76.2745098039%)"/>
+            <rect x="20" y="70" width="323.21428571428567" height="281" class="treemapLeaf section-0" stroke-width="3" fill="hsl(240, 100%, 76.2745098039%)" fill-opacity="0.3" stroke="hsl(240, 100%, 76.2745098039%)"/>
             <clipPath id="clip-leaf-0"><rect x="22" y="72" width="319.21428571428567" height="277"/></clipPath>
-            <text x="28" y="110.3" class="treemapLabel section-0" clip-path="url(#clip-leaf-0)" dominant-baseline="auto" font-size="38px" text-anchor="start" fill="#ffffff">Item B2</text>
-            <text x="28" y="141.25" class="treemapValue section-0" fill="rgb(255, 255, 255)" clip-path="url(#clip-leaf-0)" font-size="23px" dominant-baseline="auto" text-anchor="start">25</text>
+            <text x="28" y="110.3" class="treemapLabel section-0" clip-path="url(#clip-leaf-0)" font-size="38px" fill="#ffffff" text-anchor="start" dominant-baseline="auto">Item B2</text>
+            <text x="28" y="141.25" class="treemapValue section-0" font-size="23px" fill="rgb(255, 255, 255)" dominant-baseline="auto" text-anchor="start" clip-path="url(#clip-leaf-0)">25</text>
           </g>
           <g class="treemapNode treemapLeafGroup section-0">
-            <rect x="343.21428571428567" y="70" width="193.92857142857144" height="281" class="treemapLeaf section-0" stroke-width="3" stroke="hsl(240, 100%, 76.2745098039%)" fill="hsl(240, 100%, 76.2745098039%)" fill-opacity="0.3"/>
+            <rect x="343.21428571428567" y="70" width="193.92857142857144" height="281" class="treemapLeaf section-0" fill-opacity="0.3" fill="hsl(240, 100%, 76.2745098039%)" stroke-width="3" stroke="hsl(240, 100%, 76.2745098039%)"/>
             <clipPath id="clip-leaf-1"><rect x="345.21428571428567" y="72" width="189.92857142857144" height="277"/></clipPath>
-            <text x="351.21428571428567" y="110.3" class="treemapLabel section-0" font-size="38px" fill="#ffffff" clip-path="url(#clip-leaf-1)" dominant-baseline="auto" text-anchor="start">Item B1</text>
-            <text x="351.21428571428567" y="141.25" class="treemapValue section-0" dominant-baseline="auto" font-size="23px" text-anchor="start" clip-path="url(#clip-leaf-1)" fill="rgb(255, 255, 255)">15</text>
+            <text x="351.21428571428567" y="110.3" class="treemapLabel section-0" clip-path="url(#clip-leaf-1)" text-anchor="start" fill="#ffffff" dominant-baseline="auto" font-size="38px">Item B1</text>
+            <text x="351.21428571428567" y="141.25" class="treemapValue section-0" clip-path="url(#clip-leaf-1)" font-size="23px" fill="rgb(255, 255, 255)" dominant-baseline="auto" text-anchor="start">15</text>
           </g>
           <g class="treemapNode treemapLeafGroup section-1">
-            <rect x="557.1428571428571" y="70" width="255.23809523809524" height="281" class="treemapLeaf section-1" fill="hsl(60, 100%, 73.5294117647%)" stroke="hsl(60, 100%, 73.5294117647%)" stroke-width="3" fill-opacity="0.3"/>
+            <rect x="557.1428571428571" y="70" width="255.23809523809524" height="281" class="treemapLeaf section-1" fill="hsl(60, 100%, 73.5294117647%)" fill-opacity="0.3" stroke="hsl(60, 100%, 73.5294117647%)" stroke-width="3"/>
             <clipPath id="clip-leaf-2"><rect x="559.1428571428571" y="72" width="251.23809523809524" height="277"/></clipPath>
-            <text x="565.1428571428571" y="110.3" class="treemapLabel section-1" dominant-baseline="auto" text-anchor="start" fill="#333" font-size="38px" clip-path="url(#clip-leaf-2)">Item A2</text>
+            <text x="565.1428571428571" y="110.3" class="treemapLabel section-1" fill="#333" font-size="38px" clip-path="url(#clip-leaf-2)" text-anchor="start" dominant-baseline="auto">Item A2</text>
             <text x="565.1428571428571" y="141.25" class="treemapValue section-1" fill="#333" text-anchor="start" font-size="23px" dominant-baseline="auto" clip-path="url(#clip-leaf-2)">20</text>
           </g>
           <g class="treemapNode treemapLeafGroup section-1">
-            <rect x="812.3809523809523" y="70" width="127.6190476190477" height="281" class="treemapLeaf section-1" stroke-width="3" fill="hsl(60, 100%, 73.5294117647%)" fill-opacity="0.3" stroke="hsl(60, 100%, 73.5294117647%)"/>
+            <rect x="812.3809523809523" y="70" width="127.6190476190477" height="281" class="treemapLeaf section-1" stroke-width="3" fill="hsl(60, 100%, 73.5294117647%)" stroke="hsl(60, 100%, 73.5294117647%)" fill-opacity="0.3"/>
             <clipPath id="clip-leaf-3"><rect x="814.3809523809523" y="72" width="123.6190476190477" height="277"/></clipPath>
-            <text x="820.3809523809523" y="98.85190999476715" class="treemapLabel section-1" clip-path="url(#clip-leaf-3)" text-anchor="start" dominant-baseline="auto" font-size="24.53165881737312px" fill="#333">Item A1</text>
-            <text x="820.3809523809523" y="118.83230053154868" class="treemapValue section-1" text-anchor="start" clip-path="url(#clip-leaf-3)" font-size="14.84810928419952px" fill="#333" dominant-baseline="auto">10</text>
+            <text x="820.3809523809523" y="98.85190999476715" class="treemapLabel section-1" fill="#333" dominant-baseline="auto" clip-path="url(#clip-leaf-3)" text-anchor="start" font-size="24.53165881737312px">Item A1</text>
+            <text x="820.3809523809523" y="118.83230053154868" class="treemapValue section-1" fill="#333" clip-path="url(#clip-leaf-3)" text-anchor="start" dominant-baseline="auto" font-size="14.84810928419952px">10</text>
           </g>
         </g>
       </g>

--- a/docs/images/treemap_complex.svg
+++ b/docs/images/treemap_complex.svg
@@ -47,89 +47,89 @@
       <g class="treemapContainer">
         <g class="treemapSections">
           <g class="treemapSection">
-            <rect x="0" y="0" width="960" height="25" class="treemapSectionHeader" stroke-width="0.6" fill="none" fill-opacity="0.6" style="display: none;"/>
+            <rect x="0" y="0" width="960" height="25" class="treemapSectionHeader" style="display: none;" fill-opacity="0.6" stroke-width="0.6" fill="none"/>
             <clipPath id="clip-section-0"><rect width="948" height="25"/></clipPath>
-            <rect x="0" y="0" width="960" height="371" class="treemapSection section0" fill="transparent" style="display: none;" fill-opacity="0.6" stroke="transparent" stroke-width="2" stroke-opacity="0.4"/>
+            <rect x="0" y="0" width="960" height="371" class="treemapSection section0" fill-opacity="0.6" stroke="transparent" fill="transparent" stroke-width="2" stroke-opacity="0.4" style="display: none;"/>
             <text x="6" y="12.5" class="treemapSectionLabel" dominant-baseline="middle" font-weight="bold" style="display: none;"></text>
-            <text x="950" y="12.5" class="treemapSectionValue" dominant-baseline="middle" text-anchor="end" font-style="italic" style="display: none;">2,200,000</text>
+            <text x="950" y="12.5" class="treemapSectionValue" text-anchor="end" style="display: none;" dominant-baseline="middle" font-style="italic">2,200,000</text>
           </g>
           <g class="treemapSection section-0">
-            <rect x="10" y="35" width="940" height="326" class="treemapSection section-0" fill-opacity="0.6" stroke="hsl(240, 100%, 61.2745098039%)" fill="hsl(240, 100%, 76.2745098039%)" stroke-opacity="0.4" stroke-width="2"/>
+            <rect x="10" y="35" width="940" height="326" class="treemapSection section-0" stroke="hsl(240, 100%, 61.2745098039%)" stroke-opacity="0.4" stroke-width="2" fill="hsl(240, 100%, 76.2745098039%)" fill-opacity="0.6"/>
             <rect x="10" y="35" width="940" height="25" class="treemapSectionHeader" stroke-width="0" fill="none"/>
             <clipPath id="clip-section-1"><rect width="928" height="25"/></clipPath>
-            <text x="16" y="47.5" class="treemapSectionLabel section-0" dominant-baseline="middle" font-size="12px" fill="#ffffff" font-weight="bold">Company Budget</text>
-            <text x="940" y="47.5" class="treemapSectionValue section-0" dominant-baseline="middle" text-anchor="end" fill="#ffffff" font-size="10px" font-style="italic">2,200,000</text>
+            <text x="16" y="47.5" class="treemapSectionLabel section-0" dominant-baseline="middle" font-weight="bold" fill="#ffffff" font-size="12px">Company Budget</text>
+            <text x="940" y="47.5" class="treemapSectionValue section-0" font-size="10px" font-style="italic" fill="#ffffff" dominant-baseline="middle" text-anchor="end">2,200,000</text>
           </g>
           <g class="treemapSection section-1 engineering">
-            <rect x="20" y="70" width="376.3636363636364" height="281" class="treemapSection section-1" stroke="hsl(60, 100%, 48.5294117647%)" fill-opacity="0.6" stroke-opacity="0.4" stroke-width="2" fill="hsl(60, 100%, 73.5294117647%)" style="fill:#6b9bc3;stroke:#333"/>
-            <rect x="20" y="70" width="376.3636363636364" height="25" class="treemapSectionHeader" stroke-width="0" fill="none"/>
+            <rect x="20" y="70" width="376.3636363636364" height="281" class="treemapSection section-1" stroke-opacity="0.4" stroke-width="2" style="fill:#6b9bc3;stroke:#333" fill="hsl(60, 100%, 73.5294117647%)" stroke="hsl(60, 100%, 48.5294117647%)" fill-opacity="0.6"/>
+            <rect x="20" y="70" width="376.3636363636364" height="25" class="treemapSectionHeader" fill="none" stroke-width="0"/>
             <clipPath id="clip-section-2"><rect width="364.3636363636364" height="25"/></clipPath>
-            <text x="26" y="82.5" class="treemapSectionLabel section-1" font-size="12px" dominant-baseline="middle" font-weight="bold" fill="#333">Engineering</text>
-            <text x="386.3636363636364" y="82.5" class="treemapSectionValue section-1" font-size="10px" text-anchor="end" font-style="italic" dominant-baseline="middle" fill="#333">900,000</text>
+            <text x="26" y="82.5" class="treemapSectionLabel section-1" fill="#333" dominant-baseline="middle" font-weight="bold" font-size="12px">Engineering</text>
+            <text x="386.3636363636364" y="82.5" class="treemapSectionValue section-1" text-anchor="end" font-style="italic" dominant-baseline="middle" fill="#333" font-size="10px">900,000</text>
           </g>
           <g class="treemapSection section-2 sales">
-            <rect x="396.3636363636364" y="70" width="334.54545454545456" height="281" class="treemapSection section-2" stroke="hsl(80, 100%, 61.2745098039%)" fill="hsl(80, 100%, 76.2745098039%)" stroke-width="2" stroke-opacity="0.4" fill-opacity="0.6" style="fill:#c3a66b;stroke:#333"/>
-            <rect x="396.3636363636364" y="70" width="334.54545454545456" height="25" class="treemapSectionHeader" stroke-width="0" fill="none"/>
+            <rect x="396.3636363636364" y="70" width="334.54545454545456" height="281" class="treemapSection section-2" style="fill:#c3a66b;stroke:#333" stroke-width="2" fill-opacity="0.6" fill="hsl(80, 100%, 76.2745098039%)" stroke="hsl(80, 100%, 61.2745098039%)" stroke-opacity="0.4"/>
+            <rect x="396.3636363636364" y="70" width="334.54545454545456" height="25" class="treemapSectionHeader" fill="none" stroke-width="0"/>
             <clipPath id="clip-section-3"><rect width="322.54545454545456" height="25"/></clipPath>
-            <text x="402.3636363636364" y="82.5" class="treemapSectionLabel section-2" font-weight="bold" font-size="12px" dominant-baseline="middle" fill="#333">Sales</text>
-            <text x="720.909090909091" y="82.5" class="treemapSectionValue section-2" font-size="10px" text-anchor="end" dominant-baseline="middle" fill="#333" font-style="italic">800,000</text>
+            <text x="402.3636363636364" y="82.5" class="treemapSectionLabel section-2" fill="#333" font-weight="bold" font-size="12px" dominant-baseline="middle">Sales</text>
+            <text x="720.909090909091" y="82.5" class="treemapSectionValue section-2" dominant-baseline="middle" font-style="italic" font-size="10px" text-anchor="end" fill="#333">800,000</text>
           </g>
           <g class="treemapSection section-3 marketing">
-            <rect x="730.909090909091" y="70" width="209.090909090909" height="281" class="treemapSection section-3" fill="hsl(270, 100%, 76.2745098039%)" style="fill:#c36b9b;stroke:#333" fill-opacity="0.6" stroke-opacity="0.4" stroke="hsl(270, 100%, 61.2745098039%)" stroke-width="2"/>
-            <rect x="730.909090909091" y="70" width="209.090909090909" height="25" class="treemapSectionHeader" stroke-width="0" fill="none"/>
+            <rect x="730.909090909091" y="70" width="209.090909090909" height="281" class="treemapSection section-3" style="fill:#c36b9b;stroke:#333" fill-opacity="0.6" stroke="hsl(270, 100%, 61.2745098039%)" fill="hsl(270, 100%, 76.2745098039%)" stroke-opacity="0.4" stroke-width="2"/>
+            <rect x="730.909090909091" y="70" width="209.090909090909" height="25" class="treemapSectionHeader" fill="none" stroke-width="0"/>
             <clipPath id="clip-section-4"><rect width="197.090909090909" height="25"/></clipPath>
-            <text x="736.909090909091" y="82.5" class="treemapSectionLabel section-3" fill="#ffffff" font-size="12px" font-weight="bold" dominant-baseline="middle">Marketing</text>
-            <text x="930" y="82.5" class="treemapSectionValue section-3" font-size="10px" fill="#ffffff" dominant-baseline="middle" text-anchor="end" font-style="italic">500,000</text>
+            <text x="736.909090909091" y="82.5" class="treemapSectionLabel section-3" fill="#ffffff" dominant-baseline="middle" font-size="12px" font-weight="bold">Marketing</text>
+            <text x="930" y="82.5" class="treemapSectionValue section-3" text-anchor="end" font-style="italic" font-size="10px" dominant-baseline="middle" fill="#ffffff">500,000</text>
           </g>
         </g>
         <g class="treemapLeaves">
           <g class="treemapNode treemapLeafGroup section-1">
-            <rect x="30" y="105" width="277.1717171717172" height="134.85714285714286" class="treemapLeaf section-1" stroke="hsl(60, 100%, 73.5294117647%)" stroke-width="3" fill="hsl(60, 100%, 73.5294117647%)" fill-opacity="0.3"/>
+            <rect x="30" y="105" width="277.1717171717172" height="134.85714285714286" class="treemapLeaf section-1" fill-opacity="0.3" fill="hsl(60, 100%, 73.5294117647%)" stroke-width="3" stroke="hsl(60, 100%, 73.5294117647%)"/>
             <clipPath id="clip-leaf-0"><rect x="32" y="107" width="273.1717171717172" height="130.85714285714286"/></clipPath>
-            <text x="38" y="145.3" class="treemapLabel section-1" clip-path="url(#clip-leaf-0)" fill="#333" dominant-baseline="auto" font-size="38px" text-anchor="start">Backend</text>
-            <text x="38" y="176.25000000000003" class="treemapValue section-1" dominant-baseline="auto" font-size="23px" fill="#333" text-anchor="start" clip-path="url(#clip-leaf-0)">400,000</text>
+            <text x="38" y="145.3" class="treemapLabel section-1" fill="#333" clip-path="url(#clip-leaf-0)" font-size="38px" dominant-baseline="auto" text-anchor="start">Backend</text>
+            <text x="38" y="176.25000000000003" class="treemapValue section-1" text-anchor="start" dominant-baseline="auto" clip-path="url(#clip-leaf-0)" font-size="23px" fill="#333">400,000</text>
           </g>
           <g class="treemapNode treemapLeafGroup section-1">
             <rect x="30" y="239.85714285714286" width="277.1717171717172" height="101.14285714285715" class="treemapLeaf section-1" fill-opacity="0.3" fill="hsl(60, 100%, 73.5294117647%)" stroke="hsl(60, 100%, 73.5294117647%)" stroke-width="3"/>
             <clipPath id="clip-leaf-1"><rect x="32" y="241.85714285714286" width="273.1717171717172" height="97.14285714285715"/></clipPath>
-            <text x="38" y="276.8057142857143" class="treemapLabel section-1" dominant-baseline="auto" font-size="34.057142857142864px" fill="#333" clip-path="url(#clip-leaf-1)" text-anchor="start">Frontend</text>
-            <text x="38" y="304.5443609022557" class="treemapValue section-1" text-anchor="start" font-size="20.61353383458647px" dominant-baseline="auto" fill="#333" clip-path="url(#clip-leaf-1)">300,000</text>
+            <text x="38" y="276.8057142857143" class="treemapLabel section-1" text-anchor="start" dominant-baseline="auto" fill="#333" clip-path="url(#clip-leaf-1)" font-size="34.057142857142864px">Frontend</text>
+            <text x="38" y="304.5443609022557" class="treemapValue section-1" dominant-baseline="auto" clip-path="url(#clip-leaf-1)" fill="#333" text-anchor="start" font-size="20.61353383458647px">300,000</text>
           </g>
           <g class="treemapNode treemapLeafGroup section-1">
-            <rect x="307.1717171717172" y="105" width="79.19191919191918" height="236" class="treemapLeaf section-1" fill-opacity="0.3" stroke="hsl(60, 100%, 73.5294117647%)" fill="hsl(60, 100%, 73.5294117647%)" stroke-width="3"/>
+            <rect x="307.1717171717172" y="105" width="79.19191919191918" height="236" class="treemapLeaf section-1" stroke="hsl(60, 100%, 73.5294117647%)" fill="hsl(60, 100%, 73.5294117647%)" fill-opacity="0.3" stroke-width="3"/>
             <clipPath id="clip-leaf-2"><rect x="309.1717171717172" y="107" width="75.19191919191918" height="232"/></clipPath>
-            <text x="315.1717171717172" y="126.77259777259778" class="treemapLabel section-1" clip-path="url(#clip-leaf-2)" text-anchor="start" font-size="16.203056203056203px" dominant-baseline="auto" fill="#333">DevOps</text>
-            <text x="315.1717171717172" y="140.13351463351464" class="treemapValue section-1" text-anchor="start" clip-path="url(#clip-leaf-2)" fill="#333" dominant-baseline="auto" font-size="10px">200,000</text>
+            <text x="315.1717171717172" y="126.77259777259778" class="treemapLabel section-1" dominant-baseline="auto" clip-path="url(#clip-leaf-2)" fill="#333" font-size="16.203056203056203px" text-anchor="start">DevOps</text>
+            <text x="315.1717171717172" y="140.13351463351464" class="treemapValue section-1" dominant-baseline="auto" fill="#333" text-anchor="start" clip-path="url(#clip-leaf-2)" font-size="10px">200,000</text>
           </g>
           <g class="treemapNode treemapLeafGroup section-2">
-            <rect x="406.3636363636364" y="105" width="196.5909090909091" height="236" class="treemapLeaf section-2" fill="hsl(80, 100%, 76.2745098039%)" stroke="hsl(80, 100%, 76.2745098039%)" fill-opacity="0.3" stroke-width="3"/>
+            <rect x="406.3636363636364" y="105" width="196.5909090909091" height="236" class="treemapLeaf section-2" stroke="hsl(80, 100%, 76.2745098039%)" stroke-width="3" fill-opacity="0.3" fill="hsl(80, 100%, 76.2745098039%)"/>
             <clipPath id="clip-leaf-3"><rect x="408.3636363636364" y="107" width="192.5909090909091" height="232"/></clipPath>
-            <text x="414.3636363636364" y="145.3" class="treemapLabel section-2" clip-path="url(#clip-leaf-3)" dominant-baseline="auto" fill="#333" font-size="38px" text-anchor="start">Direct</text>
-            <text x="414.3636363636364" y="176.25000000000003" class="treemapValue section-2" text-anchor="start" fill="#333" font-size="23px" clip-path="url(#clip-leaf-3)" dominant-baseline="auto">500,000</text>
+            <text x="414.3636363636364" y="145.3" class="treemapLabel section-2" font-size="38px" dominant-baseline="auto" text-anchor="start" clip-path="url(#clip-leaf-3)" fill="#333">Direct</text>
+            <text x="414.3636363636364" y="176.25000000000003" class="treemapValue section-2" clip-path="url(#clip-leaf-3)" fill="#333" text-anchor="start" dominant-baseline="auto" font-size="23px">500,000</text>
           </g>
           <g class="treemapNode treemapLeafGroup section-2">
-            <rect x="602.9545454545455" y="105" width="117.9545454545455" height="236" class="treemapLeaf section-2" fill-opacity="0.3" stroke="hsl(80, 100%, 76.2745098039%)" stroke-width="3" fill="hsl(80, 100%, 76.2745098039%)"/>
+            <rect x="602.9545454545455" y="105" width="117.9545454545455" height="236" class="treemapLeaf section-2" fill="hsl(80, 100%, 76.2745098039%)" stroke-width="3" fill-opacity="0.3" stroke="hsl(80, 100%, 76.2745098039%)"/>
             <clipPath id="clip-leaf-4"><rect x="604.9545454545455" y="107" width="113.9545454545455" height="232"/></clipPath>
-            <text x="610.9545454545455" y="132.04645354645356" class="treemapLabel section-2" clip-path="url(#clip-leaf-4)" text-anchor="start" dominant-baseline="auto" fill="#333" font-size="22.407592407592418px">Channel</text>
-            <text x="610.9545454545455" y="150.29684788895318" class="treemapValue section-2" text-anchor="start" font-size="13.562490141437515px" fill="#333" dominant-baseline="auto" clip-path="url(#clip-leaf-4)">300,000</text>
+            <text x="610.9545454545455" y="132.04645354645356" class="treemapLabel section-2" dominant-baseline="auto" clip-path="url(#clip-leaf-4)" text-anchor="start" fill="#333" font-size="22.407592407592418px">Channel</text>
+            <text x="610.9545454545455" y="150.29684788895318" class="treemapValue section-2" text-anchor="start" clip-path="url(#clip-leaf-4)" dominant-baseline="auto" fill="#333" font-size="13.562490141437515px">300,000</text>
           </g>
           <g class="treemapNode treemapLeafGroup section-3">
-            <rect x="740.909090909091" y="105" width="118.18181818181813" height="188.8" class="treemapLeaf section-3" fill-opacity="0.3" fill="hsl(270, 100%, 76.2745098039%)" stroke-width="3" stroke="hsl(270, 100%, 76.2745098039%)"/>
+            <rect x="740.909090909091" y="105" width="118.18181818181813" height="188.8" class="treemapLeaf section-3" fill="hsl(270, 100%, 76.2745098039%)" stroke-width="3" fill-opacity="0.3" stroke="hsl(270, 100%, 76.2745098039%)"/>
             <clipPath id="clip-leaf-5"><rect x="742.909090909091" y="107" width="114.18181818181813" height="184.8"/></clipPath>
-            <text x="748.909090909091" y="132.0889110889111" class="treemapLabel section-3" font-size="22.457542457542445px" fill="#ffffff" text-anchor="start" clip-path="url(#clip-leaf-5)" dominant-baseline="auto">Digital</text>
-            <text x="748.909090909091" y="150.37998843262" class="treemapValue section-3" dominant-baseline="auto" text-anchor="start" font-size="13.59272306640727px" fill="rgb(255, 255, 255)" clip-path="url(#clip-leaf-5)">250,000</text>
+            <text x="748.909090909091" y="132.0889110889111" class="treemapLabel section-3" font-size="22.457542457542445px" clip-path="url(#clip-leaf-5)" text-anchor="start" fill="#ffffff" dominant-baseline="auto">Digital</text>
+            <text x="748.909090909091" y="150.37998843262" class="treemapValue section-3" clip-path="url(#clip-leaf-5)" fill="rgb(255, 255, 255)" text-anchor="start" dominant-baseline="auto" font-size="13.59272306640727px">250,000</text>
           </g>
           <g class="treemapNode treemapLeafGroup section-3">
-            <rect x="859.0909090909091" y="105" width="70.90909090909088" height="188.8" class="treemapLeaf section-3" fill-opacity="0.3" stroke="hsl(270, 100%, 76.2745098039%)" fill="hsl(270, 100%, 76.2745098039%)" stroke-width="3"/>
+            <rect x="859.0909090909091" y="105" width="70.90909090909088" height="188.8" class="treemapLeaf section-3" fill-opacity="0.3" stroke-width="3" stroke="hsl(270, 100%, 76.2745098039%)" fill="hsl(270, 100%, 76.2745098039%)"/>
             <clipPath id="clip-leaf-6"><rect x="861.0909090909091" y="107" width="66.90909090909088" height="184.8"/></clipPath>
-            <text x="867.0909090909091" y="124.96736596736596" class="treemapLabel section-3" clip-path="url(#clip-leaf-6)" text-anchor="start" dominant-baseline="auto" font-size="14.079254079254072px" fill="#ffffff">Events</text>
-            <text x="867.0909090909091" y="137.69114219114218" class="treemapValue section-3" text-anchor="start" font-size="10px" clip-path="url(#clip-leaf-6)" fill="rgb(255, 255, 255)" dominant-baseline="auto">150,000</text>
+            <text x="867.0909090909091" y="124.96736596736596" class="treemapLabel section-3" text-anchor="start" dominant-baseline="auto" font-size="14.079254079254072px" clip-path="url(#clip-leaf-6)" fill="#ffffff">Events</text>
+            <text x="867.0909090909091" y="137.69114219114218" class="treemapValue section-3" fill="rgb(255, 255, 255)" text-anchor="start" font-size="10px" dominant-baseline="auto" clip-path="url(#clip-leaf-6)">150,000</text>
           </g>
           <g class="treemapNode treemapLeafGroup section-3">
-            <rect x="740.909090909091" y="293.8" width="189.090909090909" height="47.19999999999999" class="treemapLeaf section-3" stroke-width="3" fill-opacity="0.3" stroke="hsl(270, 100%, 76.2745098039%)" fill="hsl(270, 100%, 76.2745098039%)"/>
+            <rect x="740.909090909091" y="293.8" width="189.090909090909" height="47.19999999999999" class="treemapLeaf section-3" fill="hsl(270, 100%, 76.2745098039%)" fill-opacity="0.3" stroke-width="3" stroke="hsl(270, 100%, 76.2745098039%)"/>
             <clipPath id="clip-leaf-7"><rect x="742.909090909091" y="295.8" width="185.090909090909" height="43.19999999999999"/></clipPath>
-            <text x="748.909090909091" y="312.408" class="treemapLabel section-3" text-anchor="start" font-size="12.479999999999995px" fill="#ffffff" clip-path="url(#clip-leaf-7)" dominant-baseline="auto">Print</text>
-            <text x="748.909090909091" y="324.652" class="treemapValue section-3" font-size="10px" text-anchor="start" clip-path="url(#clip-leaf-7)" dominant-baseline="auto" fill="rgb(255, 255, 255)">100,000</text>
+            <text x="748.909090909091" y="312.408" class="treemapLabel section-3" text-anchor="start" font-size="12.479999999999995px" dominant-baseline="auto" clip-path="url(#clip-leaf-7)" fill="#ffffff">Print</text>
+            <text x="748.909090909091" y="324.652" class="treemapValue section-3" text-anchor="start" dominant-baseline="auto" font-size="10px" clip-path="url(#clip-leaf-7)" fill="rgb(255, 255, 255)">100,000</text>
           </g>
         </g>
       </g>


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Regenerate treemap diagram SVGs with latest rendering
- Verified z-order is already correct (shapes before text) in treemap renderer

The z-order task (#28) was based on stale analysis - the treemap renderer already has correct z-order:
- `render_section` (line 831): rect before text
- `render_leaf` (line 942): rect before text

Eval confirms no z_order issues detected.

## Changes
- `docs/images/treemap.svg`: Regenerated with latest rendering  
- `docs/images/treemap_complex.svg`: Regenerated with latest rendering

## Test plan
- [x] `cargo test --features all-formats` passes
- [x] `cargo clippy --features all-formats -- -D warnings` passes
- [x] Treemap eval shows no z_order issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)