### PR TITLE
fix(state): correct fill color palette to match mermaid.js reference

### DIFF
--- a/docs/images/state.svg
+++ b/docs/images/state.svg
@@ -2,85 +2,23 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="191.431264933764" height="392" viewBox="3 -8 191.431264933764 392" class="mermaid">
   <style>
 
-.mermaid {
+.statediagram {
   font-family: trebuchet ms, verdana, arial, sans-serif;
   font-size: 16px;
-}
-
-.node rect,
-.node polygon,
-.node circle,
-.node ellipse,
-.node path {
-  fill: #ECECFF;
-  stroke: #9370DB;
-  stroke-width: 1px;
-}
-
-.node line {
-  stroke: #9370DB;
-  stroke-width: 1px;
-}
-
-.node .label {
   fill: #333333;
 }
 
-.node text {
-  fill: #333333;
-  font-family: trebuchet ms, verdana, arial, sans-serif;
-  font-size: 16px;
+.error-icon {
+  fill: #552222;
 }
 
-.edge-path {
-  fill: none;
-  stroke: #333333;
-  stroke-width: 1px;
+.error-text {
+  fill: #552222;
+  stroke: #552222;
 }
-
-.edge-label {
-  fill: #333333;
-  font-family: trebuchet ms, verdana, arial, sans-serif;
-}
-
-.edge-label-bg {
-  fill: rgba(232, 232, 232, 0.8);
-}
-
-.subgraph {
-  fill: #ffffde;
-  stroke: #aaaa33;
-  stroke-width: 1px;
-}
-
-.subgraph-title {
-  fill: #333333;
-  font-weight: bold;
-}
-
-.cluster rect {
-  fill: #ffffde;
-  stroke: #aaaa33;
-  stroke-width: 1px;
-  rx: 5px;
-  ry: 5px;
-}
-
-.cluster-label {
-  fill: #333333;
-  font-family: trebuchet ms, verdana, arial, sans-serif;
-  font-size: 16px;
-  font-weight: bold;
-}
-
-marker path {
-  fill: #333333;
-  stroke: #333333;
-}
-
 
 .state-title {
-  fill: #333333;
+  fill: #131300;
 }
 
 .state-box {
@@ -89,11 +27,11 @@ marker path {
 }
 
 .state-label {
-  fill: #333333;
+  fill: #131300;
 }
 
 .state-description {
-  fill: #666666;
+  fill: #333333;
 }
 
 .state-start {
@@ -142,12 +80,12 @@ marker path {
 }
 
 .note-box {
-  fill: #FFFFCC;
-  stroke: #333333;
+  fill: #fff5ad;
+  stroke: #aaaa33;
 }
 
 .note-text {
-  fill: #333333;
+  fill: black;
 }
 
 .state-composite-outer {
@@ -157,12 +95,12 @@ marker path {
 }
 
 .state-composite-inner {
-  fill: #ffffff;
+  fill: white;
   stroke: none;
 }
 
 .state-composite-inner-alt {
-  fill: #f0f0f0;
+  fill: #e0e0e0;
   stroke: none;
 }
 
@@ -180,7 +118,7 @@ marker path {
   </style>
   <defs>
     <marker id="arrow" viewBox="0 0 20 14" refX="19" refY="7" markerWidth="20" markerHeight="14" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke-width="1" fill="#333333" stroke="#333333"/>
+      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke-width="1" stroke="#333333" fill="#333333"/>
     </marker>
   </defs>
   <g class="root">
@@ -197,46 +135,46 @@ marker path {
 
     </g>
     <g class="state-node" id="state-Error">
-      <path d="M 87.153921183764 276 H 124.708608683764 A 5 5 0 0 1 129.708608683764 281 V 307 A 5 5 0 0 1 124.708608683764 312 H 87.153921183764 A 5 5 0 0 1 82.153921183764 307 V 281 A 5 5 0 0 1 87.153921183764 276 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
-      <text x="105.931264933764" y="299" class="state-label" text-anchor="middle" font-size="16">Error</text>
+      <path d="M 87.153921183764 276 H 124.708608683764 A 5 5 0 0 1 129.708608683764 281 V 307 A 5 5 0 0 1 124.708608683764 312 H 87.153921183764 A 5 5 0 0 1 82.153921183764 307 V 281 A 5 5 0 0 1 87.153921183764 276 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <text x="105.931264933764" y="299" class="state-label" font-size="16" text-anchor="middle">Error</text>
     </g>
     <g class="state-node" id="state-Idle">
       <path d="M 81.132436808764 64 H 108.929311808764 A 5 5 0 0 1 113.929311808764 69 V 95 A 5 5 0 0 1 108.929311808764 100 H 81.132436808764 A 5 5 0 0 1 76.132436808764 95 V 69 A 5 5 0 0 1 81.132436808764 64 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
       <text x="95.030874308764" y="87" class="state-label" text-anchor="middle" font-size="16">Idle</text>
     </g>
     <g class="state-node" id="state-Running">
-      <path d="M 23.230093058763998 170 H 84.831655558764 A 5 5 0 0 1 89.831655558764 175 V 201 A 5 5 0 0 1 84.831655558764 206 H 23.230093058763998 A 5 5 0 0 1 18.230093058763998 201 V 175 A 5 5 0 0 1 23.230093058763998 170 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
+      <path d="M 23.230093058763998 170 H 84.831655558764 A 5 5 0 0 1 89.831655558764 175 V 201 A 5 5 0 0 1 84.831655558764 206 H 23.230093058763998 A 5 5 0 0 1 18.230093058763998 201 V 175 A 5 5 0 0 1 23.230093058763998 170 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
       <text x="54.030874308764" y="193" class="state-label" text-anchor="middle" font-size="16">Running</text>
     </g>
     <g class="state-node" id="state-root_end">
-      <path d="M 98.931264933764 369 A 7 7 0 1 0 112.931264933764 369 A 7 7 0 1 0 98.931264933764 369 Z" class="state-end-outer" fill="none" stroke="#9370DB" stroke-width="2"/>
-      <path d="M 103.411264933764 369 A 2.52 2.52 0 1 0 108.451264933764 369 A 2.52 2.52 0 1 0 103.411264933764 369 Z" class="state-end-inner" fill="#9370DB" stroke-width="2" stroke="#9370DB"/>
+      <path d="M 98.931264933764 369 A 7 7 0 1 0 112.931264933764 369 A 7 7 0 1 0 98.931264933764 369 Z" class="state-end-outer" fill="none" stroke-width="2" stroke="#9370DB"/>
+      <path d="M 103.411264933764 369 A 2.52 2.52 0 1 0 108.451264933764 369 A 2.52 2.52 0 1 0 103.411264933764 369 Z" class="state-end-inner" stroke="#9370DB" stroke-width="2" fill="#9370DB"/>
     </g>
     <g class="state-node" id="state-root_start">
       <circle cx="95.030874308764" cy="7" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="transition">
-      <path d="M 95.03 14.00 C 95.03 22.33, 95.03 30.67, 95.03 39.00 C 95.03 47.33, 95.03 55.67, 95.03 64.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 95.03 14.00 C 95.03 22.33, 95.03 30.67, 95.03 39.00 C 95.03 47.33, 95.03 55.67, 95.03 64.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 76.13 94.21 C 55.10 107.81, 34.06 121.40, 28.06 134.04 C 22.06 146.67, 31.08 158.33, 40.11 170.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 76.13 94.21 C 55.10 107.81, 34.06 121.40, 28.06 134.04 C 22.06 146.67, 31.08 158.33, 40.11 170.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
       <path d="M 6 115.8175163215182 H 46 A 2 2 0 0 1 48 117.8175163215182 V 135.4175163215182 A 2 2 0 0 1 46 137.4175163215182 H 6 A 2 2 0 0 1 4 135.4175163215182 V 117.8175163215182 A 2 2 0 0 1 6 115.8175163215182 Z" class="transition-label-bg"/>
-      <text x="26" y="126.6175163215182" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">start</text>
+      <text x="26" y="126.6175163215182" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">start</text>
     </g>
     <g class="transition">
       <path d="M 67.96 170.00 L 95.03 100.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
       <path d="M 76.20090108319185 127.85825807208104 H 108.20090108319185 A 2 2 0 0 1 110.20090108319185 129.85825807208104 V 147.45825807208104 A 2 2 0 0 1 108.20090108319185 149.45825807208104 H 76.20090108319185 A 2 2 0 0 1 74.20090108319185 147.45825807208104 V 129.85825807208104 A 2 2 0 0 1 76.20090108319185 127.85825807208104 Z" class="transition-label-bg"/>
-      <text x="92.20090108319185" y="138.65825807208105" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">stop</text>
+      <text x="92.20090108319185" y="138.65825807208105" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">stop</text>
     </g>
     <g class="transition">
-      <path d="M 54.03 206.00 L 88.30 276.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 54.03 206.00 L 88.30 276.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
       <path d="M 38.92381300441641 235.19660499172932 H 78.92381300441642 A 2 2 0 0 1 80.92381300441642 237.19660499172932 V 254.79660499172934 A 2 2 0 0 1 78.92381300441642 256.79660499172934 H 38.92381300441641 A 2 2 0 0 1 36.92381300441641 254.79660499172934 V 237.19660499172932 A 2 2 0 0 1 38.92381300441641 235.19660499172932 Z" class="transition-label-bg"/>
       <text x="58.92381300441641" y="245.99660499172933" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">error</text>
     </g>
     <g class="transition">
-      <path d="M 128.18 276.00 C 142.59 264.33, 157.01 252.67, 164.22 229.17 C 171.43 205.67, 171.43 170.33, 161.85 146.02 C 133.10 108.41, 113.93 95.11, 113.93 95.11" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 128.18 276.00 C 142.59 264.33, 157.01 252.67, 164.22 229.17 C 171.43 205.67, 171.43 170.33, 161.85 146.02 C 133.10 108.41, 113.93 95.11, 113.93 95.11" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
       <path d="M 151.431264933764 170.0290159304274 H 191.431264933764 A 2 2 0 0 1 193.431264933764 172.0290159304274 V 189.62901593042739 A 2 2 0 0 1 191.431264933764 191.62901593042739 H 151.431264933764 A 2 2 0 0 1 149.431264933764 189.62901593042739 V 172.0290159304274 A 2 2 0 0 1 151.431264933764 170.0290159304274 Z" class="transition-label-bg"/>
-      <text x="171.431264933764" y="180.8290159304274" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">reset</text>
+      <text x="171.431264933764" y="180.8290159304274" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">reset</text>
     </g>
     <g class="transition">
       <path d="M 105.93 312.00 C 105.93 320.33, 105.93 328.67, 105.93 337.00 C 105.93 345.33, 105.93 353.67, 105.93 362.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>

--- a/docs/images/state_complex.svg
+++ b/docs/images/state_complex.svg
@@ -2,85 +2,23 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="263.4296875" height="1145" viewBox="-8 -8 263.4296875 1145" class="mermaid">
   <style>
 
-.mermaid {
+.statediagram {
   font-family: trebuchet ms, verdana, arial, sans-serif;
   font-size: 16px;
-}
-
-.node rect,
-.node polygon,
-.node circle,
-.node ellipse,
-.node path {
-  fill: #ECECFF;
-  stroke: #9370DB;
-  stroke-width: 1px;
-}
-
-.node line {
-  stroke: #9370DB;
-  stroke-width: 1px;
-}
-
-.node .label {
   fill: #333333;
 }
 
-.node text {
-  fill: #333333;
-  font-family: trebuchet ms, verdana, arial, sans-serif;
-  font-size: 16px;
+.error-icon {
+  fill: #552222;
 }
 
-.edge-path {
-  fill: none;
-  stroke: #333333;
-  stroke-width: 1px;
+.error-text {
+  fill: #552222;
+  stroke: #552222;
 }
-
-.edge-label {
-  fill: #333333;
-  font-family: trebuchet ms, verdana, arial, sans-serif;
-}
-
-.edge-label-bg {
-  fill: rgba(232, 232, 232, 0.8);
-}
-
-.subgraph {
-  fill: #ffffde;
-  stroke: #aaaa33;
-  stroke-width: 1px;
-}
-
-.subgraph-title {
-  fill: #333333;
-  font-weight: bold;
-}
-
-.cluster rect {
-  fill: #ffffde;
-  stroke: #aaaa33;
-  stroke-width: 1px;
-  rx: 5px;
-  ry: 5px;
-}
-
-.cluster-label {
-  fill: #333333;
-  font-family: trebuchet ms, verdana, arial, sans-serif;
-  font-size: 16px;
-  font-weight: bold;
-}
-
-marker path {
-  fill: #333333;
-  stroke: #333333;
-}
-
 
 .state-title {
-  fill: #333333;
+  fill: #131300;
 }
 
 .state-box {
@@ -89,11 +27,11 @@ marker path {
 }
 
 .state-label {
-  fill: #333333;
+  fill: #131300;
 }
 
 .state-description {
-  fill: #666666;
+  fill: #333333;
 }
 
 .state-start {
@@ -142,12 +80,12 @@ marker path {
 }
 
 .note-box {
-  fill: #FFFFCC;
-  stroke: #333333;
+  fill: #fff5ad;
+  stroke: #aaaa33;
 }
 
 .note-text {
-  fill: #333333;
+  fill: black;
 }
 
 .state-composite-outer {
@@ -157,12 +95,12 @@ marker path {
 }
 
 .state-composite-inner {
-  fill: #ffffff;
+  fill: white;
   stroke: none;
 }
 
 .state-composite-inner-alt {
-  fill: #f0f0f0;
+  fill: #e0e0e0;
   stroke: none;
 }
 
@@ -180,7 +118,7 @@ marker path {
   </style>
   <defs>
     <marker id="arrow" viewBox="0 0 20 14" refX="19" refY="7" markerWidth="20" markerHeight="14" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke="#333333" stroke-width="1" fill="#333333"/>
+      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke-width="1" stroke="#333333" fill="#333333"/>
     </marker>
   </defs>
   <g class="root">
@@ -200,13 +138,13 @@ marker path {
       <rect x="39.39484375000002" y="64" width="168.63999999999996" height="285" rx="5" ry="5" class="state-composite-outer"/>
       <rect x="40.39484375000002" y="85" width="166.63999999999996" height="260" rx="0" ry="0" class="state-composite-inner"/>
       <path d="M 39.39484375000002 85 L 208.03484375 85" class="state-composite-divider"/>
-      <text x="123.71484375" y="80" class="state-composite-label" font-size="14" text-anchor="middle">Idle</text>
+      <text x="123.71484375" y="80" class="state-composite-label" text-anchor="middle" font-size="14">Idle</text>
     </g>
     <g class="composite-state" id="composite-Processing">
       <rect x="30.414140625000016" y="605" width="170.16" height="524" rx="5" ry="5" class="state-composite-outer"/>
       <rect x="31.414140625000016" y="626" width="168.16" height="499" rx="0" ry="0" class="state-composite-inner"/>
       <path d="M 30.414140625000016 626 L 200.574140625 626" class="state-composite-divider"/>
-      <text x="115.49414062500001" y="621" class="state-composite-label" font-size="14" text-anchor="middle">Processing</text>
+      <text x="115.49414062500001" y="621" class="state-composite-label" text-anchor="middle" font-size="14">Processing</text>
     </g>
     <g class="composite-state" id="composite-Executing">
       <rect x="63.294140625000004" y="822" width="104.4" height="295" rx="5" ry="5" class="state-composite-outer"/>
@@ -215,11 +153,11 @@ marker path {
       <text x="115.494140625" y="838" class="state-composite-label" font-size="14" text-anchor="middle">Executing</text>
     </g>
     <g class="state-node" id="state-Active">
-      <path d="M 100.9296875 301 H 146.5 A 5 5 0 0 1 151.5 306 V 332 A 5 5 0 0 1 146.5 337 H 100.9296875 A 5 5 0 0 1 95.9296875 332 V 306 A 5 5 0 0 1 100.9296875 301 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
+      <path d="M 100.9296875 301 H 146.5 A 5 5 0 0 1 151.5 306 V 332 A 5 5 0 0 1 146.5 337 H 100.9296875 A 5 5 0 0 1 95.9296875 332 V 306 A 5 5 0 0 1 100.9296875 301 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
       <text x="123.71484375" y="324" class="state-label" text-anchor="middle" font-size="16">Active</text>
     </g>
     <g class="state-node" id="state-Done">
-      <path d="M 95.36914062500001 1069 H 135.619140625 A 5 5 0 0 1 140.619140625 1074 V 1100 A 5 5 0 0 1 135.619140625 1105 H 95.36914062500001 A 5 5 0 0 1 90.36914062500001 1100 V 1074 A 5 5 0 0 1 95.36914062500001 1069 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <path d="M 95.36914062500001 1069 H 135.619140625 A 5 5 0 0 1 140.619140625 1074 V 1100 A 5 5 0 0 1 135.619140625 1105 H 95.36914062500001 A 5 5 0 0 1 90.36914062500001 1100 V 1074 A 5 5 0 0 1 95.36914062500001 1069 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
       <text x="115.49414062500001" y="1092" class="state-label" text-anchor="middle" font-size="16">Done</text>
     </g>
     <g class="state-node" id="state-Executing_start">
@@ -229,27 +167,27 @@ marker path {
       <circle cx="123.71484375000001" cy="108" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Init">
-      <path d="M 102.99414062500001 953 H 127.994140625 A 5 5 0 0 1 132.994140625 958 V 984 A 5 5 0 0 1 127.994140625 989 H 102.99414062500001 A 5 5 0 0 1 97.99414062500001 984 V 958 A 5 5 0 0 1 102.99414062500001 953 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
-      <text x="115.49414062500001" y="976" class="state-label" text-anchor="middle" font-size="16">Init</text>
+      <path d="M 102.99414062500001 953 H 127.994140625 A 5 5 0 0 1 132.994140625 958 V 984 A 5 5 0 0 1 127.994140625 989 H 102.99414062500001 A 5 5 0 0 1 97.99414062500001 984 V 958 A 5 5 0 0 1 102.99414062500001 953 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
+      <text x="115.49414062500001" y="976" class="state-label" font-size="16" text-anchor="middle">Init</text>
     </g>
     <g class="state-node" id="state-Processing_start">
       <circle cx="115.49414062500001" cy="649" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Ready">
-      <path d="M 99.58984375 180 H 147.83984375 A 5 5 0 0 1 152.83984375 185 V 211 A 5 5 0 0 1 147.83984375 216 H 99.58984375 A 5 5 0 0 1 94.58984375 211 V 185 A 5 5 0 0 1 99.58984375 180 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <path d="M 99.58984375 180 H 147.83984375 A 5 5 0 0 1 152.83984375 185 V 211 A 5 5 0 0 1 147.83984375 216 H 99.58984375 A 5 5 0 0 1 94.58984375 211 V 185 A 5 5 0 0 1 99.58984375 180 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
       <text x="123.71484375" y="203" class="state-label" font-size="16" text-anchor="middle">Ready</text>
     </g>
     <g class="state-node" id="state-ResourceAlloc">
-      <path d="M 137.2734375 459 H 242.4296875 A 5 5 0 0 1 247.4296875 464 V 490 A 5 5 0 0 1 242.4296875 495 H 137.2734375 A 5 5 0 0 1 132.2734375 490 V 464 A 5 5 0 0 1 137.2734375 459 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <path d="M 137.2734375 459 H 242.4296875 A 5 5 0 0 1 247.4296875 464 V 490 A 5 5 0 0 1 242.4296875 495 H 137.2734375 A 5 5 0 0 1 132.2734375 490 V 464 A 5 5 0 0 1 137.2734375 459 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
       <text x="189.8515625" y="482" class="state-label" text-anchor="middle" font-size="16">ResourceAlloc</text>
     </g>
     <g class="state-node" id="state-Validating">
-      <path d="M 79.35742187500001 721 H 151.630859375 A 5 5 0 0 1 156.630859375 726 V 752 A 5 5 0 0 1 151.630859375 757 H 79.35742187500001 A 5 5 0 0 1 74.35742187500001 752 V 726 A 5 5 0 0 1 79.35742187500001 721 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <path d="M 79.35742187500001 721 H 151.630859375 A 5 5 0 0 1 156.630859375 726 V 752 A 5 5 0 0 1 151.630859375 757 H 79.35742187500001 A 5 5 0 0 1 74.35742187500001 752 V 726 A 5 5 0 0 1 79.35742187500001 721 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
       <text x="115.49414062500001" y="744" class="state-label" text-anchor="middle" font-size="16">Validating</text>
     </g>
     <g class="state-node" id="state-Validation">
-      <path d="M 5 459 H 77.2734375 A 5 5 0 0 1 82.2734375 464 V 490 A 5 5 0 0 1 77.2734375 495 H 5 A 5 5 0 0 1 0 490 V 464 A 5 5 0 0 1 5 459 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
-      <text x="41.13671875" y="482" class="state-label" font-size="16" text-anchor="middle">Validation</text>
+      <path d="M 5 459 H 77.2734375 A 5 5 0 0 1 82.2734375 464 V 490 A 5 5 0 0 1 77.2734375 495 H 5 A 5 5 0 0 1 0 490 V 464 A 5 5 0 0 1 5 459 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <text x="41.13671875" y="482" class="state-label" text-anchor="middle" font-size="16">Validation</text>
     </g>
     <g class="state-node" id="state-fork_state">
       <path d="M 82.494140625 399 H 148.494140625 A 2 2 0 0 1 150.494140625 401 V 407 A 2 2 0 0 1 148.494140625 409 H 82.494140625 A 2 2 0 0 1 80.494140625 407 V 401 A 2 2 0 0 1 82.494140625 399 Z" class="state-fork-join" fill="#333333"/>
@@ -261,33 +199,33 @@ marker path {
       <circle cx="123.71484375" cy="7" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 14.00 C 123.71 22.33, 123.71 30.67, 123.71 39.00 C 123.71 47.33, 123.71 55.67, 123.71 64.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 123.71 14.00 C 123.71 22.33, 123.71 30.67, 123.71 39.00 C 123.71 47.33, 123.71 55.67, 123.71 64.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 115.00 C 123.71 125.83, 123.71 136.67, 123.71 147.50 C 123.71 158.33, 123.71 169.17, 123.71 180.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 123.71 115.00 C 123.71 125.83, 123.71 136.67, 123.71 147.50 C 123.71 158.33, 123.71 169.17, 123.71 180.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 216.00 C 123.71 230.17, 123.71 244.33, 123.71 258.50 C 123.71 272.67, 123.71 286.83, 123.71 301.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 123.71 216.00 C 123.71 230.17, 123.71 244.33, 123.71 258.50 C 123.71 272.67, 123.71 286.83, 123.71 301.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
       <path d="M 87.71484375000001 247.7 H 159.71484375 A 2 2 0 0 1 161.71484375 249.7 V 267.3 A 2 2 0 0 1 159.71484375 269.3 H 87.71484375000001 A 2 2 0 0 1 85.71484375000001 267.3 V 249.7 A 2 2 0 0 1 87.71484375000001 247.7 Z" class="transition-label-bg"/>
-      <text x="123.71484375000001" y="258.5" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Start Job</text>
+      <text x="123.71484375000001" y="258.5" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Start Job</text>
     </g>
     <g class="transition">
-      <path d="M 115.49 349.00 C 115.49 357.33, 115.49 365.67, 115.49 374.00 C 115.49 382.33, 115.49 390.67, 115.49 399.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 115.49 349.00 C 115.49 357.33, 115.49 365.67, 115.49 374.00 C 115.49 382.33, 115.49 390.67, 115.49 399.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 103.10 409.00 C 82.45 417.33, 61.79 425.67, 51.46 434.00 C 41.14 442.33, 41.14 450.67, 41.14 459.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 103.10 409.00 C 82.45 417.33, 61.79 425.67, 51.46 434.00 C 41.14 442.33, 41.14 450.67, 41.14 459.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 127.89 409.00 C 148.54 417.33, 169.20 425.67, 179.52 434.00 C 189.85 442.33, 189.85 450.67, 189.85 459.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 127.89 409.00 C 148.54 417.33, 169.20 425.67, 179.52 434.00 C 189.85 442.33, 189.85 450.67, 189.85 459.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 41.14 495.00 C 41.14 503.33, 41.14 511.67, 51.46 520.00 C 61.79 528.33, 82.45 536.67, 103.10 545.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 41.14 495.00 C 41.14 503.33, 41.14 511.67, 51.46 520.00 C 61.79 528.33, 82.45 536.67, 103.10 545.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 189.85 495.00 C 189.85 503.33, 189.85 511.67, 179.52 520.00 C 169.20 528.33, 148.54 536.67, 127.89 545.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 189.85 495.00 C 189.85 503.33, 189.85 511.67, 179.52 520.00 C 169.20 528.33, 148.54 536.67, 127.89 545.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 115.49 555.00 C 115.49 563.33, 115.49 571.67, 115.49 580.00 C 115.49 588.33, 115.49 596.67, 115.49 605.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 115.49 555.00 C 115.49 563.33, 115.49 571.67, 115.49 580.00 C 115.49 588.33, 115.49 596.67, 115.49 605.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
       <path d="M 123.71 656.00 C 123.71 666.83, 123.71 677.67, 123.71 688.50 C 123.71 699.33, 123.71 710.17, 123.71 721.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
@@ -296,10 +234,10 @@ marker path {
       <path d="M 123.71 757.00 C 123.71 767.83, 123.71 778.67, 122.34 789.50 C 120.97 800.33, 118.23 811.17, 115.49 822.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 873.00 C 123.71 886.33, 123.71 899.67, 123.71 913.00 C 123.71 926.33, 123.71 939.67, 123.71 953.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 123.71 873.00 C 123.71 886.33, 123.71 899.67, 123.71 913.00 C 123.71 926.33, 123.71 939.67, 123.71 953.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 989.00 C 123.71 1002.33, 123.71 1015.67, 123.71 1029.00 C 123.71 1042.33, 123.71 1055.67, 123.71 1069.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 123.71 989.00 C 123.71 1002.33, 123.71 1015.67, 123.71 1029.00 C 123.71 1042.33, 123.71 1055.67, 123.71 1069.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
   </g>
 </svg>

--- a/docs/images/state_complex2.svg
+++ b/docs/images/state_complex2.svg
@@ -2,85 +2,23 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1285.8157187499999" height="1924" viewBox="-8 -8 1285.8157187499999 1924" class="mermaid">
   <style>
 
-.mermaid {
+.statediagram {
   font-family: trebuchet ms, verdana, arial, sans-serif;
   font-size: 16px;
-}
-
-.node rect,
-.node polygon,
-.node circle,
-.node ellipse,
-.node path {
-  fill: #ECECFF;
-  stroke: #9370DB;
-  stroke-width: 1px;
-}
-
-.node line {
-  stroke: #9370DB;
-  stroke-width: 1px;
-}
-
-.node .label {
   fill: #333333;
 }
 
-.node text {
-  fill: #333333;
-  font-family: trebuchet ms, verdana, arial, sans-serif;
-  font-size: 16px;
+.error-icon {
+  fill: #552222;
 }
 
-.edge-path {
-  fill: none;
-  stroke: #333333;
-  stroke-width: 1px;
+.error-text {
+  fill: #552222;
+  stroke: #552222;
 }
-
-.edge-label {
-  fill: #333333;
-  font-family: trebuchet ms, verdana, arial, sans-serif;
-}
-
-.edge-label-bg {
-  fill: rgba(232, 232, 232, 0.8);
-}
-
-.subgraph {
-  fill: #ffffde;
-  stroke: #aaaa33;
-  stroke-width: 1px;
-}
-
-.subgraph-title {
-  fill: #333333;
-  font-weight: bold;
-}
-
-.cluster rect {
-  fill: #ffffde;
-  stroke: #aaaa33;
-  stroke-width: 1px;
-  rx: 5px;
-  ry: 5px;
-}
-
-.cluster-label {
-  fill: #333333;
-  font-family: trebuchet ms, verdana, arial, sans-serif;
-  font-size: 16px;
-  font-weight: bold;
-}
-
-marker path {
-  fill: #333333;
-  stroke: #333333;
-}
-
 
 .state-title {
-  fill: #333333;
+  fill: #131300;
 }
 
 .state-box {
@@ -89,11 +27,11 @@ marker path {
 }
 
 .state-label {
-  fill: #333333;
+  fill: #131300;
 }
 
 .state-description {
-  fill: #666666;
+  fill: #333333;
 }
 
 .state-start {
@@ -142,12 +80,12 @@ marker path {
 }
 
 .note-box {
-  fill: #FFFFCC;
-  stroke: #333333;
+  fill: #fff5ad;
+  stroke: #aaaa33;
 }
 
 .note-text {
-  fill: #333333;
+  fill: black;
 }
 
 .state-composite-outer {
@@ -157,12 +95,12 @@ marker path {
 }
 
 .state-composite-inner {
-  fill: #ffffff;
+  fill: white;
   stroke: none;
 }
 
 .state-composite-inner-alt {
-  fill: #f0f0f0;
+  fill: #e0e0e0;
   stroke: none;
 }
 
@@ -180,7 +118,7 @@ marker path {
   </style>
   <defs>
     <marker id="arrow" viewBox="0 0 20 14" refX="19" refY="7" markerWidth="20" markerHeight="14" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke-width="1" fill="#333333" stroke="#333333"/>
+      <path d="M 19,7 L9,13 L14,7 L9,1 Z" fill="#333333" stroke="#333333" stroke-width="1"/>
     </marker>
   </defs>
   <g class="root">
@@ -206,38 +144,38 @@ marker path {
       <rect x="178.11653124999992" y="301" width="830.5826562499999" height="1425" rx="5" ry="5" class="state-composite-outer"/>
       <rect x="179.11653124999992" y="322" width="828.5826562499999" height="1400" rx="0" ry="0" class="state-composite-inner-alt"/>
       <path d="M 178.11653124999992 322 L 1008.6991874999999 322" class="state-composite-divider"/>
-      <text x="593.4078593749998" y="317" class="state-composite-label" font-size="14" text-anchor="middle">Processing</text>
+      <text x="593.4078593749998" y="317" class="state-composite-label" text-anchor="middle" font-size="14">Processing</text>
     </g>
     <g class="composite-state" id="composite-Paused">
       <rect x="616.5074687499998" y="1369" width="223.88750000000002" height="345" rx="5" ry="5" class="state-composite-outer"/>
       <rect x="617.5074687499998" y="1390" width="221.88750000000002" height="320" rx="0" ry="0" class="state-composite-inner-alt"/>
       <path d="M 616.5074687499998 1390 L 840.3949687499999 1390" class="state-composite-divider"/>
-      <text x="728.4512187499998" y="1385" class="state-composite-label" font-size="14" text-anchor="middle">Paused</text>
+      <text x="728.4512187499998" y="1385" class="state-composite-label" text-anchor="middle" font-size="14">Paused</text>
     </g>
     <g class="composite-state" id="composite-Running">
       <rect x="440.4059062499998" y="704" width="155.625" height="565" rx="5" ry="5" class="state-composite-outer"/>
       <rect x="441.4059062499998" y="725" width="153.625" height="540" rx="0" ry="0" class="state-composite-inner-alt"/>
       <path d="M 440.4059062499998 725 L 596.0309062499998 725" class="state-composite-divider"/>
-      <text x="518.2184062499998" y="720" class="state-composite-label" font-size="14" text-anchor="middle">Running</text>
+      <text x="518.2184062499998" y="720" class="state-composite-label" text-anchor="middle" font-size="14">Running</text>
     </g>
     <g class="state-node" id="state-Cancelled">
-      <path d="M 556.8297343749999 1808 H 629.9859843749999 A 5 5 0 0 1 634.9859843749999 1813 V 1839 A 5 5 0 0 1 629.9859843749999 1844 H 556.8297343749999 A 5 5 0 0 1 551.8297343749999 1839 V 1813 A 5 5 0 0 1 556.8297343749999 1808 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
-      <text x="593.4078593749999" y="1831" class="state-label" text-anchor="middle" font-size="16">Cancelled</text>
+      <path d="M 556.8297343749999 1808 H 629.9859843749999 A 5 5 0 0 1 634.9859843749999 1813 V 1839 A 5 5 0 0 1 629.9859843749999 1844 H 556.8297343749999 A 5 5 0 0 1 551.8297343749999 1839 V 1813 A 5 5 0 0 1 556.8297343749999 1808 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <text x="593.4078593749999" y="1831" class="state-label" font-size="16" text-anchor="middle">Cancelled</text>
     </g>
     <g class="state-node" id="state-Completed">
-      <path d="M 351.4207499999998 1523.5 H 430.7957499999998 A 5 5 0 0 1 435.7957499999998 1528.5 V 1554.5 A 5 5 0 0 1 430.7957499999998 1559.5 H 351.4207499999998 A 5 5 0 0 1 346.4207499999998 1554.5 V 1528.5 A 5 5 0 0 1 351.4207499999998 1523.5 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="391.1082499999998" y="1546.5" class="state-label" text-anchor="middle" font-size="16">Completed</text>
+      <path d="M 351.4207499999998 1523.5 H 430.7957499999998 A 5 5 0 0 1 435.7957499999998 1528.5 V 1554.5 A 5 5 0 0 1 430.7957499999998 1559.5 H 351.4207499999998 A 5 5 0 0 1 346.4207499999998 1554.5 V 1528.5 A 5 5 0 0 1 351.4207499999998 1523.5 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
+      <text x="391.1082499999998" y="1546.5" class="state-label" font-size="16" text-anchor="middle">Completed</text>
     </g>
     <g class="state-node" id="state-Executing">
-      <path d="M 482.0855937499998 981 H 554.3512187499998 A 5 5 0 0 1 559.3512187499998 986 V 1012 A 5 5 0 0 1 554.3512187499998 1017 H 482.0855937499998 A 5 5 0 0 1 477.0855937499998 1012 V 986 A 5 5 0 0 1 482.0855937499998 981 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
+      <path d="M 482.0855937499998 981 H 554.3512187499998 A 5 5 0 0 1 559.3512187499998 986 V 1012 A 5 5 0 0 1 554.3512187499998 1017 H 482.0855937499998 A 5 5 0 0 1 477.0855937499998 1012 V 986 A 5 5 0 0 1 482.0855937499998 981 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
       <text x="518.2184062499998" y="1004" class="state-label" text-anchor="middle" font-size="16">Executing</text>
     </g>
     <g class="state-node" id="state-Failed">
-      <path d="M 495.4293437499998 1523.5 H 541.0074687499998 A 5 5 0 0 1 546.0074687499998 1528.5 V 1554.5 A 5 5 0 0 1 541.0074687499998 1559.5 H 495.4293437499998 A 5 5 0 0 1 490.4293437499998 1554.5 V 1528.5 A 5 5 0 0 1 495.4293437499998 1523.5 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <path d="M 495.4293437499998 1523.5 H 541.0074687499998 A 5 5 0 0 1 546.0074687499998 1528.5 V 1554.5 A 5 5 0 0 1 541.0074687499998 1559.5 H 495.4293437499998 A 5 5 0 0 1 490.4293437499998 1554.5 V 1528.5 A 5 5 0 0 1 495.4293437499998 1523.5 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
       <text x="518.2184062499998" y="1546.5" class="state-label" text-anchor="middle" font-size="16">Failed</text>
     </g>
     <g class="state-node" id="state-Finalizing">
-      <path d="M 483.4254374999998 1112 H 553.0113749999998 A 5 5 0 0 1 558.0113749999998 1117 V 1143 A 5 5 0 0 1 553.0113749999998 1148 H 483.4254374999998 A 5 5 0 0 1 478.4254374999998 1143 V 1117 A 5 5 0 0 1 483.4254374999998 1112 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <path d="M 483.4254374999998 1112 H 553.0113749999998 A 5 5 0 0 1 558.0113749999998 1117 V 1143 A 5 5 0 0 1 553.0113749999998 1148 H 483.4254374999998 A 5 5 0 0 1 478.4254374999998 1143 V 1117 A 5 5 0 0 1 483.4254374999998 1112 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
       <text x="518.2184062499998" y="1135" class="state-label" font-size="16" text-anchor="middle">Finalizing</text>
     </g>
     <g class="state-node" id="state-Idle_start">
@@ -254,26 +192,26 @@ marker path {
       <circle cx="607.7184062499998" cy="345" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Queued">
-      <path d="M 488.7496562499998 568 H 547.6871562499998 A 5 5 0 0 1 552.6871562499998 573 V 599 A 5 5 0 0 1 547.6871562499998 604 H 488.7496562499998 A 5 5 0 0 1 483.7496562499998 599 V 573 A 5 5 0 0 1 488.7496562499998 568 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <path d="M 488.7496562499998 568 H 547.6871562499998 A 5 5 0 0 1 552.6871562499998 573 V 599 A 5 5 0 0 1 547.6871562499998 604 H 488.7496562499998 A 5 5 0 0 1 483.7496562499998 599 V 573 A 5 5 0 0 1 488.7496562499998 568 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
       <text x="518.2184062499998" y="591" class="state-label" text-anchor="middle" font-size="16">Queued</text>
     </g>
     <g class="state-node" id="state-Ready">
-      <path d="M 569.2828593749999 180 H 617.5328593749999 A 5 5 0 0 1 622.5328593749999 185 V 211 A 5 5 0 0 1 617.5328593749999 216 H 569.2828593749999 A 5 5 0 0 1 564.2828593749999 211 V 185 A 5 5 0 0 1 569.2828593749999 180 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
-      <text x="593.4078593749999" y="203" class="state-label" font-size="16" text-anchor="middle">Ready</text>
+      <path d="M 569.2828593749999 180 H 617.5328593749999 A 5 5 0 0 1 622.5328593749999 185 V 211 A 5 5 0 0 1 617.5328593749999 216 H 569.2828593749999 A 5 5 0 0 1 564.2828593749999 211 V 185 A 5 5 0 0 1 569.2828593749999 180 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <text x="593.4078593749999" y="203" class="state-label" text-anchor="middle" font-size="16">Ready</text>
     </g>
     <g class="state-node" id="state-Running_end">
-      <path d="M 511.2184062499998 1250 A 7 7 0 1 0 525.2184062499998 1250 A 7 7 0 1 0 511.2184062499998 1250 Z" class="state-end-outer" stroke-width="2" fill="none" stroke="#9370DB"/>
-      <path d="M 515.6984062499998 1250 A 2.52 2.52 0 1 0 520.7384062499998 1250 A 2.52 2.52 0 1 0 515.6984062499998 1250 Z" class="state-end-inner" fill="#9370DB" stroke-width="2" stroke="#9370DB"/>
+      <path d="M 511.2184062499998 1250 A 7 7 0 1 0 525.2184062499998 1250 A 7 7 0 1 0 511.2184062499998 1250 Z" class="state-end-outer" stroke="#9370DB" stroke-width="2" fill="none"/>
+      <path d="M 515.6984062499998 1250 A 2.52 2.52 0 1 0 520.7384062499998 1250 A 2.52 2.52 0 1 0 515.6984062499998 1250 Z" class="state-end-inner" fill="#9370DB" stroke="#9370DB" stroke-width="2"/>
     </g>
     <g class="state-node" id="state-Running_start">
       <circle cx="518.2184062499998" cy="748" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Timeout">
-      <path d="M 698.5527812499998 1666 H 758.3496562499998 A 5 5 0 0 1 763.3496562499998 1671 V 1697 A 5 5 0 0 1 758.3496562499998 1702 H 698.5527812499998 A 5 5 0 0 1 693.5527812499998 1697 V 1671 A 5 5 0 0 1 698.5527812499998 1666 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
+      <path d="M 698.5527812499998 1666 H 758.3496562499998 A 5 5 0 0 1 763.3496562499998 1671 V 1697 A 5 5 0 0 1 758.3496562499998 1702 H 698.5527812499998 A 5 5 0 0 1 693.5527812499998 1697 V 1671 A 5 5 0 0 1 698.5527812499998 1666 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
       <text x="728.4512187499998" y="1689" class="state-label" text-anchor="middle" font-size="16">Timeout</text>
     </g>
     <g class="state-node" id="state-Validating">
-      <path d="M 571.5816874999998 432 H 643.8551249999998 A 5 5 0 0 1 648.8551249999998 437 V 463 A 5 5 0 0 1 643.8551249999998 468 H 571.5816874999998 A 5 5 0 0 1 566.5816874999998 463 V 437 A 5 5 0 0 1 571.5816874999998 432 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
+      <path d="M 571.5816874999998 432 H 643.8551249999998 A 5 5 0 0 1 648.8551249999998 437 V 463 A 5 5 0 0 1 643.8551249999998 468 H 571.5816874999998 A 5 5 0 0 1 566.5816874999998 463 V 437 A 5 5 0 0 1 571.5816874999998 432 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
       <text x="607.7184062499998" y="455" class="state-label" text-anchor="middle" font-size="16">Validating</text>
     </g>
     <g class="state-node" id="state-WaitingResume">
@@ -281,7 +219,7 @@ marker path {
       <text x="728.4512187499998" y="1538" class="state-label" font-size="16" text-anchor="middle">WaitingResume</text>
     </g>
     <g class="state-node" id="state-root_end">
-      <path d="M 596.4078593749999 1901 A 7 7 0 1 0 610.4078593749999 1901 A 7 7 0 1 0 596.4078593749999 1901 Z" class="state-end-outer" stroke="#9370DB" stroke-width="2" fill="none"/>
+      <path d="M 596.4078593749999 1901 A 7 7 0 1 0 610.4078593749999 1901 A 7 7 0 1 0 596.4078593749999 1901 Z" class="state-end-outer" stroke-width="2" fill="none" stroke="#9370DB"/>
       <path d="M 600.887859375 1901 A 2.52 2.52 0 1 0 605.9278593749999 1901 A 2.52 2.52 0 1 0 600.887859375 1901 Z" class="state-end-inner" fill="#9370DB" stroke="#9370DB" stroke-width="2"/>
     </g>
     <g class="state-node" id="state-root_start">
@@ -291,25 +229,25 @@ marker path {
       <path d="M 593.41 14.00 C 593.41 22.33, 593.41 30.67, 593.41 39.00 C 593.41 47.33, 593.41 55.67, 593.41 64.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 593.41 115.00 C 593.41 125.83, 593.41 136.67, 593.41 147.50 C 593.41 158.33, 593.41 169.17, 593.41 180.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 593.41 115.00 C 593.41 125.83, 593.41 136.67, 593.41 147.50 C 593.41 158.33, 593.41 169.17, 593.41 180.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 593.41 216.00 C 593.41 230.17, 593.41 244.33, 593.41 258.50 C 593.41 272.67, 593.41 286.83, 593.41 301.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 593.41 216.00 C 593.41 230.17, 593.41 244.33, 593.41 258.50 C 593.41 272.67, 593.41 286.83, 593.41 301.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
       <path d="M 557.4078593749999 247.7 H 629.4078593749999 A 2 2 0 0 1 631.4078593749999 249.7 V 267.3 A 2 2 0 0 1 629.4078593749999 269.3 H 557.4078593749999 A 2 2 0 0 1 555.4078593749999 267.3 V 249.7 A 2 2 0 0 1 557.4078593749999 247.7 Z" class="transition-label-bg"/>
-      <text x="593.4078593749999" y="258.5" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Start Job</text>
+      <text x="593.4078593749999" y="258.5" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Start Job</text>
     </g>
     <g class="transition">
-      <path d="M 566.64 352.00 C 566.64 365.33, 566.64 378.67, 566.64 392.00 C 566.64 405.33, 566.64 418.67, 566.64 432.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 566.64 352.00 C 566.64 365.33, 566.64 378.67, 566.64 392.00 C 566.64 405.33, 566.64 418.67, 566.64 432.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 542.95 468.00 C 521.01 484.67, 499.08 501.33, 488.11 518.00 C 477.14 534.67, 477.14 551.33, 477.14 568.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 542.95 468.00 C 521.01 484.67, 499.08 501.33, 488.11 518.00 C 477.14 534.67, 477.14 551.33, 477.14 568.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
       <path d="M 470.138495411706 497.3242618659663 H 510.138495411706 A 2 2 0 0 1 512.138495411706 499.3242618659663 V 516.9242618659663 A 2 2 0 0 1 510.138495411706 518.9242618659663 H 470.138495411706 A 2 2 0 0 1 468.138495411706 516.9242618659663 V 499.3242618659663 A 2 2 0 0 1 470.138495411706 497.3242618659663 Z" class="transition-label-bg"/>
-      <text x="490.138495411706" y="508.12426186596633" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Valid</text>
+      <text x="490.138495411706" y="508.12426186596633" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Valid</text>
     </g>
     <g class="transition">
-      <path d="M 607.78 460.02 C 687.14 479.35, 766.51 498.67, 806.19 641.84 C 845.87 785.00, 845.87 1052.00, 789.05 1219.79 C 618.58 1456.15, 504.93 1524.73, 504.93 1524.73" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 607.78 460.02 C 687.14 479.35, 766.51 498.67, 806.19 641.84 C 845.87 785.00, 845.87 1052.00, 789.05 1219.79 C 618.58 1456.15, 504.93 1524.73, 504.93 1524.73" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
       <path d="M 817.87309375 984.2758386278989 H 873.87309375 A 2 2 0 0 1 875.87309375 986.2758386278989 V 1003.8758386278989 A 2 2 0 0 1 873.87309375 1005.8758386278989 H 817.87309375 A 2 2 0 0 1 815.87309375 1003.8758386278989 V 986.2758386278989 A 2 2 0 0 1 817.87309375 984.2758386278989 Z" class="transition-label-bg"/>
-      <text x="845.87309375" y="995.0758386278989" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Invalid</text>
+      <text x="845.87309375" y="995.0758386278989" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Invalid</text>
     </g>
     <g class="transition">
       <path d="M 477.14 604.00 L 518.22 704.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
@@ -317,73 +255,73 @@ marker path {
       <text x="477.14028124999993" y="654" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Worker Available</text>
     </g>
     <g class="transition">
-      <path d="M 518.22 1269.00 C 462.16 1285.67, 406.09 1302.33, 378.06 1344.75 C 350.03 1387.17, 350.03 1455.33, 350.03 1523.50" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 518.22 1269.00 C 462.16 1285.67, 406.09 1302.33, 378.06 1344.75 C 350.03 1387.17, 350.03 1455.33, 350.03 1523.50" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
       <path d="M 322.03012499999994 1341.4217243105106 H 378.03012499999994 A 2 2 0 0 1 380.03012499999994 1343.4217243105106 V 1361.0217243105105 A 2 2 0 0 1 378.03012499999994 1363.0217243105105 H 322.03012499999994 A 2 2 0 0 1 320.03012499999994 1361.0217243105105 V 1343.4217243105106 A 2 2 0 0 1 322.03012499999994 1341.4217243105106 Z" class="transition-label-bg"/>
-      <text x="350.03012499999994" y="1352.2217243105106" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Success</text>
+      <text x="350.03012499999994" y="1352.2217243105106" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Success</text>
     </g>
     <g class="transition">
-      <path d="M 518.22 1269.00 C 502.98 1285.67, 487.74 1302.33, 480.84 1344.75 C 473.93 1387.17, 475.35 1455.33, 476.77 1523.50" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 518.22 1269.00 C 502.98 1285.67, 487.74 1302.33, 480.84 1344.75 C 473.93 1387.17, 475.35 1455.33, 476.77 1523.50" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
       <path d="M 454.11549191777334 1385.4529924434096 H 494.11549191777334 A 2 2 0 0 1 496.11549191777334 1387.4529924434096 V 1405.0529924434095 A 2 2 0 0 1 494.11549191777334 1407.0529924434095 H 454.11549191777334 A 2 2 0 0 1 452.11549191777334 1405.0529924434095 V 1387.4529924434096 A 2 2 0 0 1 454.11549191777334 1385.4529924434096 Z" class="transition-label-bg"/>
       <text x="474.11549191777334" y="1396.2529924434095" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Error</text>
     </g>
     <g class="transition">
-      <path d="M 518.22 1269.00 C 554.27 1285.67, 590.32 1302.33, 625.36 1319.00 C 660.40 1335.67, 694.43 1352.33, 728.45 1369.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 518.22 1269.00 C 554.27 1285.67, 590.32 1302.33, 625.36 1319.00 C 660.40 1335.67, 694.43 1352.33, 728.45 1369.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
       <path d="M 549.2774161809454 1252.2852674963112 H 653.2774161809454 A 2 2 0 0 1 655.2774161809454 1254.2852674963112 V 1271.8852674963111 A 2 2 0 0 1 653.2774161809454 1273.8852674963111 H 549.2774161809454 A 2 2 0 0 1 547.2774161809454 1271.8852674963111 V 1254.2852674963112 A 2 2 0 0 1 549.2774161809454 1252.2852674963112 Z" class="transition-label-bg"/>
-      <text x="601.2774161809454" y="1263.0852674963112" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Pause Request</text>
+      <text x="601.2774161809454" y="1263.0852674963112" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Pause Request</text>
     </g>
     <g class="transition">
-      <path d="M 518.22 755.00 C 518.22 770.83, 518.22 786.67, 518.22 802.50 C 518.22 818.33, 518.22 834.17, 518.22 850.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 518.22 755.00 C 518.22 770.83, 518.22 786.67, 518.22 802.50 C 518.22 818.33, 518.22 834.17, 518.22 850.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 518.22 886.00 C 518.22 901.83, 518.22 917.67, 518.22 933.50 C 518.22 949.33, 518.22 965.17, 518.22 981.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 518.22 886.00 C 518.22 901.83, 518.22 917.67, 518.22 933.50 C 518.22 949.33, 518.22 965.17, 518.22 981.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 518.22 1017.00 C 518.22 1032.83, 518.22 1048.67, 518.22 1064.50 C 518.22 1080.33, 518.22 1096.17, 518.22 1112.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 518.22 1017.00 C 518.22 1032.83, 518.22 1048.67, 518.22 1064.50 C 518.22 1080.33, 518.22 1096.17, 518.22 1112.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
       <path d="M 518.22 1148.00 C 518.22 1163.83, 518.22 1179.67, 518.22 1195.50 C 518.22 1211.33, 518.22 1227.17, 518.22 1243.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 728.45 1420.00 C 728.45 1435.83, 728.45 1451.67, 728.45 1467.50 C 728.45 1483.33, 728.45 1499.17, 728.45 1515.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 728.45 1420.00 C 728.45 1435.83, 728.45 1451.67, 728.45 1467.50 C 728.45 1483.33, 728.45 1499.17, 728.45 1515.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 728.45 1551.00 C 728.45 1570.17, 728.45 1589.33, 728.45 1608.50 C 728.45 1627.67, 728.45 1646.83, 728.45 1666.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 728.45 1551.00 C 728.45 1570.17, 728.45 1589.33, 728.45 1608.50 C 728.45 1627.67, 728.45 1646.83, 728.45 1666.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
       <path d="M 704.4512187499998 1597.7 H 752.4512187499998 A 2 2 0 0 1 754.4512187499998 1599.7 V 1617.3 A 2 2 0 0 1 752.4512187499998 1619.3 H 704.4512187499998 A 2 2 0 0 1 702.4512187499998 1617.3 V 1599.7 A 2 2 0 0 1 704.4512187499998 1597.7 Z" class="transition-label-bg"/>
       <text x="728.4512187499998" y="1608.5" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">1 hour</text>
     </g>
     <g class="transition">
-      <path d="M 728.45 1714.00 C 735.09 1582.33, 741.73 1450.67, 706.69 1282.33 C 671.65 1114.00, 594.94 909.00, 518.22 704.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 728.45 1714.00 C 735.09 1582.33, 741.73 1450.67, 706.69 1282.33 C 671.65 1114.00, 594.94 909.00, 518.22 704.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
       <path d="M 644.0486238573761 1209.7315072202136 H 692.0486238573761 A 2 2 0 0 1 694.0486238573761 1211.7315072202136 V 1229.3315072202136 A 2 2 0 0 1 692.0486238573761 1231.3315072202136 H 644.0486238573761 A 2 2 0 0 1 642.0486238573761 1229.3315072202136 V 1211.7315072202136 A 2 2 0 0 1 644.0486238573761 1209.7315072202136 Z" class="transition-label-bg"/>
-      <text x="668.0486238573761" y="1220.5315072202136" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Resume</text>
+      <text x="668.0486238573761" y="1220.5315072202136" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Resume</text>
     </g>
     <g class="transition">
-      <path d="M 728.45 1714.00 C 705.94 1729.67, 683.44 1745.33, 660.93 1761.00 C 638.42 1776.67, 615.92 1792.33, 593.41 1808.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 728.45 1714.00 C 705.94 1729.67, 683.44 1745.33, 660.93 1761.00 C 638.42 1776.67, 615.92 1792.33, 593.41 1808.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
       <path d="M 604.9295390624999 1750.2 H 716.9295390624999 A 2 2 0 0 1 718.9295390624999 1752.2 V 1769.8 A 2 2 0 0 1 716.9295390624999 1771.8 H 604.9295390624999 A 2 2 0 0 1 602.9295390624999 1769.8 V 1752.2 A 2 2 0 0 1 604.9295390624999 1750.2 Z" class="transition-label-bg"/>
-      <text x="660.9295390624999" y="1761" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Cancel Request</text>
+      <text x="660.9295390624999" y="1761" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Cancel Request</text>
     </g>
     <g class="transition">
-      <path d="M 728.45 1702.00 C 705.94 1719.67, 683.44 1737.33, 660.93 1755.00 C 638.42 1772.67, 615.92 1790.33, 593.41 1808.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 728.45 1702.00 C 705.94 1719.67, 683.44 1737.33, 660.93 1755.00 C 638.42 1772.67, 615.92 1790.33, 593.41 1808.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 391.11 1523.50 C 424.82 1559.25, 458.54 1595.00, 492.26 1630.75 C 525.97 1666.50, 559.69 1702.25, 593.41 1738.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 391.11 1523.50 C 424.82 1559.25, 458.54 1595.00, 492.26 1630.75 C 525.97 1666.50, 559.69 1702.25, 593.41 1738.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
       <path d="M 472.2580546874999 1619.95 H 512.2580546874999 A 2 2 0 0 1 514.2580546874999 1621.95 V 1639.55 A 2 2 0 0 1 512.2580546874999 1641.55 H 472.2580546874999 A 2 2 0 0 1 470.2580546874999 1639.55 V 1621.95 A 2 2 0 0 1 472.2580546874999 1619.95 Z" class="transition-label-bg"/>
-      <text x="492.2580546874999" y="1630.75" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Reset</text>
+      <text x="492.2580546874999" y="1630.75" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Reset</text>
     </g>
     <g class="transition">
-      <path d="M 518.22 1523.50 C 530.75 1559.25, 543.28 1595.00, 555.81 1630.75 C 568.34 1666.50, 580.88 1702.25, 593.41 1738.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 518.22 1523.50 C 530.75 1559.25, 543.28 1595.00, 555.81 1630.75 C 568.34 1666.50, 580.88 1702.25, 593.41 1738.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
       <path d="M 535.8131328124998 1619.95 H 575.8131328124998 A 2 2 0 0 1 577.8131328124998 1621.95 V 1639.55 A 2 2 0 0 1 575.8131328124998 1641.55 H 535.8131328124998 A 2 2 0 0 1 533.8131328124998 1639.55 V 1621.95 A 2 2 0 0 1 535.8131328124998 1619.95 Z" class="transition-label-bg"/>
-      <text x="555.8131328124998" y="1630.75" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Retry</text>
+      <text x="555.8131328124998" y="1630.75" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Retry</text>
     </g>
     <g class="transition">
-      <path d="M 605.80 1808.00 C 613.84 1796.33, 621.87 1784.67, 619.81 1494.00 C 617.74 1203.33, 605.57 633.67, 593.41 64.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 605.80 1808.00 C 613.84 1796.33, 621.87 1784.67, 619.81 1494.00 C 617.74 1203.33, 605.57 633.67, 593.41 64.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
       <path d="M 607.7904565700014 1765.2745848949294 H 647.7904565700014 A 2 2 0 0 1 649.7904565700014 1767.2745848949294 V 1784.8745848949293 A 2 2 0 0 1 647.7904565700014 1786.8745848949293 H 607.7904565700014 A 2 2 0 0 1 605.7904565700014 1784.8745848949293 V 1767.2745848949294 A 2 2 0 0 1 607.7904565700014 1765.2745848949294 Z" class="transition-label-bg"/>
-      <text x="627.7904565700014" y="1776.0745848949293" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Reset</text>
+      <text x="627.7904565700014" y="1776.0745848949293" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Reset</text>
     </g>
     <g class="transition">
-      <path d="M 391.11 1559.50 C 425.90 1615.41, 460.69 1671.32, 495.48 1727.24 C 530.27 1783.15, 565.06 1839.06, 599.85 1894.97" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 391.11 1559.50 C 425.90 1615.41, 460.69 1671.32, 495.48 1727.24 C 530.27 1783.15, 565.06 1839.06, 599.85 1894.97" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 593.41 1844.00 C 593.41 1852.33, 593.41 1860.67, 594.73 1869.05 C 596.05 1877.44, 598.68 1885.88, 601.32 1894.32" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 593.41 1844.00 C 593.41 1852.33, 593.41 1860.67, 594.73 1869.05 C 596.05 1877.44, 598.68 1885.88, 601.32 1894.32" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
   </g>
 </svg>

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -1416,9 +1416,8 @@ pub fn render_state(db: &StateDb, config: &RenderConfig) -> Result<String> {
     let view_y = bounds_y - margin - title_offset;
     doc.set_size_with_origin(view_x, view_y, max_width, max_height);
 
-    // Add theme styles
+    // Add state-specific theme styles (no base flowchart CSS - state has its own complete styles)
     if config.embed_css {
-        doc.add_style(&config.theme.generate_css());
         doc.add_style(&generate_state_css(&config.theme));
     }
 
@@ -2339,10 +2338,33 @@ fn render_end_state_bullseye(
 }
 
 fn generate_state_css(theme: &crate::render::svg::Theme) -> String {
+    // Compute stateLabelColor = invert(primaryColor), matching mermaid's theme-default.js:
+    //   this.stateLabelColor = this.stateLabelColor || this.stateBkg || this.primaryTextColor;
+    //   this.primaryTextColor = invert(this.primaryColor);
+    // For the default theme (#ECECFF), invert gives #131300
+    let state_label_color = crate::render::svg::color::Color::parse(&theme.primary_color)
+        .map(|c| crate::render::svg::color::invert(&c).to_hex())
+        .unwrap_or_else(|| theme.primary_text_color.clone());
+
     format!(
         r#"
-.state-title {{
+.statediagram {{
+  font-family: {font_family};
+  font-size: {font_size};
   fill: {text_color};
+}}
+
+.error-icon {{
+  fill: #552222;
+}}
+
+.error-text {{
+  fill: #552222;
+  stroke: #552222;
+}}
+
+.state-title {{
+  fill: {state_label_color};
 }}
 
 .state-box {{
@@ -2351,11 +2373,11 @@ fn generate_state_css(theme: &crate::render::svg::Theme) -> String {
 }}
 
 .state-label {{
-  fill: {text_color};
+  fill: {state_label_color};
 }}
 
 .state-description {{
-  fill: #666666;
+  fill: {text_color};
 }}
 
 .state-start {{
@@ -2405,11 +2427,11 @@ fn generate_state_css(theme: &crate::render::svg::Theme) -> String {
 
 .note-box {{
   fill: {note_bkg_color};
-  stroke: {line_color};
+  stroke: {note_border_color};
 }}
 
 .note-text {{
-  fill: {text_color};
+  fill: {note_text_color};
 }}
 
 .state-composite-outer {{
@@ -2424,7 +2446,7 @@ fn generate_state_css(theme: &crate::render::svg::Theme) -> String {
 }}
 
 .state-composite-inner-alt {{
-  fill: #f0f0f0;
+  fill: #e0e0e0;
   stroke: none;
 }}
 
@@ -2439,6 +2461,8 @@ fn generate_state_css(theme: &crate::render::svg::Theme) -> String {
   fill: none;
 }}
 "#,
+        font_family = theme.font_family,
+        font_size = theme.font_size,
         text_color = theme.primary_text_color,
         primary_color = theme.primary_color,
         primary_border_color = theme.primary_border_color,
@@ -2446,6 +2470,9 @@ fn generate_state_css(theme: &crate::render::svg::Theme) -> String {
         background = theme.background,
         edge_label_background = theme.edge_label_background,
         note_bkg_color = theme.note_bkg_color,
+        note_border_color = theme.note_border_color,
+        note_text_color = theme.note_text_color,
+        state_label_color = state_label_color,
     )
 }
 
@@ -3072,7 +3099,7 @@ Cancelled --> [*]
     #[test]
     fn test_nested_composite_has_alternate_background() {
         // Nested composite states (like Executing inside Processing) should have
-        // gray alternate background (#f0f0f0) instead of white
+        // gray alternate background (#e0e0e0) to match mermaid reference .alt-composit class
         let input = r#"stateDiagram-v2
     state Processing {
         [*] --> Validating
@@ -3093,10 +3120,77 @@ Cancelled --> [*]
             "Nested composite state should use alternate inner class"
         );
 
-        // Verify the CSS includes the alternate background color
+        // Verify the CSS includes the alternate background color (#e0e0e0 matches mermaid .alt-composit)
         assert!(
-            svg.contains("#f0f0f0"),
-            "CSS should include alternate background color #f0f0f0"
+            svg.contains("#e0e0e0"),
+            "CSS should include alternate background color #e0e0e0 (mermaid .alt-composit)"
+        );
+    }
+
+    #[test]
+    fn test_state_fill_colors_match_mermaid_reference() {
+        // Verify that the state diagram CSS uses the correct fill colors
+        // matching the mermaid.js reference implementation.
+        // See reference-implementations/mermaid/packages/mermaid/src/diagrams/state/styles.js
+        let input = r#"stateDiagram-v2
+    [*] --> Idle
+    Idle --> Running : start
+    Running --> Idle : stop
+    Running --> Error : error
+    Error --> Idle : reset
+    Error --> [*]
+"#;
+        let db = parse(input).expect("Should parse");
+        let config = crate::render::RenderConfig::default();
+        let svg = render_state(&db, &config).expect("Should render");
+
+        // note_bkg_color should be #fff5ad (mermaid default), not #FFFFCC
+        assert!(
+            svg.contains("#fff5ad"),
+            "Note background should be #fff5ad (mermaid default theme)"
+        );
+        assert!(
+            !svg.contains("#FFFFCC") && !svg.contains("#ffffcc"),
+            "Should not contain old note background #FFFFCC"
+        );
+
+        // Composite inner should use literal 'white', not '#ffffff'
+        assert!(
+            svg.contains("fill: white"),
+            "Composite inner fill should use literal 'white'"
+        );
+
+        // State title should use #131300 (invert of primaryColor #ECECFF)
+        assert!(
+            svg.contains("#131300"),
+            "State title color should be #131300 (stateLabelColor = invert(primaryColor))"
+        );
+
+        // Note text should use 'black' (mermaid: actorTextColor)
+        assert!(
+            svg.contains("fill: black"),
+            "Note text fill should be 'black'"
+        );
+
+        // Alt-composite should use #e0e0e0 (mermaid .alt-composit hardcoded)
+        assert!(
+            svg.contains("#e0e0e0"),
+            "Alt-composite background should be #e0e0e0"
+        );
+
+        // Error styles should use #552222 (mermaid error-icon/error-text)
+        assert!(svg.contains("#552222"), "Error styles should use #552222");
+
+        // Should NOT contain #666666 (wrong description color)
+        assert!(
+            !svg.contains("#666666"),
+            "Should not use #666666 for state description"
+        );
+
+        // Should NOT contain #ffffde (secondary_color, not used in state diagrams)
+        assert!(
+            !svg.contains("#ffffde"),
+            "Should not contain secondary_color #ffffde in state diagram CSS"
         );
     }
 

--- a/src/render/svg/theme.rs
+++ b/src/render/svg/theme.rs
@@ -280,7 +280,7 @@ impl Default for Theme {
             tertiary_color: "#fafafa".to_string(),
             cluster_border_color: "#aaaa33".to_string(),
             line_color: "#333333".to_string(),
-            background: "#ffffff".to_string(),
+            background: "white".to_string(),
             edge_label_background: "rgba(232, 232, 232, 0.8)".to_string(),
             font_family: "trebuchet ms, verdana, arial, sans-serif".to_string(),
             font_size: "16px".to_string(),
@@ -298,9 +298,9 @@ impl Default for Theme {
             actor_line_color: "#999999".to_string(),
             signal_color: "#333333".to_string(),
             signal_text_color: "#333333".to_string(),
-            note_bkg_color: "#FFFFCC".to_string(),
+            note_bkg_color: "#fff5ad".to_string(),
             note_border_color: "#aaaa33".to_string(),
-            note_text_color: "#333333".to_string(),
+            note_text_color: "black".to_string(),
             activation_bkg_color: "#f4f4f4".to_string(),
             activation_border_color: "#666666".to_string(),
             label_box_bkg_color: "#fff5ad".to_string(),
@@ -1796,7 +1796,7 @@ mod tests {
         assert_eq!(theme.primary_color, "#ff0000");
         assert_eq!(theme.secondary_color, "#00ff00");
         // Other colors should remain default
-        assert_eq!(theme.background, "#ffffff");
+        assert_eq!(theme.background, "white");
     }
 
     #[test]
@@ -1849,7 +1849,7 @@ mod tests {
         let theme = Theme::default();
 
         assert_eq!(theme.get_variable("primaryColor"), Some("#ECECFF"));
-        assert_eq!(theme.get_variable("background"), Some("#ffffff"));
+        assert_eq!(theme.get_variable("background"), Some("white"));
         assert_eq!(theme.get_variable("unknownVar"), None);
 
         // Aliases should work
@@ -1924,7 +1924,7 @@ mod tests {
         assert_eq!(theme.primary_color, "#ff0000");
         assert_eq!(theme.line_color, "#00ff00");
         // Other values should remain default
-        assert_eq!(theme.background, "#ffffff");
+        assert_eq!(theme.background, "white");
     }
 
     #[test]


### PR DESCRIPTION
<!-- midtown: prince -->

## Summary
- Aligns state diagram fill colors with mermaid.js reference (was 42% color match, now passing)
- Fixes 7 color mismatches: note background (#fff5ad), note text (black), background (white), state title (#131300), description (#333333), alt-composite (#e0e0e0), error styles (#552222)
- Removes base flowchart CSS from state diagrams to eliminate secondary_color (#ffffde) leak

## Test plan
- [x] New test `test_state_fill_colors_match_mermaid_reference` verifies all expected colors
- [x] Updated `test_nested_composite_has_alternate_background` for #e0e0e0
- [x] All 17 state tests pass
- [x] All 1560 tests pass (3 theme tests updated for `white` default)
- [x] `cargo clippy` clean
- [x] Eval color warning resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)