### PR TITLE
fix(requirement): align CSS colors and stroke-width with mermaid reference

### DIFF
--- a/docs/images/requirement.svg
+++ b/docs/images/requirement.svg
@@ -90,12 +90,12 @@ marker path {
 }
 
 .requirement-type {
-  fill: #333333;
+  fill: #131300;
   font-weight: bold;
 }
 
 .requirement-name {
-  fill: #333333;
+  fill: #131300;
 }
 
 .requirement-attr {
@@ -113,12 +113,12 @@ marker path {
 }
 
 .element-type {
-  fill: #333333;
+  fill: #131300;
   font-weight: bold;
 }
 
 .element-name {
-  fill: #333333;
+  fill: #131300;
 }
 
 .element-attr {
@@ -132,11 +132,11 @@ marker path {
 .relationship-line {
   fill: none;
   stroke: #333333;
-  stroke-width: 1.5;
+  stroke-width: 1;
 }
 
 .relationship-label {
-  fill: #333333;
+  fill: black;
 }
 
 .relationship-label-bg {
@@ -149,6 +149,19 @@ marker path {
   stroke: none;
 }
 
+.error-icon {
+  fill: #552222;
+}
+
+.error-text {
+  fill: #552222;
+  stroke: #552222;
+}
+
+.label {
+  fill: #333;
+}
+
   </style>
   <defs>
     <marker id="requirement-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
@@ -156,13 +169,10 @@ marker path {
     </marker>
     <marker id="requirement-contains-start" viewBox="0 0 20 20" refX="0" refY="10" markerWidth="20" markerHeight="20" orient="auto">
       <g>
-        <circle cx="10" cy="10" r="9" stroke="#333333" stroke-width="1" fill="none"/>
+        <circle cx="10" cy="10" r="9" stroke-width="1" fill="none" stroke="#333333"/>
         <line x1="1" y1="10" x2="19" y2="10" stroke="#333333" stroke-width="1"/>
-        <line x1="10" y1="1" x2="10" y2="19" stroke="#333333" stroke-width="1"/>
+        <line x1="10" y1="1" x2="10" y2="19" stroke-width="1" stroke="#333333"/>
       </g>
-    </marker>
-    <marker id="requirement-contains" viewBox="0 0 20 20" refX="18" refY="10" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0,10 L10,0 L20,10 L10,20 z" class="marker"/>
     </marker>
   </defs>
   <g class="root">
@@ -181,72 +191,72 @@ marker path {
     <g class="relationship">
       <path d="M 74.75 124.00 L 84.81 460.00" class="relationship-line" stroke-dasharray="10,7" marker-end="url(#requirement-arrow)"/>
       <rect x="25.25" y="282.7084087022259" width="99" height="20" rx="3" ry="3" class="relationship-label-bg"/>
-      <text x="74.75" y="296.7084087022259" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;satisfies&gt;&gt;</text>
+      <text x="74.75" y="296.7084087022259" class="relationship-label" font-size="11" text-anchor="middle">&lt;&lt;satisfies&gt;&gt;</text>
     </g>
     <g class="relationship">
       <path d="M 274.38 377.23 C 257.29 393.15, 240.21 409.08, 226.53 422.87 C 212.85 436.67, 202.57 448.33, 192.29 460.00" class="relationship-line" marker-end="url(#requirement-arrow)" stroke-dasharray="10,7"/>
       <rect x="192.69019545341064" y="407.01629488012367" width="78" height="20" rx="3" ry="3" class="relationship-label-bg"/>
-      <text x="231.69019545341064" y="421.01629488012367" class="relationship-label" font-size="11" text-anchor="middle">&lt;&lt;traces&gt;&gt;</text>
+      <text x="231.69019545341064" y="421.01629488012367" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;traces&gt;&gt;</text>
     </g>
     <g class="relationship">
-      <path d="M 407.91 390.00 L 426.38 460.00" class="relationship-line" marker-start="url(#requirement-contains-start)" marker-end="url(#requirement-arrow)"/>
+      <path d="M 407.91 390.00 L 426.38 460.00" class="relationship-line" marker-end="url(#requirement-arrow)" marker-start="url(#requirement-contains-start)"/>
       <rect x="379.3083443996525" y="412.9781304291921" width="92" height="20" rx="3" ry="3" class="relationship-label-bg"/>
       <text x="425.3083443996525" y="426.9781304291921" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;contains&gt;&gt;</text>
     </g>
     <g class="relationship">
-      <path d="M 359.38 136.00 C 359.38 147.67, 359.38 159.33, 359.38 171.00 C 359.38 182.67, 359.38 194.33, 359.38 206.00" class="relationship-line" stroke-dasharray="10,7" marker-end="url(#requirement-arrow)"/>
+      <path d="M 359.38 136.00 C 359.38 147.67, 359.38 159.33, 359.38 171.00 C 359.38 182.67, 359.38 194.33, 359.38 206.00" class="relationship-line" marker-end="url(#requirement-arrow)" stroke-dasharray="10,7"/>
       <rect x="313.375" y="161" width="92" height="20" rx="3" ry="3" class="relationship-label-bg"/>
-      <text x="359.375" y="175" class="relationship-label" font-size="11" text-anchor="middle">&lt;&lt;verifies&gt;&gt;</text>
+      <text x="359.375" y="175" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;verifies&gt;&gt;</text>
     </g>
     <g class="requirement-node" id="test_req">
-      <rect x="274.375" y="206" width="170" height="184" rx="0" ry="0" class="requirement-box" fill="#ECECFF" stroke="#9370DB" stroke-width="2"/>
+      <rect x="274.375" y="206" width="170" height="184" rx="0" ry="0" class="requirement-box" stroke="#9370DB" fill="#ECECFF" stroke-width="2"/>
       <rect x="274.375" y="206" width="170" height="68" rx="0" ry="0" class="requirement-header" stroke="#9370DB" fill="#ECECFF"/>
-      <line x1="274.375" y1="274" x2="444.375" y2="274" class="divider" stroke="#9370DB" stroke-width="1"/>
+      <line x1="274.375" y1="274" x2="444.375" y2="274" class="divider" stroke-width="1" stroke="#9370DB"/>
       <text x="359.375" y="226" class="requirement-type" font-size="16" text-anchor="middle">&lt;&lt;Requirement&gt;&gt;</text>
-      <text x="359.375" y="250" class="requirement-name" font-size="16" text-anchor="middle" font-weight="bold">test_req</text>
-      <text x="284.375" y="298" class="requirement-attr" text-anchor="start" font-size="16">ID: 1</text>
+      <text x="359.375" y="250" class="requirement-name" font-size="16" font-weight="bold" text-anchor="middle">test_req</text>
+      <text x="284.375" y="298" class="requirement-attr" font-size="16" text-anchor="start">ID: 1</text>
       <text x="284.375" y="322" class="requirement-attr" font-size="16" text-anchor="start">Text: the test text.</text>
-      <text x="284.375" y="346" class="requirement-attr" text-anchor="start" font-size="16">Risk: High</text>
-      <text x="284.375" y="370" class="requirement-attr" font-size="16" text-anchor="start">Verification: Test</text>
+      <text x="284.375" y="346" class="requirement-attr" font-size="16" text-anchor="start">Risk: High</text>
+      <text x="284.375" y="370" class="requirement-attr" text-anchor="start" font-size="16">Verification: Test</text>
+    </g>
+    <g class="requirement-node" id="test_req3">
+      <rect x="315.125" y="460" width="222.5" height="184" rx="0" ry="0" class="requirement-box" stroke="#9370DB" fill="#ECECFF" stroke-width="2"/>
+      <rect x="315.125" y="460" width="222.5" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
+      <line x1="315.125" y1="528" x2="537.625" y2="528" class="divider" stroke="#9370DB" stroke-width="1"/>
+      <text x="426.375" y="480" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Performance Requirement&gt;&gt;</text>
+      <text x="426.375" y="504" class="requirement-name" font-size="16" font-weight="bold" text-anchor="middle">test_req3</text>
+      <text x="325.125" y="552" class="requirement-attr" text-anchor="start" font-size="16">ID: 1.2</text>
+      <text x="325.125" y="576" class="requirement-attr" font-size="16" text-anchor="start">Text: the third test text.</text>
+      <text x="325.125" y="600" class="requirement-attr" font-size="16" text-anchor="start">Risk: Medium</text>
+      <text x="325.125" y="624" class="requirement-attr" text-anchor="start" font-size="16">Verification: Demonstration</text>
     </g>
     <g class="requirement-node" id="test_req2">
-      <rect x="0" y="460" width="222.5" height="184" rx="0" ry="0" class="requirement-box" stroke-width="2" stroke="#9370DB" fill="#ECECFF"/>
-      <rect x="0" y="460" width="222.5" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
+      <rect x="0" y="460" width="222.5" height="184" rx="0" ry="0" class="requirement-box" fill="#ECECFF" stroke="#9370DB" stroke-width="2"/>
+      <rect x="0" y="460" width="222.5" height="68" rx="0" ry="0" class="requirement-header" stroke="#9370DB" fill="#ECECFF"/>
       <line x1="0" y1="528" x2="222.5" y2="528" class="divider" stroke="#9370DB" stroke-width="1"/>
-      <text x="111.25" y="480" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Functional Requirement&gt;&gt;</text>
-      <text x="111.25" y="504" class="requirement-name" font-size="16" font-weight="bold" text-anchor="middle">test_req2</text>
-      <text x="10" y="552" class="requirement-attr" text-anchor="start" font-size="16">ID: 1.1</text>
+      <text x="111.25" y="480" class="requirement-type" font-size="16" text-anchor="middle">&lt;&lt;Functional Requirement&gt;&gt;</text>
+      <text x="111.25" y="504" class="requirement-name" font-weight="bold" text-anchor="middle" font-size="16">test_req2</text>
+      <text x="10" y="552" class="requirement-attr" font-size="16" text-anchor="start">ID: 1.1</text>
       <text x="10" y="576" class="requirement-attr" text-anchor="start" font-size="16">Text: the second test text.</text>
       <text x="10" y="600" class="requirement-attr" text-anchor="start" font-size="16">Risk: Low</text>
       <text x="10" y="624" class="requirement-attr" text-anchor="start" font-size="16">Verification: Inspection</text>
     </g>
-    <g class="requirement-node" id="test_req3">
-      <rect x="315.125" y="460" width="222.5" height="184" rx="0" ry="0" class="requirement-box" stroke-width="2" fill="#ECECFF" stroke="#9370DB"/>
-      <rect x="315.125" y="460" width="222.5" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
-      <line x1="315.125" y1="528" x2="537.625" y2="528" class="divider" stroke-width="1" stroke="#9370DB"/>
-      <text x="426.375" y="480" class="requirement-type" font-size="16" text-anchor="middle">&lt;&lt;Performance Requirement&gt;&gt;</text>
-      <text x="426.375" y="504" class="requirement-name" font-size="16" font-weight="bold" text-anchor="middle">test_req3</text>
-      <text x="325.125" y="552" class="requirement-attr" text-anchor="start" font-size="16">ID: 1.2</text>
-      <text x="325.125" y="576" class="requirement-attr" text-anchor="start" font-size="16">Text: the third test text.</text>
-      <text x="325.125" y="600" class="requirement-attr" font-size="16" text-anchor="start">Risk: Medium</text>
-      <text x="325.125" y="624" class="requirement-attr" text-anchor="start" font-size="16">Verification: Demonstration</text>
+    <g class="element-node" id="test_entity">
+      <rect x="4.75" y="12" width="140" height="112" rx="0" ry="0" class="element-box" stroke="#9370DB" fill="#ECECFF" stroke-width="2"/>
+      <rect x="4.75" y="12" width="140" height="56" rx="0" ry="0" class="element-header" fill="#ECECFF" stroke="#9370DB"/>
+      <line x1="4.75" y1="68" x2="144.75" y2="68" class="divider" stroke="#9370DB" stroke-width="1"/>
+      <text x="74.75" y="32" class="element-type" font-size="16" text-anchor="middle">&lt;&lt;Element&gt;&gt;</text>
+      <text x="74.75" y="56" class="element-name" text-anchor="middle" font-size="16" font-weight="bold">test_entity</text>
+      <text x="14.75" y="92" class="element-attr" text-anchor="start" font-size="16">Type: simulation</text>
     </g>
     <g class="element-node" id="test_entity2">
-      <rect x="255.625" y="0" width="207.5" height="136" rx="0" ry="0" class="element-box" stroke="#9370DB" stroke-width="2" fill="#ECECFF"/>
-      <rect x="255.625" y="0" width="207.5" height="56" rx="0" ry="0" class="element-header" stroke="#9370DB" fill="#ECECFF"/>
-      <line x1="255.625" y1="56" x2="463.125" y2="56" class="divider" stroke-width="1" stroke="#9370DB"/>
+      <rect x="255.625" y="0" width="207.5" height="136" rx="0" ry="0" class="element-box" fill="#ECECFF" stroke-width="2" stroke="#9370DB"/>
+      <rect x="255.625" y="0" width="207.5" height="56" rx="0" ry="0" class="element-header" fill="#ECECFF" stroke="#9370DB"/>
+      <line x1="255.625" y1="56" x2="463.125" y2="56" class="divider" stroke="#9370DB" stroke-width="1"/>
       <text x="359.375" y="20" class="element-type" font-size="16" text-anchor="middle">&lt;&lt;Element&gt;&gt;</text>
-      <text x="359.375" y="44" class="element-name" text-anchor="middle" font-weight="bold" font-size="16">test_entity2</text>
+      <text x="359.375" y="44" class="element-name" text-anchor="middle" font-size="16" font-weight="bold">test_entity2</text>
       <text x="265.625" y="80" class="element-attr" text-anchor="start" font-size="16">Type: word doc</text>
-      <text x="265.625" y="104" class="element-attr" text-anchor="start" font-size="16">Doc Ref: reqs/test_entity</text>
-    </g>
-    <g class="element-node" id="test_entity">
-      <rect x="4.75" y="12" width="140" height="112" rx="0" ry="0" class="element-box" fill="#ECECFF" stroke-width="2" stroke="#9370DB"/>
-      <rect x="4.75" y="12" width="140" height="56" rx="0" ry="0" class="element-header" fill="#ECECFF" stroke="#9370DB"/>
-      <line x1="4.75" y1="68" x2="144.75" y2="68" class="divider" stroke-width="1" stroke="#9370DB"/>
-      <text x="74.75" y="32" class="element-type" font-size="16" text-anchor="middle">&lt;&lt;Element&gt;&gt;</text>
-      <text x="74.75" y="56" class="element-name" font-size="16" text-anchor="middle" font-weight="bold">test_entity</text>
-      <text x="14.75" y="92" class="element-attr" text-anchor="start" font-size="16">Type: simulation</text>
+      <text x="265.625" y="104" class="element-attr" font-size="16" text-anchor="start">Doc Ref: reqs/test_entity</text>
     </g>
   </g>
 </svg>

--- a/docs/images/requirement_complex.svg
+++ b/docs/images/requirement_complex.svg
@@ -90,12 +90,12 @@ marker path {
 }
 
 .requirement-type {
-  fill: #333333;
+  fill: #131300;
   font-weight: bold;
 }
 
 .requirement-name {
-  fill: #333333;
+  fill: #131300;
 }
 
 .requirement-attr {
@@ -113,12 +113,12 @@ marker path {
 }
 
 .element-type {
-  fill: #333333;
+  fill: #131300;
   font-weight: bold;
 }
 
 .element-name {
-  fill: #333333;
+  fill: #131300;
 }
 
 .element-attr {
@@ -132,11 +132,11 @@ marker path {
 .relationship-line {
   fill: none;
   stroke: #333333;
-  stroke-width: 1.5;
+  stroke-width: 1;
 }
 
 .relationship-label {
-  fill: #333333;
+  fill: black;
 }
 
 .relationship-label-bg {
@@ -149,6 +149,19 @@ marker path {
   stroke: none;
 }
 
+.error-icon {
+  fill: #552222;
+}
+
+.error-text {
+  fill: #552222;
+  stroke: #552222;
+}
+
+.label {
+  fill: #333;
+}
+
   </style>
   <defs>
     <marker id="requirement-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
@@ -157,12 +170,9 @@ marker path {
     <marker id="requirement-contains-start" viewBox="0 0 20 20" refX="0" refY="10" markerWidth="20" markerHeight="20" orient="auto">
       <g>
         <circle cx="10" cy="10" r="9" fill="none" stroke="#333333" stroke-width="1"/>
-        <line x1="1" y1="10" x2="19" y2="10" stroke="#333333" stroke-width="1"/>
+        <line x1="1" y1="10" x2="19" y2="10" stroke-width="1" stroke="#333333"/>
         <line x1="10" y1="1" x2="10" y2="19" stroke="#333333" stroke-width="1"/>
       </g>
-    </marker>
-    <marker id="requirement-contains" viewBox="0 0 20 20" refX="18" refY="10" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0,10 L10,0 L20,10 L10,20 z" class="marker"/>
     </marker>
   </defs>
   <g class="root">
@@ -184,7 +194,7 @@ marker path {
       <text x="111.25" y="205" class="relationship-label" font-size="11" text-anchor="middle">&lt;&lt;satisfies&gt;&gt;</text>
     </g>
     <g class="relationship">
-      <path d="M 820.35 184.00 C 811.36 195.67, 802.37 207.33, 702.72 230.88 C 603.08 254.43, 412.79 289.86, 222.50 325.29" class="relationship-line" stroke-dasharray="10,7" marker-end="url(#requirement-arrow)"/>
+      <path d="M 820.35 184.00 C 811.36 195.67, 802.37 207.33, 702.72 230.88 C 603.08 254.43, 412.79 289.86, 222.50 325.29" class="relationship-line" marker-end="url(#requirement-arrow)" stroke-dasharray="10,7"/>
       <rect x="490.6581663966592" y="258.0995607368507" width="78" height="20" rx="3" ry="3" class="relationship-label-bg"/>
       <text x="529.6581663966592" y="272.0995607368507" class="relationship-label" font-size="11" text-anchor="middle">&lt;&lt;traces&gt;&gt;</text>
     </g>
@@ -194,12 +204,12 @@ marker path {
       <text x="957.1833443996526" y="220.9781304291921" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;contains&gt;&gt;</text>
     </g>
     <g class="relationship">
-      <path d="M 958.25 438.00 C 958.25 449.67, 958.25 461.33, 958.25 473.00 C 958.25 484.67, 958.25 496.33, 958.25 508.00" class="relationship-line" marker-start="url(#requirement-contains-start)" marker-end="url(#requirement-arrow)"/>
+      <path d="M 958.25 438.00 C 958.25 449.67, 958.25 461.33, 958.25 473.00 C 958.25 484.67, 958.25 496.33, 958.25 508.00" class="relationship-line" marker-end="url(#requirement-arrow)" marker-start="url(#requirement-contains-start)"/>
       <rect x="912.25" y="463" width="92" height="20" rx="3" ry="3" class="relationship-label-bg"/>
-      <text x="958.25" y="477" class="relationship-label" font-size="11" text-anchor="middle">&lt;&lt;contains&gt;&gt;</text>
+      <text x="958.25" y="477" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;contains&gt;&gt;</text>
     </g>
     <g class="relationship">
-      <path d="M 958.25 692.00 C 958.25 703.67, 958.25 715.33, 942.60 731.03 C 926.96 746.73, 895.67 766.47, 864.38 786.20" class="relationship-line" marker-end="url(#requirement-arrow)" stroke-dasharray="10,7"/>
+      <path d="M 958.25 692.00 C 958.25 703.67, 958.25 715.33, 942.60 731.03 C 926.96 746.73, 895.67 766.47, 864.38 786.20" class="relationship-line" stroke-dasharray="10,7" marker-end="url(#requirement-arrow)"/>
       <rect x="883.6146659639663" y="737.2666042089448" width="85" height="20" rx="3" ry="3" class="relationship-label-bg"/>
       <text x="926.1146659639663" y="751.2666042089448" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;derives&gt;&gt;</text>
     </g>
@@ -209,100 +219,100 @@ marker path {
       <text x="756.875" y="985" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;refines&gt;&gt;</text>
     </g>
     <g class="relationship">
-      <path d="M 622.50 160.00 C 622.50 349.00, 622.50 538.00, 628.67 638.33 C 634.84 738.67, 647.19 750.33, 659.53 762.00" class="relationship-line" stroke-dasharray="10,7" marker-end="url(#requirement-arrow)"/>
+      <path d="M 622.50 160.00 C 622.50 349.00, 622.50 538.00, 628.67 638.33 C 634.84 738.67, 647.19 750.33, 659.53 762.00" class="relationship-line" marker-end="url(#requirement-arrow)" stroke-dasharray="10,7"/>
       <rect x="576.5" y="458.9774635623228" width="92" height="20" rx="3" ry="3" class="relationship-label-bg"/>
       <text x="622.5" y="472.9774635623228" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;verifies&gt;&gt;</text>
     </g>
-    <g class="requirement-node" id="test_req2">
-      <rect x="0" y="254" width="222.5" height="184" rx="0" ry="0" class="requirement-box" stroke-width="2" fill="#ECECFF" stroke="#9370DB"/>
-      <rect x="0" y="254" width="222.5" height="68" rx="0" ry="0" class="requirement-header" stroke="#9370DB" fill="#ECECFF"/>
-      <line x1="0" y1="322" x2="222.5" y2="322" class="divider" stroke="#9370DB" stroke-width="1"/>
-      <text x="111.25" y="274" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Functional Requirement&gt;&gt;</text>
-      <text x="111.25" y="298" class="requirement-name" text-anchor="middle" font-weight="bold" font-size="16">test_req2</text>
-      <text x="10" y="346" class="requirement-attr" font-size="16" text-anchor="start">ID: 1.1</text>
-      <text x="10" y="370" class="requirement-attr" text-anchor="start" font-size="16">Text: the second test text.</text>
-      <text x="10" y="394" class="requirement-attr" text-anchor="start" font-size="16">Risk: Low</text>
-      <text x="10" y="418" class="requirement-attr" text-anchor="start" font-size="16">Verification: Inspection</text>
-    </g>
-    <g class="requirement-node" id="test_req3">
-      <rect x="847" y="254" width="222.5" height="184" rx="0" ry="0" class="requirement-box" fill="#ECECFF" stroke="#9370DB" stroke-width="2"/>
-      <rect x="847" y="254" width="222.5" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
-      <line x1="847" y1="322" x2="1069.5" y2="322" class="divider" stroke-width="1" stroke="#9370DB"/>
-      <text x="958.25" y="274" class="requirement-type" font-size="16" text-anchor="middle">&lt;&lt;Performance Requirement&gt;&gt;</text>
-      <text x="958.25" y="298" class="requirement-name" font-size="16" text-anchor="middle" font-weight="bold">test_req3</text>
-      <text x="857" y="346" class="requirement-attr" font-size="16" text-anchor="start">ID: 1.2</text>
-      <text x="857" y="370" class="requirement-attr" text-anchor="start" font-size="16">Text: the third test text.</text>
-      <text x="857" y="394" class="requirement-attr" font-size="16" text-anchor="start">Risk: Medium</text>
-      <text x="857" y="418" class="requirement-attr" text-anchor="start" font-size="16">Verification: Demonstration</text>
-    </g>
     <g class="requirement-node" id="test_req4">
-      <rect x="847" y="508" width="222.5" height="184" rx="0" ry="0" class="requirement-box" stroke-width="2" fill="#ECECFF" stroke="#9370DB"/>
-      <rect x="847" y="508" width="222.5" height="68" rx="0" ry="0" class="requirement-header" stroke="#9370DB" fill="#ECECFF"/>
+      <rect x="847" y="508" width="222.5" height="184" rx="0" ry="0" class="requirement-box" stroke="#9370DB" stroke-width="2" fill="#ECECFF"/>
+      <rect x="847" y="508" width="222.5" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
       <line x1="847" y1="576" x2="1069.5" y2="576" class="divider" stroke-width="1" stroke="#9370DB"/>
       <text x="958.25" y="528" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Interface Requirement&gt;&gt;</text>
       <text x="958.25" y="552" class="requirement-name" text-anchor="middle" font-weight="bold" font-size="16">test_req4</text>
       <text x="857" y="600" class="requirement-attr" text-anchor="start" font-size="16">ID: 1.2.1</text>
-      <text x="857" y="624" class="requirement-attr" font-size="16" text-anchor="start">Text: the fourth test text.</text>
-      <text x="857" y="648" class="requirement-attr" font-size="16" text-anchor="start">Risk: Medium</text>
-      <text x="857" y="672" class="requirement-attr" text-anchor="start" font-size="16">Verification: Analysis</text>
+      <text x="857" y="624" class="requirement-attr" text-anchor="start" font-size="16">Text: the fourth test text.</text>
+      <text x="857" y="648" class="requirement-attr" text-anchor="start" font-size="16">Risk: Medium</text>
+      <text x="857" y="672" class="requirement-attr" font-size="16" text-anchor="start">Verification: Analysis</text>
     </g>
-    <g class="requirement-node" id="test_req">
-      <rect x="806.25" y="0" width="170" height="184" rx="0" ry="0" class="requirement-box" fill="#ECECFF" stroke="#9370DB" stroke-width="2"/>
-      <rect x="806.25" y="0" width="170" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
-      <line x1="806.25" y1="68" x2="976.25" y2="68" class="divider" stroke="#9370DB" stroke-width="1"/>
-      <text x="891.25" y="20" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Requirement&gt;&gt;</text>
-      <text x="891.25" y="44" class="requirement-name" text-anchor="middle" font-size="16" font-weight="bold">test_req</text>
-      <text x="816.25" y="92" class="requirement-attr" text-anchor="start" font-size="16">ID: 1</text>
-      <text x="816.25" y="116" class="requirement-attr" text-anchor="start" font-size="16">Text: the test text.</text>
-      <text x="816.25" y="140" class="requirement-attr" text-anchor="start" font-size="16">Risk: High</text>
-      <text x="816.25" y="164" class="requirement-attr" text-anchor="start" font-size="16">Verification: Test</text>
+    <g class="requirement-node" id="test_req3">
+      <rect x="847" y="254" width="222.5" height="184" rx="0" ry="0" class="requirement-box" stroke="#9370DB" fill="#ECECFF" stroke-width="2"/>
+      <rect x="847" y="254" width="222.5" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
+      <line x1="847" y1="322" x2="1069.5" y2="322" class="divider" stroke="#9370DB" stroke-width="1"/>
+      <text x="958.25" y="274" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Performance Requirement&gt;&gt;</text>
+      <text x="958.25" y="298" class="requirement-name" font-size="16" text-anchor="middle" font-weight="bold">test_req3</text>
+      <text x="857" y="346" class="requirement-attr" font-size="16" text-anchor="start">ID: 1.2</text>
+      <text x="857" y="370" class="requirement-attr" text-anchor="start" font-size="16">Text: the third test text.</text>
+      <text x="857" y="394" class="requirement-attr" text-anchor="start" font-size="16">Risk: Medium</text>
+      <text x="857" y="418" class="requirement-attr" text-anchor="start" font-size="16">Verification: Demonstration</text>
     </g>
     <g class="requirement-node" id="test_req6">
-      <rect x="649.375" y="1016" width="215" height="184" rx="0" ry="0" class="requirement-box" stroke-width="2" stroke="#9370DB" fill="#ECECFF"/>
+      <rect x="649.375" y="1016" width="215" height="184" rx="0" ry="0" class="requirement-box" fill="#ECECFF" stroke="#9370DB" stroke-width="2"/>
       <rect x="649.375" y="1016" width="215" height="68" rx="0" ry="0" class="requirement-header" stroke="#9370DB" fill="#ECECFF"/>
-      <line x1="649.375" y1="1084" x2="864.375" y2="1084" class="divider" stroke-width="1" stroke="#9370DB"/>
-      <text x="756.875" y="1036" class="requirement-type" font-size="16" text-anchor="middle">&lt;&lt;Design Constraint&gt;&gt;</text>
-      <text x="756.875" y="1060" class="requirement-name" font-size="16" text-anchor="middle" font-weight="bold">test_req6</text>
-      <text x="659.375" y="1108" class="requirement-attr" text-anchor="start" font-size="16">ID: 1.2.3</text>
+      <line x1="649.375" y1="1084" x2="864.375" y2="1084" class="divider" stroke="#9370DB" stroke-width="1"/>
+      <text x="756.875" y="1036" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Design Constraint&gt;&gt;</text>
+      <text x="756.875" y="1060" class="requirement-name" font-weight="bold" font-size="16" text-anchor="middle">test_req6</text>
+      <text x="659.375" y="1108" class="requirement-attr" font-size="16" text-anchor="start">ID: 1.2.3</text>
       <text x="659.375" y="1132" class="requirement-attr" text-anchor="start" font-size="16">Text: the sixth test text.</text>
-      <text x="659.375" y="1156" class="requirement-attr" font-size="16" text-anchor="start">Risk: Medium</text>
-      <text x="659.375" y="1180" class="requirement-attr" font-size="16" text-anchor="start">Verification: Analysis</text>
+      <text x="659.375" y="1156" class="requirement-attr" text-anchor="start" font-size="16">Risk: Medium</text>
+      <text x="659.375" y="1180" class="requirement-attr" text-anchor="start" font-size="16">Verification: Analysis</text>
     </g>
     <g class="requirement-node" id="test_req5">
-      <rect x="649.375" y="762" width="215" height="184" rx="0" ry="0" class="requirement-box" stroke="#9370DB" stroke-width="2" fill="#ECECFF"/>
-      <rect x="649.375" y="762" width="215" height="68" rx="0" ry="0" class="requirement-header" stroke="#9370DB" fill="#ECECFF"/>
-      <line x1="649.375" y1="830" x2="864.375" y2="830" class="divider" stroke="#9370DB" stroke-width="1"/>
-      <text x="756.875" y="782" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Physical Requirement&gt;&gt;</text>
-      <text x="756.875" y="806" class="requirement-name" font-weight="bold" font-size="16" text-anchor="middle">test_req5</text>
+      <rect x="649.375" y="762" width="215" height="184" rx="0" ry="0" class="requirement-box" fill="#ECECFF" stroke-width="2" stroke="#9370DB"/>
+      <rect x="649.375" y="762" width="215" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
+      <line x1="649.375" y1="830" x2="864.375" y2="830" class="divider" stroke-width="1" stroke="#9370DB"/>
+      <text x="756.875" y="782" class="requirement-type" font-size="16" text-anchor="middle">&lt;&lt;Physical Requirement&gt;&gt;</text>
+      <text x="756.875" y="806" class="requirement-name" text-anchor="middle" font-size="16" font-weight="bold">test_req5</text>
       <text x="659.375" y="854" class="requirement-attr" font-size="16" text-anchor="start">ID: 1.2.2</text>
       <text x="659.375" y="878" class="requirement-attr" font-size="16" text-anchor="start">Text: the fifth test text.</text>
       <text x="659.375" y="902" class="requirement-attr" text-anchor="start" font-size="16">Risk: Medium</text>
       <text x="659.375" y="926" class="requirement-attr" font-size="16" text-anchor="start">Verification: Analysis</text>
     </g>
+    <g class="requirement-node" id="test_req">
+      <rect x="806.25" y="0" width="170" height="184" rx="0" ry="0" class="requirement-box" fill="#ECECFF" stroke-width="2" stroke="#9370DB"/>
+      <rect x="806.25" y="0" width="170" height="68" rx="0" ry="0" class="requirement-header" stroke="#9370DB" fill="#ECECFF"/>
+      <line x1="806.25" y1="68" x2="976.25" y2="68" class="divider" stroke="#9370DB" stroke-width="1"/>
+      <text x="891.25" y="20" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Requirement&gt;&gt;</text>
+      <text x="891.25" y="44" class="requirement-name" font-size="16" font-weight="bold" text-anchor="middle">test_req</text>
+      <text x="816.25" y="92" class="requirement-attr" text-anchor="start" font-size="16">ID: 1</text>
+      <text x="816.25" y="116" class="requirement-attr" text-anchor="start" font-size="16">Text: the test text.</text>
+      <text x="816.25" y="140" class="requirement-attr" font-size="16" text-anchor="start">Risk: High</text>
+      <text x="816.25" y="164" class="requirement-attr" font-size="16" text-anchor="start">Verification: Test</text>
+    </g>
+    <g class="requirement-node" id="test_req2">
+      <rect x="0" y="254" width="222.5" height="184" rx="0" ry="0" class="requirement-box" fill="#ECECFF" stroke="#9370DB" stroke-width="2"/>
+      <rect x="0" y="254" width="222.5" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
+      <line x1="0" y1="322" x2="222.5" y2="322" class="divider" stroke="#9370DB" stroke-width="1"/>
+      <text x="111.25" y="274" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Functional Requirement&gt;&gt;</text>
+      <text x="111.25" y="298" class="requirement-name" text-anchor="middle" font-size="16" font-weight="bold">test_req2</text>
+      <text x="10" y="346" class="requirement-attr" text-anchor="start" font-size="16">ID: 1.1</text>
+      <text x="10" y="370" class="requirement-attr" text-anchor="start" font-size="16">Text: the second test text.</text>
+      <text x="10" y="394" class="requirement-attr" text-anchor="start" font-size="16">Risk: Low</text>
+      <text x="10" y="418" class="requirement-attr" font-size="16" text-anchor="start">Verification: Inspection</text>
+    </g>
     <g class="element-node" id="test_entity">
-      <rect x="41.25" y="36" width="140" height="112" rx="0" ry="0" class="element-box" stroke-width="2" stroke="#9370DB" fill="#ECECFF"/>
+      <rect x="41.25" y="36" width="140" height="112" rx="0" ry="0" class="element-box" fill="#ECECFF" stroke="#9370DB" stroke-width="2"/>
       <rect x="41.25" y="36" width="140" height="56" rx="0" ry="0" class="element-header" stroke="#9370DB" fill="#ECECFF"/>
-      <line x1="41.25" y1="92" x2="181.25" y2="92" class="divider" stroke-width="1" stroke="#9370DB"/>
+      <line x1="41.25" y1="92" x2="181.25" y2="92" class="divider" stroke="#9370DB" stroke-width="1"/>
       <text x="111.25" y="56" class="element-type" font-size="16" text-anchor="middle">&lt;&lt;Element&gt;&gt;</text>
       <text x="111.25" y="80" class="element-name" text-anchor="middle" font-size="16" font-weight="bold">test_entity</text>
-      <text x="51.25" y="116" class="element-attr" font-size="16" text-anchor="start">Type: simulation</text>
+      <text x="51.25" y="116" class="element-attr" text-anchor="start" font-size="16">Type: simulation</text>
     </g>
     <g class="element-node" id="test_entity2">
-      <rect x="231.25" y="24" width="207.5" height="136" rx="0" ry="0" class="element-box" stroke="#9370DB" stroke-width="2" fill="#ECECFF"/>
+      <rect x="231.25" y="24" width="207.5" height="136" rx="0" ry="0" class="element-box" fill="#ECECFF" stroke="#9370DB" stroke-width="2"/>
       <rect x="231.25" y="24" width="207.5" height="56" rx="0" ry="0" class="element-header" fill="#ECECFF" stroke="#9370DB"/>
       <line x1="231.25" y1="80" x2="438.75" y2="80" class="divider" stroke-width="1" stroke="#9370DB"/>
-      <text x="335" y="44" class="element-type" text-anchor="middle" font-size="16">&lt;&lt;Element&gt;&gt;</text>
+      <text x="335" y="44" class="element-type" font-size="16" text-anchor="middle">&lt;&lt;Element&gt;&gt;</text>
       <text x="335" y="68" class="element-name" font-size="16" font-weight="bold" text-anchor="middle">test_entity2</text>
       <text x="241.25" y="104" class="element-attr" font-size="16" text-anchor="start">Type: word doc</text>
-      <text x="241.25" y="128" class="element-attr" font-size="16" text-anchor="start">Doc Ref: reqs/test_entity</text>
+      <text x="241.25" y="128" class="element-attr" text-anchor="start" font-size="16">Doc Ref: reqs/test_entity</text>
     </g>
     <g class="element-node" id="test_entity3">
-      <rect x="488.75" y="24" width="267.5" height="136" rx="0" ry="0" class="element-box" fill="#ECECFF" stroke="#9370DB" stroke-width="2"/>
+      <rect x="488.75" y="24" width="267.5" height="136" rx="0" ry="0" class="element-box" stroke-width="2" stroke="#9370DB" fill="#ECECFF"/>
       <rect x="488.75" y="24" width="267.5" height="56" rx="0" ry="0" class="element-header" stroke="#9370DB" fill="#ECECFF"/>
       <line x1="488.75" y1="80" x2="756.25" y2="80" class="divider" stroke="#9370DB" stroke-width="1"/>
       <text x="622.5" y="44" class="element-type" font-size="16" text-anchor="middle">&lt;&lt;Element&gt;&gt;</text>
-      <text x="622.5" y="68" class="element-name" font-weight="bold" text-anchor="middle" font-size="16">test_entity3</text>
-      <text x="498.75" y="104" class="element-attr" font-size="16" text-anchor="start">Type: test suite</text>
+      <text x="622.5" y="68" class="element-name" text-anchor="middle" font-size="16" font-weight="bold">test_entity3</text>
+      <text x="498.75" y="104" class="element-attr" text-anchor="start" font-size="16">Type: test suite</text>
       <text x="498.75" y="128" class="element-attr" text-anchor="start" font-size="16">Doc Ref: github.com/all_the_tests</text>
     </g>
   </g>

--- a/docs/images/requirement_full.svg
+++ b/docs/images/requirement_full.svg
@@ -90,12 +90,12 @@ marker path {
 }
 
 .requirement-type {
-  fill: #333333;
+  fill: #131300;
   font-weight: bold;
 }
 
 .requirement-name {
-  fill: #333333;
+  fill: #131300;
 }
 
 .requirement-attr {
@@ -113,12 +113,12 @@ marker path {
 }
 
 .element-type {
-  fill: #333333;
+  fill: #131300;
   font-weight: bold;
 }
 
 .element-name {
-  fill: #333333;
+  fill: #131300;
 }
 
 .element-attr {
@@ -132,11 +132,11 @@ marker path {
 .relationship-line {
   fill: none;
   stroke: #333333;
-  stroke-width: 1.5;
+  stroke-width: 1;
 }
 
 .relationship-label {
-  fill: #333333;
+  fill: black;
 }
 
 .relationship-label-bg {
@@ -149,6 +149,19 @@ marker path {
   stroke: none;
 }
 
+.error-icon {
+  fill: #552222;
+}
+
+.error-text {
+  fill: #552222;
+  stroke: #552222;
+}
+
+.label {
+  fill: #333;
+}
+
   </style>
   <defs>
     <marker id="requirement-arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto">
@@ -156,13 +169,10 @@ marker path {
     </marker>
     <marker id="requirement-contains-start" viewBox="0 0 20 20" refX="0" refY="10" markerWidth="20" markerHeight="20" orient="auto">
       <g>
-        <circle cx="10" cy="10" r="9" stroke="#333333" stroke-width="1" fill="none"/>
+        <circle cx="10" cy="10" r="9" stroke="#333333" fill="none" stroke-width="1"/>
         <line x1="1" y1="10" x2="19" y2="10" stroke="#333333" stroke-width="1"/>
-        <line x1="10" y1="1" x2="10" y2="19" stroke="#333333" stroke-width="1"/>
+        <line x1="10" y1="1" x2="10" y2="19" stroke-width="1" stroke="#333333"/>
       </g>
-    </marker>
-    <marker id="requirement-contains" viewBox="0 0 20 20" refX="18" refY="10" markerWidth="10" markerHeight="10" orient="auto">
-      <path d="M0,10 L10,0 L20,10 L10,20 z" class="marker"/>
     </marker>
   </defs>
   <g class="root">
@@ -184,126 +194,126 @@ marker path {
       <text x="111.25" y="205" class="relationship-label" font-size="11" text-anchor="middle">&lt;&lt;satisfies&gt;&gt;</text>
     </g>
     <g class="relationship">
-      <path d="M 820.35 184.00 C 811.36 195.67, 802.37 207.33, 702.72 230.88 C 603.08 254.43, 412.79 289.86, 222.50 325.29" class="relationship-line" marker-end="url(#requirement-arrow)" stroke-dasharray="10,7"/>
+      <path d="M 820.35 184.00 C 811.36 195.67, 802.37 207.33, 702.72 230.88 C 603.08 254.43, 412.79 289.86, 222.50 325.29" class="relationship-line" stroke-dasharray="10,7" marker-end="url(#requirement-arrow)"/>
       <rect x="490.6581663966592" y="258.0995607368507" width="78" height="20" rx="3" ry="3" class="relationship-label-bg"/>
       <text x="529.6581663966592" y="272.0995607368507" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;traces&gt;&gt;</text>
     </g>
     <g class="relationship">
-      <path d="M 939.79 184.00 L 958.25 254.00" class="relationship-line" marker-start="url(#requirement-contains-start)" marker-end="url(#requirement-arrow)"/>
+      <path d="M 939.79 184.00 L 958.25 254.00" class="relationship-line" marker-end="url(#requirement-arrow)" marker-start="url(#requirement-contains-start)"/>
       <rect x="911.1833443996526" y="206.9781304291921" width="92" height="20" rx="3" ry="3" class="relationship-label-bg"/>
-      <text x="957.1833443996526" y="220.9781304291921" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;contains&gt;&gt;</text>
+      <text x="957.1833443996526" y="220.9781304291921" class="relationship-label" font-size="11" text-anchor="middle">&lt;&lt;contains&gt;&gt;</text>
     </g>
     <g class="relationship">
-      <path d="M 958.25 438.00 C 958.25 449.67, 958.25 461.33, 958.25 473.00 C 958.25 484.67, 958.25 496.33, 958.25 508.00" class="relationship-line" marker-start="url(#requirement-contains-start)" marker-end="url(#requirement-arrow)"/>
+      <path d="M 958.25 438.00 C 958.25 449.67, 958.25 461.33, 958.25 473.00 C 958.25 484.67, 958.25 496.33, 958.25 508.00" class="relationship-line" marker-end="url(#requirement-arrow)" marker-start="url(#requirement-contains-start)"/>
       <rect x="912.25" y="463" width="92" height="20" rx="3" ry="3" class="relationship-label-bg"/>
       <text x="958.25" y="477" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;contains&gt;&gt;</text>
     </g>
     <g class="relationship">
       <path d="M 958.25 692.00 C 958.25 703.67, 958.25 715.33, 942.60 731.03 C 926.96 746.73, 895.67 766.47, 864.38 786.20" class="relationship-line" marker-end="url(#requirement-arrow)" stroke-dasharray="10,7"/>
       <rect x="883.6146659639663" y="737.2666042089448" width="85" height="20" rx="3" ry="3" class="relationship-label-bg"/>
-      <text x="926.1146659639663" y="751.2666042089448" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;derives&gt;&gt;</text>
+      <text x="926.1146659639663" y="751.2666042089448" class="relationship-label" font-size="11" text-anchor="middle">&lt;&lt;derives&gt;&gt;</text>
     </g>
     <g class="relationship">
       <path d="M 756.88 946.00 C 756.88 957.67, 756.88 969.33, 756.88 981.00 C 756.88 992.67, 756.88 1004.33, 756.88 1016.00" class="relationship-line" marker-end="url(#requirement-arrow)" stroke-dasharray="10,7"/>
       <rect x="714.375" y="971" width="85" height="20" rx="3" ry="3" class="relationship-label-bg"/>
-      <text x="756.875" y="985" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;refines&gt;&gt;</text>
+      <text x="756.875" y="985" class="relationship-label" font-size="11" text-anchor="middle">&lt;&lt;refines&gt;&gt;</text>
     </g>
     <g class="relationship">
-      <path d="M 622.50 160.00 C 622.50 349.00, 622.50 538.00, 628.67 638.33 C 634.84 738.67, 647.19 750.33, 659.53 762.00" class="relationship-line" stroke-dasharray="10,7" marker-end="url(#requirement-arrow)"/>
+      <path d="M 622.50 160.00 C 622.50 349.00, 622.50 538.00, 628.67 638.33 C 634.84 738.67, 647.19 750.33, 659.53 762.00" class="relationship-line" marker-end="url(#requirement-arrow)" stroke-dasharray="10,7"/>
       <rect x="576.5" y="458.9774635623228" width="92" height="20" rx="3" ry="3" class="relationship-label-bg"/>
-      <text x="622.5" y="472.9774635623228" class="relationship-label" text-anchor="middle" font-size="11">&lt;&lt;verifies&gt;&gt;</text>
+      <text x="622.5" y="472.9774635623228" class="relationship-label" font-size="11" text-anchor="middle">&lt;&lt;verifies&gt;&gt;</text>
+    </g>
+    <g class="requirement-node" id="test_req2">
+      <rect x="0" y="254" width="222.5" height="184" rx="0" ry="0" class="requirement-box" stroke-width="2" fill="#ECECFF" stroke="#9370DB"/>
+      <rect x="0" y="254" width="222.5" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
+      <line x1="0" y1="322" x2="222.5" y2="322" class="divider" stroke="#9370DB" stroke-width="1"/>
+      <text x="111.25" y="274" class="requirement-type" font-size="16" text-anchor="middle">&lt;&lt;Functional Requirement&gt;&gt;</text>
+      <text x="111.25" y="298" class="requirement-name" text-anchor="middle" font-size="16" font-weight="bold">test_req2</text>
+      <text x="10" y="346" class="requirement-attr" font-size="16" text-anchor="start">ID: 1.1</text>
+      <text x="10" y="370" class="requirement-attr" font-size="16" text-anchor="start">Text: the second test text.</text>
+      <text x="10" y="394" class="requirement-attr" text-anchor="start" font-size="16">Risk: Low</text>
+      <text x="10" y="418" class="requirement-attr" font-size="16" text-anchor="start">Verification: Inspection</text>
     </g>
     <g class="requirement-node" id="test_req5">
-      <rect x="649.375" y="762" width="215" height="184" rx="0" ry="0" class="requirement-box" stroke-width="2" stroke="#9370DB" fill="#ECECFF"/>
+      <rect x="649.375" y="762" width="215" height="184" rx="0" ry="0" class="requirement-box" stroke="#9370DB" fill="#ECECFF" stroke-width="2"/>
       <rect x="649.375" y="762" width="215" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
       <line x1="649.375" y1="830" x2="864.375" y2="830" class="divider" stroke="#9370DB" stroke-width="1"/>
       <text x="756.875" y="782" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Physical Requirement&gt;&gt;</text>
-      <text x="756.875" y="806" class="requirement-name" text-anchor="middle" font-size="16" font-weight="bold">test_req5</text>
+      <text x="756.875" y="806" class="requirement-name" font-weight="bold" font-size="16" text-anchor="middle">test_req5</text>
       <text x="659.375" y="854" class="requirement-attr" font-size="16" text-anchor="start">ID: 1.2.2</text>
-      <text x="659.375" y="878" class="requirement-attr" text-anchor="start" font-size="16">Text: the fifth test text.</text>
+      <text x="659.375" y="878" class="requirement-attr" font-size="16" text-anchor="start">Text: the fifth test text.</text>
       <text x="659.375" y="902" class="requirement-attr" text-anchor="start" font-size="16">Risk: Medium</text>
       <text x="659.375" y="926" class="requirement-attr" font-size="16" text-anchor="start">Verification: Analysis</text>
     </g>
     <g class="requirement-node" id="test_req6">
-      <rect x="649.375" y="1016" width="215" height="184" rx="0" ry="0" class="requirement-box" stroke-width="2" fill="#ECECFF" stroke="#9370DB"/>
+      <rect x="649.375" y="1016" width="215" height="184" rx="0" ry="0" class="requirement-box" stroke="#9370DB" stroke-width="2" fill="#ECECFF"/>
       <rect x="649.375" y="1016" width="215" height="68" rx="0" ry="0" class="requirement-header" stroke="#9370DB" fill="#ECECFF"/>
       <line x1="649.375" y1="1084" x2="864.375" y2="1084" class="divider" stroke="#9370DB" stroke-width="1"/>
       <text x="756.875" y="1036" class="requirement-type" font-size="16" text-anchor="middle">&lt;&lt;Design Constraint&gt;&gt;</text>
-      <text x="756.875" y="1060" class="requirement-name" font-weight="bold" text-anchor="middle" font-size="16">test_req6</text>
-      <text x="659.375" y="1108" class="requirement-attr" font-size="16" text-anchor="start">ID: 1.2.3</text>
-      <text x="659.375" y="1132" class="requirement-attr" text-anchor="start" font-size="16">Text: the sixth test text.</text>
-      <text x="659.375" y="1156" class="requirement-attr" font-size="16" text-anchor="start">Risk: Medium</text>
+      <text x="756.875" y="1060" class="requirement-name" font-size="16" font-weight="bold" text-anchor="middle">test_req6</text>
+      <text x="659.375" y="1108" class="requirement-attr" text-anchor="start" font-size="16">ID: 1.2.3</text>
+      <text x="659.375" y="1132" class="requirement-attr" font-size="16" text-anchor="start">Text: the sixth test text.</text>
+      <text x="659.375" y="1156" class="requirement-attr" text-anchor="start" font-size="16">Risk: Medium</text>
       <text x="659.375" y="1180" class="requirement-attr" font-size="16" text-anchor="start">Verification: Analysis</text>
     </g>
-    <g class="requirement-node" id="test_req">
-      <rect x="806.25" y="0" width="170" height="184" rx="0" ry="0" class="requirement-box" stroke="#9370DB" stroke-width="2" fill="#ECECFF"/>
-      <rect x="806.25" y="0" width="170" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
-      <line x1="806.25" y1="68" x2="976.25" y2="68" class="divider" stroke-width="1" stroke="#9370DB"/>
-      <text x="891.25" y="20" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Requirement&gt;&gt;</text>
-      <text x="891.25" y="44" class="requirement-name" font-size="16" font-weight="bold" text-anchor="middle">test_req</text>
-      <text x="816.25" y="92" class="requirement-attr" text-anchor="start" font-size="16">ID: 1</text>
-      <text x="816.25" y="116" class="requirement-attr" text-anchor="start" font-size="16">Text: the test text.</text>
-      <text x="816.25" y="140" class="requirement-attr" font-size="16" text-anchor="start">Risk: High</text>
-      <text x="816.25" y="164" class="requirement-attr" font-size="16" text-anchor="start">Verification: Test</text>
-    </g>
     <g class="requirement-node" id="test_req3">
-      <rect x="847" y="254" width="222.5" height="184" rx="0" ry="0" class="requirement-box" fill="#ECECFF" stroke-width="2" stroke="#9370DB"/>
-      <rect x="847" y="254" width="222.5" height="68" rx="0" ry="0" class="requirement-header" stroke="#9370DB" fill="#ECECFF"/>
-      <line x1="847" y1="322" x2="1069.5" y2="322" class="divider" stroke-width="1" stroke="#9370DB"/>
-      <text x="958.25" y="274" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Performance Requirement&gt;&gt;</text>
+      <rect x="847" y="254" width="222.5" height="184" rx="0" ry="0" class="requirement-box" stroke-width="2" fill="#ECECFF" stroke="#9370DB"/>
+      <rect x="847" y="254" width="222.5" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
+      <line x1="847" y1="322" x2="1069.5" y2="322" class="divider" stroke="#9370DB" stroke-width="1"/>
+      <text x="958.25" y="274" class="requirement-type" font-size="16" text-anchor="middle">&lt;&lt;Performance Requirement&gt;&gt;</text>
       <text x="958.25" y="298" class="requirement-name" font-size="16" font-weight="bold" text-anchor="middle">test_req3</text>
-      <text x="857" y="346" class="requirement-attr" font-size="16" text-anchor="start">ID: 1.2</text>
+      <text x="857" y="346" class="requirement-attr" text-anchor="start" font-size="16">ID: 1.2</text>
       <text x="857" y="370" class="requirement-attr" text-anchor="start" font-size="16">Text: the third test text.</text>
       <text x="857" y="394" class="requirement-attr" text-anchor="start" font-size="16">Risk: Medium</text>
       <text x="857" y="418" class="requirement-attr" text-anchor="start" font-size="16">Verification: Demonstration</text>
     </g>
-    <g class="requirement-node" id="test_req2">
-      <rect x="0" y="254" width="222.5" height="184" rx="0" ry="0" class="requirement-box" fill="#ECECFF" stroke="#9370DB" stroke-width="2"/>
-      <rect x="0" y="254" width="222.5" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
-      <line x1="0" y1="322" x2="222.5" y2="322" class="divider" stroke-width="1" stroke="#9370DB"/>
-      <text x="111.25" y="274" class="requirement-type" font-size="16" text-anchor="middle">&lt;&lt;Functional Requirement&gt;&gt;</text>
-      <text x="111.25" y="298" class="requirement-name" font-weight="bold" text-anchor="middle" font-size="16">test_req2</text>
-      <text x="10" y="346" class="requirement-attr" text-anchor="start" font-size="16">ID: 1.1</text>
-      <text x="10" y="370" class="requirement-attr" text-anchor="start" font-size="16">Text: the second test text.</text>
-      <text x="10" y="394" class="requirement-attr" text-anchor="start" font-size="16">Risk: Low</text>
-      <text x="10" y="418" class="requirement-attr" font-size="16" text-anchor="start">Verification: Inspection</text>
+    <g class="requirement-node" id="test_req">
+      <rect x="806.25" y="0" width="170" height="184" rx="0" ry="0" class="requirement-box" stroke-width="2" fill="#ECECFF" stroke="#9370DB"/>
+      <rect x="806.25" y="0" width="170" height="68" rx="0" ry="0" class="requirement-header" stroke="#9370DB" fill="#ECECFF"/>
+      <line x1="806.25" y1="68" x2="976.25" y2="68" class="divider" stroke-width="1" stroke="#9370DB"/>
+      <text x="891.25" y="20" class="requirement-type" font-size="16" text-anchor="middle">&lt;&lt;Requirement&gt;&gt;</text>
+      <text x="891.25" y="44" class="requirement-name" font-weight="bold" text-anchor="middle" font-size="16">test_req</text>
+      <text x="816.25" y="92" class="requirement-attr" font-size="16" text-anchor="start">ID: 1</text>
+      <text x="816.25" y="116" class="requirement-attr" font-size="16" text-anchor="start">Text: the test text.</text>
+      <text x="816.25" y="140" class="requirement-attr" text-anchor="start" font-size="16">Risk: High</text>
+      <text x="816.25" y="164" class="requirement-attr" text-anchor="start" font-size="16">Verification: Test</text>
     </g>
     <g class="requirement-node" id="test_req4">
-      <rect x="847" y="508" width="222.5" height="184" rx="0" ry="0" class="requirement-box" stroke-width="2" fill="#ECECFF" stroke="#9370DB"/>
-      <rect x="847" y="508" width="222.5" height="68" rx="0" ry="0" class="requirement-header" fill="#ECECFF" stroke="#9370DB"/>
+      <rect x="847" y="508" width="222.5" height="184" rx="0" ry="0" class="requirement-box" stroke="#9370DB" stroke-width="2" fill="#ECECFF"/>
+      <rect x="847" y="508" width="222.5" height="68" rx="0" ry="0" class="requirement-header" stroke="#9370DB" fill="#ECECFF"/>
       <line x1="847" y1="576" x2="1069.5" y2="576" class="divider" stroke="#9370DB" stroke-width="1"/>
       <text x="958.25" y="528" class="requirement-type" text-anchor="middle" font-size="16">&lt;&lt;Interface Requirement&gt;&gt;</text>
-      <text x="958.25" y="552" class="requirement-name" font-size="16" text-anchor="middle" font-weight="bold">test_req4</text>
-      <text x="857" y="600" class="requirement-attr" text-anchor="start" font-size="16">ID: 1.2.1</text>
-      <text x="857" y="624" class="requirement-attr" text-anchor="start" font-size="16">Text: the fourth test text.</text>
+      <text x="958.25" y="552" class="requirement-name" text-anchor="middle" font-size="16" font-weight="bold">test_req4</text>
+      <text x="857" y="600" class="requirement-attr" font-size="16" text-anchor="start">ID: 1.2.1</text>
+      <text x="857" y="624" class="requirement-attr" font-size="16" text-anchor="start">Text: the fourth test text.</text>
       <text x="857" y="648" class="requirement-attr" text-anchor="start" font-size="16">Risk: Medium</text>
       <text x="857" y="672" class="requirement-attr" text-anchor="start" font-size="16">Verification: Analysis</text>
     </g>
+    <g class="element-node" id="test_entity">
+      <rect x="41.25" y="36" width="140" height="112" rx="0" ry="0" class="element-box" fill="#ECECFF" stroke="#9370DB" stroke-width="2"/>
+      <rect x="41.25" y="36" width="140" height="56" rx="0" ry="0" class="element-header" stroke="#9370DB" fill="#ECECFF"/>
+      <line x1="41.25" y1="92" x2="181.25" y2="92" class="divider" stroke-width="1" stroke="#9370DB"/>
+      <text x="111.25" y="56" class="element-type" font-size="16" text-anchor="middle">&lt;&lt;Element&gt;&gt;</text>
+      <text x="111.25" y="80" class="element-name" text-anchor="middle" font-size="16" font-weight="bold">test_entity</text>
+      <text x="51.25" y="116" class="element-attr" text-anchor="start" font-size="16">Type: simulation</text>
+    </g>
     <g class="element-node" id="test_entity2">
-      <rect x="231.25" y="24" width="207.5" height="136" rx="0" ry="0" class="element-box" stroke="#9370DB" stroke-width="2" fill="#ECECFF"/>
+      <rect x="231.25" y="24" width="207.5" height="136" rx="0" ry="0" class="element-box" stroke="#9370DB" fill="#ECECFF" stroke-width="2"/>
       <rect x="231.25" y="24" width="207.5" height="56" rx="0" ry="0" class="element-header" fill="#ECECFF" stroke="#9370DB"/>
       <line x1="231.25" y1="80" x2="438.75" y2="80" class="divider" stroke="#9370DB" stroke-width="1"/>
-      <text x="335" y="44" class="element-type" font-size="16" text-anchor="middle">&lt;&lt;Element&gt;&gt;</text>
-      <text x="335" y="68" class="element-name" font-size="16" font-weight="bold" text-anchor="middle">test_entity2</text>
+      <text x="335" y="44" class="element-type" text-anchor="middle" font-size="16">&lt;&lt;Element&gt;&gt;</text>
+      <text x="335" y="68" class="element-name" text-anchor="middle" font-size="16" font-weight="bold">test_entity2</text>
       <text x="241.25" y="104" class="element-attr" font-size="16" text-anchor="start">Type: word doc</text>
-      <text x="241.25" y="128" class="element-attr" font-size="16" text-anchor="start">Doc Ref: reqs/test_entity</text>
+      <text x="241.25" y="128" class="element-attr" text-anchor="start" font-size="16">Doc Ref: reqs/test_entity</text>
     </g>
     <g class="element-node" id="test_entity3">
-      <rect x="488.75" y="24" width="267.5" height="136" rx="0" ry="0" class="element-box" fill="#ECECFF" stroke-width="2" stroke="#9370DB"/>
+      <rect x="488.75" y="24" width="267.5" height="136" rx="0" ry="0" class="element-box" stroke="#9370DB" stroke-width="2" fill="#ECECFF"/>
       <rect x="488.75" y="24" width="267.5" height="56" rx="0" ry="0" class="element-header" fill="#ECECFF" stroke="#9370DB"/>
       <line x1="488.75" y1="80" x2="756.25" y2="80" class="divider" stroke="#9370DB" stroke-width="1"/>
       <text x="622.5" y="44" class="element-type" font-size="16" text-anchor="middle">&lt;&lt;Element&gt;&gt;</text>
-      <text x="622.5" y="68" class="element-name" font-weight="bold" font-size="16" text-anchor="middle">test_entity3</text>
+      <text x="622.5" y="68" class="element-name" text-anchor="middle" font-weight="bold" font-size="16">test_entity3</text>
       <text x="498.75" y="104" class="element-attr" text-anchor="start" font-size="16">Type: test suite</text>
-      <text x="498.75" y="128" class="element-attr" text-anchor="start" font-size="16">Doc Ref: github.com/all_the_tests</text>
-    </g>
-    <g class="element-node" id="test_entity">
-      <rect x="41.25" y="36" width="140" height="112" rx="0" ry="0" class="element-box" stroke-width="2" fill="#ECECFF" stroke="#9370DB"/>
-      <rect x="41.25" y="36" width="140" height="56" rx="0" ry="0" class="element-header" stroke="#9370DB" fill="#ECECFF"/>
-      <line x1="41.25" y1="92" x2="181.25" y2="92" class="divider" stroke="#9370DB" stroke-width="1"/>
-      <text x="111.25" y="56" class="element-type" font-size="16" text-anchor="middle">&lt;&lt;Element&gt;&gt;</text>
-      <text x="111.25" y="80" class="element-name" font-size="16" font-weight="bold" text-anchor="middle">test_entity</text>
-      <text x="51.25" y="116" class="element-attr" text-anchor="start" font-size="16">Type: simulation</text>
+      <text x="498.75" y="128" class="element-attr" font-size="16" text-anchor="start">Doc Ref: github.com/all_the_tests</text>
     </g>
   </g>
 </svg>

--- a/src/render/requirement.rs
+++ b/src/render/requirement.rs
@@ -182,7 +182,9 @@ impl ToLayoutGraph for RequirementDb {
         };
 
         // Match mermaid's dagre configuration for requirement diagrams
-        // Using longest-path ranker - produces better visual parity for this diagram type
+        // Note: mermaid uses network-simplex which produces correct ranking but
+        // our ordering phase doesn't match mermaid's dagre column ordering yet.
+        // Using longest-path for now as it produces better visual parity overall.
         graph.options = LayoutOptions {
             direction,
             node_spacing: 50.0,
@@ -836,7 +838,14 @@ fn render_relationship_line(
 
 /// Generate CSS for requirement diagrams
 /// Colors match mermaid.js default theme for requirement diagrams
+/// Reference: mermaid's styles.js for requirementDiagram
 fn generate_requirement_css(theme: &Theme) -> String {
+    // Mermaid uses specific colors for requirement diagrams:
+    // - .reqTitle, .reqLabel { fill: #131300 } (dark label color)
+    // - .relationshipLabel { fill: black }
+    // - .relationshipLine { stroke-width: 1 }
+    // - .error-icon, .error-text { fill: #552222 }
+    let label_color = "#131300"; // mermaid's reqTitle/reqLabel fill
     format!(
         r#"
 .requirement-box {{
@@ -850,12 +859,12 @@ fn generate_requirement_css(theme: &Theme) -> String {
 }}
 
 .requirement-type {{
-  fill: {text_color};
+  fill: {label_color};
   font-weight: bold;
 }}
 
 .requirement-name {{
-  fill: {text_color};
+  fill: {label_color};
 }}
 
 .requirement-attr {{
@@ -873,12 +882,12 @@ fn generate_requirement_css(theme: &Theme) -> String {
 }}
 
 .element-type {{
-  fill: {text_color};
+  fill: {label_color};
   font-weight: bold;
 }}
 
 .element-name {{
-  fill: {text_color};
+  fill: {label_color};
 }}
 
 .element-attr {{
@@ -892,11 +901,11 @@ fn generate_requirement_css(theme: &Theme) -> String {
 .relationship-line {{
   fill: none;
   stroke: {line_color};
-  stroke-width: 1.5;
+  stroke-width: 1;
 }}
 
 .relationship-label {{
-  fill: {text_color};
+  fill: black;
 }}
 
 .relationship-label-bg {{
@@ -908,11 +917,25 @@ fn generate_requirement_css(theme: &Theme) -> String {
   fill: {line_color};
   stroke: none;
 }}
+
+.error-icon {{
+  fill: #552222;
+}}
+
+.error-text {{
+  fill: #552222;
+  stroke: #552222;
+}}
+
+.label {{
+  fill: #333;
+}}
 "#,
         primary_color = theme.primary_color,
         border_color = theme.primary_border_color,
         text_color = theme.primary_text_color,
         line_color = theme.line_color,
+        label_color = label_color,
     )
 }
 
@@ -977,20 +1000,7 @@ fn generate_requirement_markers() -> Vec<SvgElement> {
                 attrs: Attrs::new(),
             }],
         },
-        // Contains end marker (diamond) - for backwards compatibility
-        SvgElement::Marker {
-            id: "requirement-contains".to_string(),
-            view_box: "0 0 20 20".to_string(),
-            ref_x: 18.0,
-            ref_y: 10.0,
-            marker_width: 10.0,
-            marker_height: 10.0,
-            orient: "auto".to_string(),
-            marker_units: None,
-            children: vec![SvgElement::Path {
-                d: "M0,10 L10,0 L20,10 L10,20 z".to_string(),
-                attrs: Attrs::new().with_class("marker"),
-            }],
-        },
+        // Note: mermaid reference only defines 2 markers (arrow + contains-start)
+        // The diamond "contains" marker is not used - removed for parity
     ]
 }

--- a/tests/requirement_rendering.rs
+++ b/tests/requirement_rendering.rs
@@ -1312,3 +1312,63 @@ fn should_have_contains_start_marker_definition() {
         "The contains-start marker should contain a circle and lines (for the + symbol)."
     );
 }
+
+/// Test that CSS colors match mermaid reference
+#[test]
+fn should_use_correct_css_colors() {
+    let input = r#"requirementDiagram
+    requirement test_req {
+    id: 1
+    text: the test text.
+    risk: high
+    verifymethod: test
+    }
+
+    element test_entity {
+    type: simulation
+    }
+
+    test_entity - satisfies -> test_req"#;
+
+    let svg = render_requirement_svg(input);
+
+    // Relationship labels should use 'black' fill (matching mermaid's .relationshipLabel)
+    assert!(
+        svg.contains("fill: black") || svg.contains("fill:black"),
+        "Relationship labels should use 'black' fill to match mermaid reference. SVG CSS: {}",
+        &svg[..svg.find("</style>").unwrap_or(500)]
+    );
+
+    // Relationship line stroke-width should be 1 (matching mermaid's .relationshipLine)
+    assert!(
+        svg.contains("stroke-width: 1;") || svg.contains("stroke-width:1;"),
+        "Relationship lines should use stroke-width: 1 to match mermaid reference"
+    );
+}
+
+/// Test that relationship line stroke-width is 1px (matching mermaid reference)
+#[test]
+fn should_use_stroke_width_1_for_relationship_lines() {
+    let input = r#"requirementDiagram
+    requirement test_req {
+    id: 1
+    text: the test text.
+    risk: high
+    verifymethod: test
+    }
+
+    element test_entity {
+    type: simulation
+    }
+
+    test_entity - satisfies -> test_req"#;
+
+    let svg = render_requirement_svg(input);
+
+    // The CSS should define relationship-line with stroke-width: 1
+    // NOT stroke-width: 1.5
+    assert!(
+        !svg.contains("stroke-width: 1.5"),
+        "Relationship lines should NOT use stroke-width: 1.5 (mermaid uses 1)"
+    );
+}


### PR DESCRIPTION
<!-- midtown: bleecker -->

## Summary
- Fixed CSS color mismatches in requirement diagrams to match mermaid.js reference theme
  - `#131300` for title/label text (was `#333333`)
  - `black` for relationship labels (was `#333333`)
  - `stroke-width: 1` for relationship lines (was `1.5`)
  - Added error CSS classes (`#552222`) and `.label` class (`#333`)
- Removed unused diamond contains marker (reference only defines 2 markers)
- Added tests for CSS color correctness and stroke-width
- Regenerated requirement diagram SVGs

**Eval impact:** Eliminates 4 color mismatch warnings across all requirement samples. Structural similarity maintained at 97.6%.

## Test plan
- [x] All 35 requirement rendering tests pass
- [x] New tests verify correct CSS colors and stroke-width
- [x] `cargo clippy --features all-formats -- -D warnings` clean
- [x] Eval run confirms color warnings resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)