### PR TITLE
fix(state): center nested composites within parent composites

### DIFF
--- a/docs/images/state.svg
+++ b/docs/images/state.svg
@@ -180,7 +180,7 @@ marker path {
   </style>
   <defs>
     <marker id="arrow" viewBox="0 0 20 14" refX="19" refY="7" markerWidth="20" markerHeight="14" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke="#333333" stroke-width="1" fill="#333333"/>
+      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke-width="1" fill="#333333" stroke="#333333"/>
     </marker>
   </defs>
   <g class="root">
@@ -205,41 +205,41 @@ marker path {
       <text x="95.030874308764" y="87" class="state-label" text-anchor="middle" font-size="16">Idle</text>
     </g>
     <g class="state-node" id="state-Running">
-      <path d="M 23.230093058763998 170 H 84.831655558764 A 5 5 0 0 1 89.831655558764 175 V 201 A 5 5 0 0 1 84.831655558764 206 H 23.230093058763998 A 5 5 0 0 1 18.230093058763998 201 V 175 A 5 5 0 0 1 23.230093058763998 170 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <path d="M 23.230093058763998 170 H 84.831655558764 A 5 5 0 0 1 89.831655558764 175 V 201 A 5 5 0 0 1 84.831655558764 206 H 23.230093058763998 A 5 5 0 0 1 18.230093058763998 201 V 175 A 5 5 0 0 1 23.230093058763998 170 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
       <text x="54.030874308764" y="193" class="state-label" text-anchor="middle" font-size="16">Running</text>
     </g>
     <g class="state-node" id="state-root_end">
       <path d="M 98.931264933764 369 A 7 7 0 1 0 112.931264933764 369 A 7 7 0 1 0 98.931264933764 369 Z" class="state-end-outer" fill="none" stroke="#9370DB" stroke-width="2"/>
-      <path d="M 103.411264933764 369 A 2.52 2.52 0 1 0 108.451264933764 369 A 2.52 2.52 0 1 0 103.411264933764 369 Z" class="state-end-inner" stroke-width="2" stroke="#9370DB" fill="#9370DB"/>
+      <path d="M 103.411264933764 369 A 2.52 2.52 0 1 0 108.451264933764 369 A 2.52 2.52 0 1 0 103.411264933764 369 Z" class="state-end-inner" fill="#9370DB" stroke-width="2" stroke="#9370DB"/>
     </g>
     <g class="state-node" id="state-root_start">
       <circle cx="95.030874308764" cy="7" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="transition">
-      <path d="M 95.03 14.00 C 95.03 22.33, 95.03 30.67, 95.03 39.00 C 95.03 47.33, 95.03 55.67, 95.03 64.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 95.03 14.00 C 95.03 22.33, 95.03 30.67, 95.03 39.00 C 95.03 47.33, 95.03 55.67, 95.03 64.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 76.13 94.21 C 55.10 107.81, 34.06 121.40, 28.06 134.04 C 22.06 146.67, 31.08 158.33, 40.11 170.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 76.13 94.21 C 55.10 107.81, 34.06 121.40, 28.06 134.04 C 22.06 146.67, 31.08 158.33, 40.11 170.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
       <path d="M 6 115.8175163215182 H 46 A 2 2 0 0 1 48 117.8175163215182 V 135.4175163215182 A 2 2 0 0 1 46 137.4175163215182 H 6 A 2 2 0 0 1 4 135.4175163215182 V 117.8175163215182 A 2 2 0 0 1 6 115.8175163215182 Z" class="transition-label-bg"/>
       <text x="26" y="126.6175163215182" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">start</text>
     </g>
     <g class="transition">
-      <path d="M 67.96 170.00 L 95.03 100.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 67.96 170.00 L 95.03 100.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
       <path d="M 76.20090108319185 127.85825807208104 H 108.20090108319185 A 2 2 0 0 1 110.20090108319185 129.85825807208104 V 147.45825807208104 A 2 2 0 0 1 108.20090108319185 149.45825807208104 H 76.20090108319185 A 2 2 0 0 1 74.20090108319185 147.45825807208104 V 129.85825807208104 A 2 2 0 0 1 76.20090108319185 127.85825807208104 Z" class="transition-label-bg"/>
-      <text x="92.20090108319185" y="138.65825807208105" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">stop</text>
+      <text x="92.20090108319185" y="138.65825807208105" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">stop</text>
     </g>
     <g class="transition">
-      <path d="M 54.03 206.00 L 88.30 276.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 54.03 206.00 L 88.30 276.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
       <path d="M 38.92381300441641 235.19660499172932 H 78.92381300441642 A 2 2 0 0 1 80.92381300441642 237.19660499172932 V 254.79660499172934 A 2 2 0 0 1 78.92381300441642 256.79660499172934 H 38.92381300441641 A 2 2 0 0 1 36.92381300441641 254.79660499172934 V 237.19660499172932 A 2 2 0 0 1 38.92381300441641 235.19660499172932 Z" class="transition-label-bg"/>
       <text x="58.92381300441641" y="245.99660499172933" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">error</text>
     </g>
     <g class="transition">
       <path d="M 128.18 276.00 C 142.59 264.33, 157.01 252.67, 164.22 229.17 C 171.43 205.67, 171.43 170.33, 161.85 146.02 C 133.10 108.41, 113.93 95.11, 113.93 95.11" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
       <path d="M 151.431264933764 170.0290159304274 H 191.431264933764 A 2 2 0 0 1 193.431264933764 172.0290159304274 V 189.62901593042739 A 2 2 0 0 1 191.431264933764 191.62901593042739 H 151.431264933764 A 2 2 0 0 1 149.431264933764 189.62901593042739 V 172.0290159304274 A 2 2 0 0 1 151.431264933764 170.0290159304274 Z" class="transition-label-bg"/>
-      <text x="171.431264933764" y="180.8290159304274" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">reset</text>
+      <text x="171.431264933764" y="180.8290159304274" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">reset</text>
     </g>
     <g class="transition">
-      <path d="M 105.93 312.00 C 105.93 320.33, 105.93 328.67, 105.93 337.00 C 105.93 345.33, 105.93 353.67, 105.93 362.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 105.93 312.00 C 105.93 320.33, 105.93 328.67, 105.93 337.00 C 105.93 345.33, 105.93 353.67, 105.93 362.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
   </g>
 </svg>

--- a/docs/images/state_complex.svg
+++ b/docs/images/state_complex.svg
@@ -180,7 +180,7 @@ marker path {
   </style>
   <defs>
     <marker id="arrow" viewBox="0 0 20 14" refX="19" refY="7" markerWidth="20" markerHeight="14" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke="#333333" fill="#333333" stroke-width="1"/>
+      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke="#333333" stroke-width="1" fill="#333333"/>
     </marker>
   </defs>
   <g class="root">
@@ -203,53 +203,53 @@ marker path {
       <text x="123.71484375" y="80" class="state-composite-label" font-size="14" text-anchor="middle">Idle</text>
     </g>
     <g class="composite-state" id="composite-Processing">
-      <rect x="38.63484374999999" y="605" width="170.16" height="524" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="39.63484374999999" y="626" width="168.16" height="499" rx="0" ry="0" class="state-composite-inner"/>
-      <path d="M 38.63484374999999 626 L 208.79484374999998 626" class="state-composite-divider"/>
-      <text x="123.71484374999999" y="621" class="state-composite-label" font-size="14" text-anchor="middle">Processing</text>
+      <rect x="30.414140625000016" y="605" width="170.16" height="524" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="31.414140625000016" y="626" width="168.16" height="499" rx="0" ry="0" class="state-composite-inner"/>
+      <path d="M 30.414140625000016 626 L 200.574140625 626" class="state-composite-divider"/>
+      <text x="115.49414062500001" y="621" class="state-composite-label" font-size="14" text-anchor="middle">Processing</text>
     </g>
     <g class="composite-state" id="composite-Executing">
-      <rect x="71.51484375" y="822" width="104.4" height="295" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="72.51484375" y="843" width="102.4" height="270" rx="0" ry="0" class="state-composite-inner-alt"/>
-      <path d="M 71.51484375 843 L 175.91484375 843" class="state-composite-divider"/>
-      <text x="123.71484375" y="838" class="state-composite-label" text-anchor="middle" font-size="14">Executing</text>
+      <rect x="63.294140625000004" y="822" width="104.4" height="295" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="64.29414062500001" y="843" width="102.4" height="270" rx="0" ry="0" class="state-composite-inner-alt"/>
+      <path d="M 63.294140625000004 843 L 167.69414062500002 843" class="state-composite-divider"/>
+      <text x="115.494140625" y="838" class="state-composite-label" font-size="14" text-anchor="middle">Executing</text>
     </g>
     <g class="state-node" id="state-Active">
-      <path d="M 100.9296875 301 H 146.5 A 5 5 0 0 1 151.5 306 V 332 A 5 5 0 0 1 146.5 337 H 100.9296875 A 5 5 0 0 1 95.9296875 332 V 306 A 5 5 0 0 1 100.9296875 301 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <path d="M 100.9296875 301 H 146.5 A 5 5 0 0 1 151.5 306 V 332 A 5 5 0 0 1 146.5 337 H 100.9296875 A 5 5 0 0 1 95.9296875 332 V 306 A 5 5 0 0 1 100.9296875 301 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
       <text x="123.71484375" y="324" class="state-label" text-anchor="middle" font-size="16">Active</text>
     </g>
     <g class="state-node" id="state-Done">
-      <path d="M 103.58984375 1069 H 143.83984375 A 5 5 0 0 1 148.83984375 1074 V 1100 A 5 5 0 0 1 143.83984375 1105 H 103.58984375 A 5 5 0 0 1 98.58984375 1100 V 1074 A 5 5 0 0 1 103.58984375 1069 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
-      <text x="123.71484375" y="1092" class="state-label" text-anchor="middle" font-size="16">Done</text>
+      <path d="M 95.36914062500001 1069 H 135.619140625 A 5 5 0 0 1 140.619140625 1074 V 1100 A 5 5 0 0 1 135.619140625 1105 H 95.36914062500001 A 5 5 0 0 1 90.36914062500001 1100 V 1074 A 5 5 0 0 1 95.36914062500001 1069 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <text x="115.49414062500001" y="1092" class="state-label" text-anchor="middle" font-size="16">Done</text>
     </g>
     <g class="state-node" id="state-Executing_start">
-      <circle cx="123.71484375" cy="866" r="7" class="state-start" fill="#333333"/>
+      <circle cx="115.49414062500001" cy="866" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Idle_start">
       <circle cx="123.71484375000001" cy="108" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Init">
-      <path d="M 111.21484375 953 H 136.21484375 A 5 5 0 0 1 141.21484375 958 V 984 A 5 5 0 0 1 136.21484375 989 H 111.21484375 A 5 5 0 0 1 106.21484375 984 V 958 A 5 5 0 0 1 111.21484375 953 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
-      <text x="123.71484375" y="976" class="state-label" text-anchor="middle" font-size="16">Init</text>
+      <path d="M 102.99414062500001 953 H 127.994140625 A 5 5 0 0 1 132.994140625 958 V 984 A 5 5 0 0 1 127.994140625 989 H 102.99414062500001 A 5 5 0 0 1 97.99414062500001 984 V 958 A 5 5 0 0 1 102.99414062500001 953 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="115.49414062500001" y="976" class="state-label" text-anchor="middle" font-size="16">Init</text>
     </g>
     <g class="state-node" id="state-Processing_start">
-      <circle cx="123.71484375" cy="649" r="7" class="state-start" fill="#333333"/>
+      <circle cx="115.49414062500001" cy="649" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Ready">
-      <path d="M 99.58984375 180 H 147.83984375 A 5 5 0 0 1 152.83984375 185 V 211 A 5 5 0 0 1 147.83984375 216 H 99.58984375 A 5 5 0 0 1 94.58984375 211 V 185 A 5 5 0 0 1 99.58984375 180 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="123.71484375" y="203" class="state-label" text-anchor="middle" font-size="16">Ready</text>
+      <path d="M 99.58984375 180 H 147.83984375 A 5 5 0 0 1 152.83984375 185 V 211 A 5 5 0 0 1 147.83984375 216 H 99.58984375 A 5 5 0 0 1 94.58984375 211 V 185 A 5 5 0 0 1 99.58984375 180 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <text x="123.71484375" y="203" class="state-label" font-size="16" text-anchor="middle">Ready</text>
     </g>
     <g class="state-node" id="state-ResourceAlloc">
-      <path d="M 137.2734375 459 H 242.4296875 A 5 5 0 0 1 247.4296875 464 V 490 A 5 5 0 0 1 242.4296875 495 H 137.2734375 A 5 5 0 0 1 132.2734375 490 V 464 A 5 5 0 0 1 137.2734375 459 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <path d="M 137.2734375 459 H 242.4296875 A 5 5 0 0 1 247.4296875 464 V 490 A 5 5 0 0 1 242.4296875 495 H 137.2734375 A 5 5 0 0 1 132.2734375 490 V 464 A 5 5 0 0 1 137.2734375 459 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
       <text x="189.8515625" y="482" class="state-label" text-anchor="middle" font-size="16">ResourceAlloc</text>
     </g>
     <g class="state-node" id="state-Validating">
-      <path d="M 87.578125 721 H 159.8515625 A 5 5 0 0 1 164.8515625 726 V 752 A 5 5 0 0 1 159.8515625 757 H 87.578125 A 5 5 0 0 1 82.578125 752 V 726 A 5 5 0 0 1 87.578125 721 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
-      <text x="123.71484375" y="744" class="state-label" font-size="16" text-anchor="middle">Validating</text>
+      <path d="M 79.35742187500001 721 H 151.630859375 A 5 5 0 0 1 156.630859375 726 V 752 A 5 5 0 0 1 151.630859375 757 H 79.35742187500001 A 5 5 0 0 1 74.35742187500001 752 V 726 A 5 5 0 0 1 79.35742187500001 721 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="115.49414062500001" y="744" class="state-label" text-anchor="middle" font-size="16">Validating</text>
     </g>
     <g class="state-node" id="state-Validation">
-      <path d="M 5 459 H 77.2734375 A 5 5 0 0 1 82.2734375 464 V 490 A 5 5 0 0 1 77.2734375 495 H 5 A 5 5 0 0 1 0 490 V 464 A 5 5 0 0 1 5 459 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
-      <text x="41.13671875" y="482" class="state-label" text-anchor="middle" font-size="16">Validation</text>
+      <path d="M 5 459 H 77.2734375 A 5 5 0 0 1 82.2734375 464 V 490 A 5 5 0 0 1 77.2734375 495 H 5 A 5 5 0 0 1 0 490 V 464 A 5 5 0 0 1 5 459 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
+      <text x="41.13671875" y="482" class="state-label" font-size="16" text-anchor="middle">Validation</text>
     </g>
     <g class="state-node" id="state-fork_state">
       <path d="M 82.494140625 399 H 148.494140625 A 2 2 0 0 1 150.494140625 401 V 407 A 2 2 0 0 1 148.494140625 409 H 82.494140625 A 2 2 0 0 1 80.494140625 407 V 401 A 2 2 0 0 1 82.494140625 399 Z" class="state-fork-join" fill="#333333"/>
@@ -261,45 +261,45 @@ marker path {
       <circle cx="123.71484375" cy="7" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 14.00 C 123.71 22.33, 123.71 30.67, 123.71 39.00 C 123.71 47.33, 123.71 55.67, 123.71 64.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 123.71 14.00 C 123.71 22.33, 123.71 30.67, 123.71 39.00 C 123.71 47.33, 123.71 55.67, 123.71 64.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 115.00 C 123.71 125.83, 123.71 136.67, 123.71 147.50 C 123.71 158.33, 123.71 169.17, 123.71 180.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 123.71 115.00 C 123.71 125.83, 123.71 136.67, 123.71 147.50 C 123.71 158.33, 123.71 169.17, 123.71 180.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 216.00 C 123.71 230.17, 123.71 244.33, 123.71 258.50 C 123.71 272.67, 123.71 286.83, 123.71 301.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 123.71 216.00 C 123.71 230.17, 123.71 244.33, 123.71 258.50 C 123.71 272.67, 123.71 286.83, 123.71 301.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
       <path d="M 87.71484375000001 247.7 H 159.71484375 A 2 2 0 0 1 161.71484375 249.7 V 267.3 A 2 2 0 0 1 159.71484375 269.3 H 87.71484375000001 A 2 2 0 0 1 85.71484375000001 267.3 V 249.7 A 2 2 0 0 1 87.71484375000001 247.7 Z" class="transition-label-bg"/>
-      <text x="123.71484375000001" y="258.5" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Start Job</text>
+      <text x="123.71484375000001" y="258.5" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Start Job</text>
     </g>
     <g class="transition">
-      <path d="M 115.49 349.00 C 115.49 357.33, 115.49 365.67, 115.49 374.00 C 115.49 382.33, 115.49 390.67, 115.49 399.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 115.49 349.00 C 115.49 357.33, 115.49 365.67, 115.49 374.00 C 115.49 382.33, 115.49 390.67, 115.49 399.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
       <path d="M 103.10 409.00 C 82.45 417.33, 61.79 425.67, 51.46 434.00 C 41.14 442.33, 41.14 450.67, 41.14 459.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 127.89 409.00 C 148.54 417.33, 169.20 425.67, 179.52 434.00 C 189.85 442.33, 189.85 450.67, 189.85 459.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 127.89 409.00 C 148.54 417.33, 169.20 425.67, 179.52 434.00 C 189.85 442.33, 189.85 450.67, 189.85 459.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 41.14 495.00 C 41.14 503.33, 41.14 511.67, 51.46 520.00 C 61.79 528.33, 82.45 536.67, 103.10 545.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 41.14 495.00 C 41.14 503.33, 41.14 511.67, 51.46 520.00 C 61.79 528.33, 82.45 536.67, 103.10 545.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 189.85 495.00 C 189.85 503.33, 189.85 511.67, 179.52 520.00 C 169.20 528.33, 148.54 536.67, 127.89 545.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 189.85 495.00 C 189.85 503.33, 189.85 511.67, 179.52 520.00 C 169.20 528.33, 148.54 536.67, 127.89 545.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 115.49 555.00 C 115.49 563.33, 115.49 571.67, 115.49 580.00 C 115.49 588.33, 115.49 596.67, 115.49 605.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 115.49 555.00 C 115.49 563.33, 115.49 571.67, 115.49 580.00 C 115.49 588.33, 115.49 596.67, 115.49 605.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 656.00 C 123.71 666.83, 123.71 677.67, 123.71 688.50 C 123.71 699.33, 123.71 710.17, 123.71 721.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 123.71 656.00 C 123.71 666.83, 123.71 677.67, 123.71 688.50 C 123.71 699.33, 123.71 710.17, 123.71 721.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 757.00 C 123.71 767.83, 123.71 778.67, 123.71 789.50 C 123.71 800.33, 123.71 811.17, 123.71 822.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 123.71 757.00 C 123.71 767.83, 123.71 778.67, 122.34 789.50 C 120.97 800.33, 118.23 811.17, 115.49 822.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 873.00 C 123.71 886.33, 123.71 899.67, 123.71 913.00 C 123.71 926.33, 123.71 939.67, 123.71 953.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 123.71 873.00 C 123.71 886.33, 123.71 899.67, 123.71 913.00 C 123.71 926.33, 123.71 939.67, 123.71 953.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 989.00 C 123.71 1002.33, 123.71 1015.67, 123.71 1029.00 C 123.71 1042.33, 123.71 1055.67, 123.71 1069.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 123.71 989.00 C 123.71 1002.33, 123.71 1015.67, 123.71 1029.00 C 123.71 1042.33, 123.71 1055.67, 123.71 1069.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
   </g>
 </svg>

--- a/docs/images/state_complex2.svg
+++ b/docs/images/state_complex2.svg
@@ -197,193 +197,193 @@ marker path {
 
     </g>
     <g class="composite-state" id="composite-Idle">
-      <rect x="136.84804687499997" y="64" width="1186.8157187499999" height="1674" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="137.84804687499997" y="85" width="1184.8157187499999" height="1649" rx="0" ry="0" class="state-composite-inner"/>
-      <path d="M 136.84804687499997 85 L 1323.6637656249998 85" class="state-composite-divider"/>
-      <text x="730.25590625" y="80" class="state-composite-label" font-size="14" text-anchor="middle">Idle</text>
+      <rect x="0" y="64" width="1186.8157187499999" height="1674" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="1" y="85" width="1184.8157187499999" height="1649" rx="0" ry="0" class="state-composite-inner"/>
+      <path d="M 0 85 L 1186.8157187499999 85" class="state-composite-divider"/>
+      <text x="593.4078593749999" y="80" class="state-composite-label" font-size="14" text-anchor="middle">Idle</text>
     </g>
     <g class="composite-state" id="composite-Processing">
-      <rect x="178.11653125" y="301" width="830.5826562499999" height="1425" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="179.11653125" y="322" width="828.5826562499999" height="1400" rx="0" ry="0" class="state-composite-inner-alt"/>
-      <path d="M 178.11653125 322 L 1008.6991874999999 322" class="state-composite-divider"/>
-      <text x="593.4078593749999" y="317" class="state-composite-label" font-size="14" text-anchor="middle">Processing</text>
+      <rect x="178.11653124999992" y="301" width="830.5826562499999" height="1425" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="179.11653124999992" y="322" width="828.5826562499999" height="1400" rx="0" ry="0" class="state-composite-inner-alt"/>
+      <path d="M 178.11653124999992 322 L 1008.6991874999999 322" class="state-composite-divider"/>
+      <text x="593.4078593749998" y="317" class="state-composite-label" font-size="14" text-anchor="middle">Processing</text>
     </g>
     <g class="composite-state" id="composite-Paused">
-      <rect x="481.4641093749999" y="1369" width="223.88750000000002" height="345" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="482.4641093749999" y="1390" width="221.88750000000002" height="320" rx="0" ry="0" class="state-composite-inner-alt"/>
-      <path d="M 481.4641093749999 1390 L 705.351609375 1390" class="state-composite-divider"/>
-      <text x="593.4078593749999" y="1385" class="state-composite-label" font-size="14" text-anchor="middle">Paused</text>
+      <rect x="616.5074687499998" y="1369" width="223.88750000000002" height="345" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="617.5074687499998" y="1390" width="221.88750000000002" height="320" rx="0" ry="0" class="state-composite-inner-alt"/>
+      <path d="M 616.5074687499998 1390 L 840.3949687499999 1390" class="state-composite-divider"/>
+      <text x="728.4512187499998" y="1385" class="state-composite-label" font-size="14" text-anchor="middle">Paused</text>
     </g>
     <g class="composite-state" id="composite-Running">
-      <rect x="515.5953593749999" y="704" width="155.625" height="565" rx="5" ry="5" class="state-composite-outer"/>
-      <rect x="516.5953593749999" y="725" width="153.625" height="540" rx="0" ry="0" class="state-composite-inner-alt"/>
-      <path d="M 515.5953593749999 725 L 671.2203593749999 725" class="state-composite-divider"/>
-      <text x="593.4078593749999" y="720" class="state-composite-label" font-size="14" text-anchor="middle">Running</text>
+      <rect x="440.4059062499998" y="704" width="155.625" height="565" rx="5" ry="5" class="state-composite-outer"/>
+      <rect x="441.4059062499998" y="725" width="153.625" height="540" rx="0" ry="0" class="state-composite-inner-alt"/>
+      <path d="M 440.4059062499998 725 L 596.0309062499998 725" class="state-composite-divider"/>
+      <text x="518.2184062499998" y="720" class="state-composite-label" font-size="14" text-anchor="middle">Running</text>
     </g>
     <g class="state-node" id="state-Cancelled">
-      <path d="M 556.8297343749999 1808 H 629.9859843749999 A 5 5 0 0 1 634.9859843749999 1813 V 1839 A 5 5 0 0 1 629.9859843749999 1844 H 556.8297343749999 A 5 5 0 0 1 551.8297343749999 1839 V 1813 A 5 5 0 0 1 556.8297343749999 1808 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
-      <text x="593.4078593749999" y="1831" class="state-label" font-size="16" text-anchor="middle">Cancelled</text>
+      <path d="M 556.8297343749999 1808 H 629.9859843749999 A 5 5 0 0 1 634.9859843749999 1813 V 1839 A 5 5 0 0 1 629.9859843749999 1844 H 556.8297343749999 A 5 5 0 0 1 551.8297343749999 1839 V 1813 A 5 5 0 0 1 556.8297343749999 1808 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
+      <text x="593.4078593749999" y="1831" class="state-label" text-anchor="middle" font-size="16">Cancelled</text>
     </g>
     <g class="state-node" id="state-Completed">
-      <path d="M 447.19067187499996 1523.5 H 526.5656718749999 A 5 5 0 0 1 531.5656718749999 1528.5 V 1554.5 A 5 5 0 0 1 526.5656718749999 1559.5 H 447.19067187499996 A 5 5 0 0 1 442.19067187499996 1554.5 V 1528.5 A 5 5 0 0 1 447.19067187499996 1523.5 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="486.87817187499996" y="1546.5" class="state-label" text-anchor="middle" font-size="16">Completed</text>
+      <path d="M 351.4207499999998 1523.5 H 430.7957499999998 A 5 5 0 0 1 435.7957499999998 1528.5 V 1554.5 A 5 5 0 0 1 430.7957499999998 1559.5 H 351.4207499999998 A 5 5 0 0 1 346.4207499999998 1554.5 V 1528.5 A 5 5 0 0 1 351.4207499999998 1523.5 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <text x="391.1082499999998" y="1546.5" class="state-label" text-anchor="middle" font-size="16">Completed</text>
     </g>
     <g class="state-node" id="state-Executing">
-      <path d="M 557.2750468749999 981 H 629.5406718749999 A 5 5 0 0 1 634.5406718749999 986 V 1012 A 5 5 0 0 1 629.5406718749999 1017 H 557.2750468749999 A 5 5 0 0 1 552.2750468749999 1012 V 986 A 5 5 0 0 1 557.2750468749999 981 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="593.4078593749999" y="1004" class="state-label" text-anchor="middle" font-size="16">Executing</text>
+      <path d="M 482.0855937499998 981 H 554.3512187499998 A 5 5 0 0 1 559.3512187499998 986 V 1012 A 5 5 0 0 1 554.3512187499998 1017 H 482.0855937499998 A 5 5 0 0 1 477.0855937499998 1012 V 986 A 5 5 0 0 1 482.0855937499998 981 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
+      <text x="518.2184062499998" y="1004" class="state-label" text-anchor="middle" font-size="16">Executing</text>
     </g>
     <g class="state-node" id="state-Failed">
-      <path d="M 591.199265625 1523.5 H 636.777390625 A 5 5 0 0 1 641.777390625 1528.5 V 1554.5 A 5 5 0 0 1 636.777390625 1559.5 H 591.199265625 A 5 5 0 0 1 586.199265625 1554.5 V 1528.5 A 5 5 0 0 1 591.199265625 1523.5 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
-      <text x="613.988328125" y="1546.5" class="state-label" text-anchor="middle" font-size="16">Failed</text>
+      <path d="M 495.4293437499998 1523.5 H 541.0074687499998 A 5 5 0 0 1 546.0074687499998 1528.5 V 1554.5 A 5 5 0 0 1 541.0074687499998 1559.5 H 495.4293437499998 A 5 5 0 0 1 490.4293437499998 1554.5 V 1528.5 A 5 5 0 0 1 495.4293437499998 1523.5 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="518.2184062499998" y="1546.5" class="state-label" text-anchor="middle" font-size="16">Failed</text>
     </g>
     <g class="state-node" id="state-Finalizing">
-      <path d="M 558.6148906249999 1112 H 628.2008281249999 A 5 5 0 0 1 633.2008281249999 1117 V 1143 A 5 5 0 0 1 628.2008281249999 1148 H 558.6148906249999 A 5 5 0 0 1 553.6148906249999 1143 V 1117 A 5 5 0 0 1 558.6148906249999 1112 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
-      <text x="593.4078593749999" y="1135" class="state-label" font-size="16" text-anchor="middle">Finalizing</text>
+      <path d="M 483.4254374999998 1112 H 553.0113749999998 A 5 5 0 0 1 558.0113749999998 1117 V 1143 A 5 5 0 0 1 553.0113749999998 1148 H 483.4254374999998 A 5 5 0 0 1 478.4254374999998 1143 V 1117 A 5 5 0 0 1 483.4254374999998 1112 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="518.2184062499998" y="1135" class="state-label" font-size="16" text-anchor="middle">Finalizing</text>
     </g>
     <g class="state-node" id="state-Idle_start">
       <circle cx="593.4078593749999" cy="108" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Initializing">
-      <path d="M 557.2789531249999 850 H 629.5367656249999 A 5 5 0 0 1 634.5367656249999 855 V 881 A 5 5 0 0 1 629.5367656249999 886 H 557.2789531249999 A 5 5 0 0 1 552.2789531249999 881 V 855 A 5 5 0 0 1 557.2789531249999 850 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="593.4078593749999" y="873" class="state-label" text-anchor="middle" font-size="16">Initializing</text>
+      <path d="M 482.0894999999998 850 H 554.3473124999998 A 5 5 0 0 1 559.3473124999998 855 V 881 A 5 5 0 0 1 554.3473124999998 886 H 482.0894999999998 A 5 5 0 0 1 477.0894999999998 881 V 855 A 5 5 0 0 1 482.0894999999998 850 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <text x="518.2184062499998" y="873" class="state-label" text-anchor="middle" font-size="16">Initializing</text>
     </g>
     <g class="state-node" id="state-Paused_start">
-      <circle cx="593.4078593749999" cy="1413" r="7" class="state-start" fill="#333333"/>
+      <circle cx="728.4512187499998" cy="1413" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Processing_start">
-      <circle cx="703.488328125" cy="345" r="7" class="state-start" fill="#333333"/>
+      <circle cx="607.7184062499998" cy="345" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Queued">
-      <path d="M 584.519578125 568 H 643.457078125 A 5 5 0 0 1 648.457078125 573 V 599 A 5 5 0 0 1 643.457078125 604 H 584.519578125 A 5 5 0 0 1 579.519578125 599 V 573 A 5 5 0 0 1 584.519578125 568 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
-      <text x="613.988328125" y="591" class="state-label" text-anchor="middle" font-size="16">Queued</text>
+      <path d="M 488.7496562499998 568 H 547.6871562499998 A 5 5 0 0 1 552.6871562499998 573 V 599 A 5 5 0 0 1 547.6871562499998 604 H 488.7496562499998 A 5 5 0 0 1 483.7496562499998 599 V 573 A 5 5 0 0 1 488.7496562499998 568 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <text x="518.2184062499998" y="591" class="state-label" text-anchor="middle" font-size="16">Queued</text>
     </g>
     <g class="state-node" id="state-Ready">
       <path d="M 569.2828593749999 180 H 617.5328593749999 A 5 5 0 0 1 622.5328593749999 185 V 211 A 5 5 0 0 1 617.5328593749999 216 H 569.2828593749999 A 5 5 0 0 1 564.2828593749999 211 V 185 A 5 5 0 0 1 569.2828593749999 180 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
       <text x="593.4078593749999" y="203" class="state-label" font-size="16" text-anchor="middle">Ready</text>
     </g>
     <g class="state-node" id="state-Running_end">
-      <path d="M 586.4078593749999 1250 A 7 7 0 1 0 600.4078593749999 1250 A 7 7 0 1 0 586.4078593749999 1250 Z" class="state-end-outer" fill="none" stroke-width="2" stroke="#9370DB"/>
-      <path d="M 590.887859375 1250 A 2.52 2.52 0 1 0 595.9278593749999 1250 A 2.52 2.52 0 1 0 590.887859375 1250 Z" class="state-end-inner" stroke-width="2" fill="#9370DB" stroke="#9370DB"/>
+      <path d="M 511.2184062499998 1250 A 7 7 0 1 0 525.2184062499998 1250 A 7 7 0 1 0 511.2184062499998 1250 Z" class="state-end-outer" stroke-width="2" fill="none" stroke="#9370DB"/>
+      <path d="M 515.6984062499998 1250 A 2.52 2.52 0 1 0 520.7384062499998 1250 A 2.52 2.52 0 1 0 515.6984062499998 1250 Z" class="state-end-inner" fill="#9370DB" stroke-width="2" stroke="#9370DB"/>
     </g>
     <g class="state-node" id="state-Running_start">
-      <circle cx="593.4078593749999" cy="748" r="7" class="state-start" fill="#333333"/>
+      <circle cx="518.2184062499998" cy="748" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Timeout">
-      <path d="M 563.5094218749999 1666 H 623.3062968749999 A 5 5 0 0 1 628.3062968749999 1671 V 1697 A 5 5 0 0 1 623.3062968749999 1702 H 563.5094218749999 A 5 5 0 0 1 558.5094218749999 1697 V 1671 A 5 5 0 0 1 563.5094218749999 1666 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
-      <text x="593.4078593749999" y="1689" class="state-label" font-size="16" text-anchor="middle">Timeout</text>
+      <path d="M 698.5527812499998 1666 H 758.3496562499998 A 5 5 0 0 1 763.3496562499998 1671 V 1697 A 5 5 0 0 1 758.3496562499998 1702 H 698.5527812499998 A 5 5 0 0 1 693.5527812499998 1697 V 1671 A 5 5 0 0 1 698.5527812499998 1666 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
+      <text x="728.4512187499998" y="1689" class="state-label" text-anchor="middle" font-size="16">Timeout</text>
     </g>
     <g class="state-node" id="state-Validating">
-      <path d="M 667.351609375 432 H 739.625046875 A 5 5 0 0 1 744.625046875 437 V 463 A 5 5 0 0 1 739.625046875 468 H 667.351609375 A 5 5 0 0 1 662.351609375 463 V 437 A 5 5 0 0 1 667.351609375 432 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
-      <text x="703.488328125" y="455" class="state-label" font-size="16" text-anchor="middle">Validating</text>
+      <path d="M 571.5816874999998 432 H 643.8551249999998 A 5 5 0 0 1 648.8551249999998 437 V 463 A 5 5 0 0 1 643.8551249999998 468 H 571.5816874999998 A 5 5 0 0 1 566.5816874999998 463 V 437 A 5 5 0 0 1 571.5816874999998 432 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
+      <text x="607.7184062499998" y="455" class="state-label" text-anchor="middle" font-size="16">Validating</text>
     </g>
     <g class="state-node" id="state-WaitingResume">
-      <path d="M 535.9430156249999 1515 H 650.8727031249999 A 5 5 0 0 1 655.8727031249999 1520 V 1546 A 5 5 0 0 1 650.8727031249999 1551 H 535.9430156249999 A 5 5 0 0 1 530.9430156249999 1546 V 1520 A 5 5 0 0 1 535.9430156249999 1515 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
-      <text x="593.4078593749999" y="1538" class="state-label" text-anchor="middle" font-size="16">WaitingResume</text>
+      <path d="M 670.9863749999998 1515 H 785.9160624999998 A 5 5 0 0 1 790.9160624999998 1520 V 1546 A 5 5 0 0 1 785.9160624999998 1551 H 670.9863749999998 A 5 5 0 0 1 665.9863749999998 1546 V 1520 A 5 5 0 0 1 670.9863749999998 1515 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
+      <text x="728.4512187499998" y="1538" class="state-label" font-size="16" text-anchor="middle">WaitingResume</text>
     </g>
     <g class="state-node" id="state-root_end">
-      <path d="M 596.4078593749999 1901 A 7 7 0 1 0 610.4078593749999 1901 A 7 7 0 1 0 596.4078593749999 1901 Z" class="state-end-outer" fill="none" stroke="#9370DB" stroke-width="2"/>
-      <path d="M 600.887859375 1901 A 2.52 2.52 0 1 0 605.9278593749999 1901 A 2.52 2.52 0 1 0 600.887859375 1901 Z" class="state-end-inner" fill="#9370DB" stroke-width="2" stroke="#9370DB"/>
+      <path d="M 596.4078593749999 1901 A 7 7 0 1 0 610.4078593749999 1901 A 7 7 0 1 0 596.4078593749999 1901 Z" class="state-end-outer" stroke="#9370DB" stroke-width="2" fill="none"/>
+      <path d="M 600.887859375 1901 A 2.52 2.52 0 1 0 605.9278593749999 1901 A 2.52 2.52 0 1 0 600.887859375 1901 Z" class="state-end-inner" fill="#9370DB" stroke="#9370DB" stroke-width="2"/>
     </g>
     <g class="state-node" id="state-root_start">
-      <circle cx="730.25590625" cy="7" r="7" class="state-start" fill="#333333"/>
+      <circle cx="593.4078593749999" cy="7" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="transition">
-      <path d="M 730.26 14.00 C 730.26 22.33, 730.26 30.67, 730.26 39.00 C 730.26 47.33, 730.26 55.67, 730.26 64.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 593.41 14.00 C 593.41 22.33, 593.41 30.67, 593.41 39.00 C 593.41 47.33, 593.41 55.67, 593.41 64.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 593.41 115.00 C 593.41 125.83, 593.41 136.67, 593.41 147.50 C 593.41 158.33, 593.41 169.17, 593.41 180.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 593.41 115.00 C 593.41 125.83, 593.41 136.67, 593.41 147.50 C 593.41 158.33, 593.41 169.17, 593.41 180.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 593.41 216.00 C 593.41 230.17, 593.41 244.33, 593.41 258.50 C 593.41 272.67, 593.41 286.83, 593.41 301.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 593.41 216.00 C 593.41 230.17, 593.41 244.33, 593.41 258.50 C 593.41 272.67, 593.41 286.83, 593.41 301.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
       <path d="M 557.4078593749999 247.7 H 629.4078593749999 A 2 2 0 0 1 631.4078593749999 249.7 V 267.3 A 2 2 0 0 1 629.4078593749999 269.3 H 557.4078593749999 A 2 2 0 0 1 555.4078593749999 267.3 V 249.7 A 2 2 0 0 1 557.4078593749999 247.7 Z" class="transition-label-bg"/>
-      <text x="593.4078593749999" y="258.5" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Start Job</text>
+      <text x="593.4078593749999" y="258.5" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Start Job</text>
     </g>
     <g class="transition">
-      <path d="M 703.49 352.00 C 703.49 365.33, 703.49 378.67, 703.49 392.00 C 703.49 405.33, 703.49 418.67, 703.49 432.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 566.64 352.00 C 566.64 365.33, 566.64 378.67, 566.64 392.00 C 566.64 405.33, 566.64 418.67, 566.64 432.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 679.80 468.00 C 657.86 484.67, 635.92 501.33, 624.96 518.00 C 613.99 534.67, 613.99 551.33, 613.99 568.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
-      <path d="M 606.986542286706 497.3242618659663 H 646.986542286706 A 2 2 0 0 1 648.986542286706 499.3242618659663 V 516.9242618659663 A 2 2 0 0 1 646.986542286706 518.9242618659663 H 606.986542286706 A 2 2 0 0 1 604.986542286706 516.9242618659663 V 499.3242618659663 A 2 2 0 0 1 606.986542286706 497.3242618659663 Z" class="transition-label-bg"/>
-      <text x="626.986542286706" y="508.12426186596633" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Valid</text>
+      <path d="M 542.95 468.00 C 521.01 484.67, 499.08 501.33, 488.11 518.00 C 477.14 534.67, 477.14 551.33, 477.14 568.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 470.138495411706 497.3242618659663 H 510.138495411706 A 2 2 0 0 1 512.138495411706 499.3242618659663 V 516.9242618659663 A 2 2 0 0 1 510.138495411706 518.9242618659663 H 470.138495411706 A 2 2 0 0 1 468.138495411706 516.9242618659663 V 499.3242618659663 A 2 2 0 0 1 470.138495411706 497.3242618659663 Z" class="transition-label-bg"/>
+      <text x="490.138495411706" y="508.12426186596633" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Valid</text>
     </g>
     <g class="transition">
-      <path d="M 744.63 460.02 C 823.99 479.35, 903.36 498.67, 943.04 641.84 C 982.72 785.00, 982.72 1052.00, 925.90 1219.79 C 755.43 1456.15, 641.78 1524.73, 641.78 1524.73" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
-      <path d="M 954.721140625 984.2758386278989 H 1010.721140625 A 2 2 0 0 1 1012.721140625 986.2758386278989 V 1003.8758386278989 A 2 2 0 0 1 1010.721140625 1005.8758386278989 H 954.721140625 A 2 2 0 0 1 952.721140625 1003.8758386278989 V 986.2758386278989 A 2 2 0 0 1 954.721140625 984.2758386278989 Z" class="transition-label-bg"/>
-      <text x="982.721140625" y="995.0758386278989" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Invalid</text>
+      <path d="M 607.78 460.02 C 687.14 479.35, 766.51 498.67, 806.19 641.84 C 845.87 785.00, 845.87 1052.00, 789.05 1219.79 C 618.58 1456.15, 504.93 1524.73, 504.93 1524.73" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 817.87309375 984.2758386278989 H 873.87309375 A 2 2 0 0 1 875.87309375 986.2758386278989 V 1003.8758386278989 A 2 2 0 0 1 873.87309375 1005.8758386278989 H 817.87309375 A 2 2 0 0 1 815.87309375 1003.8758386278989 V 986.2758386278989 A 2 2 0 0 1 817.87309375 984.2758386278989 Z" class="transition-label-bg"/>
+      <text x="845.87309375" y="995.0758386278989" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Invalid</text>
     </g>
     <g class="transition">
-      <path d="M 613.99 604.00 L 593.41 704.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
-      <path d="M 549.988328125 643.2 H 677.988328125 A 2 2 0 0 1 679.988328125 645.2 V 662.8000000000001 A 2 2 0 0 1 677.988328125 664.8000000000001 H 549.988328125 A 2 2 0 0 1 547.988328125 662.8000000000001 V 645.2 A 2 2 0 0 1 549.988328125 643.2 Z" class="transition-label-bg"/>
-      <text x="613.988328125" y="654" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Worker Available</text>
+      <path d="M 477.14 604.00 L 518.22 704.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 413.14028124999993 643.2 H 541.1402812499999 A 2 2 0 0 1 543.1402812499999 645.2 V 662.8000000000001 A 2 2 0 0 1 541.1402812499999 664.8000000000001 H 413.14028124999993 A 2 2 0 0 1 411.14028124999993 662.8000000000001 V 645.2 A 2 2 0 0 1 413.14028124999993 643.2 Z" class="transition-label-bg"/>
+      <text x="477.14028124999993" y="654" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Worker Available</text>
     </g>
     <g class="transition">
-      <path d="M 593.41 1269.00 C 557.90 1285.67, 522.39 1302.33, 504.63 1344.75 C 486.88 1387.17, 486.88 1455.33, 486.88 1523.50" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-      <path d="M 458.87817187499996 1341.4217243105106 H 514.8781718749999 A 2 2 0 0 1 516.8781718749999 1343.4217243105106 V 1361.0217243105105 A 2 2 0 0 1 514.8781718749999 1363.0217243105105 H 458.87817187499996 A 2 2 0 0 1 456.87817187499996 1361.0217243105105 V 1343.4217243105106 A 2 2 0 0 1 458.87817187499996 1341.4217243105106 Z" class="transition-label-bg"/>
-      <text x="486.87817187499996" y="1352.2217243105106" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Success</text>
+      <path d="M 518.22 1269.00 C 462.16 1285.67, 406.09 1302.33, 378.06 1344.75 C 350.03 1387.17, 350.03 1455.33, 350.03 1523.50" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 322.03012499999994 1341.4217243105106 H 378.03012499999994 A 2 2 0 0 1 380.03012499999994 1343.4217243105106 V 1361.0217243105105 A 2 2 0 0 1 378.03012499999994 1363.0217243105105 H 322.03012499999994 A 2 2 0 0 1 320.03012499999994 1361.0217243105105 V 1343.4217243105106 A 2 2 0 0 1 322.03012499999994 1341.4217243105106 Z" class="transition-label-bg"/>
+      <text x="350.03012499999994" y="1352.2217243105106" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Success</text>
     </g>
     <g class="transition">
-      <path d="M 593.41 1269.00 L 613.61 1523.50" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
-      <path d="M 590.9635387927733 1385.4529924434096 H 630.9635387927733 A 2 2 0 0 1 632.9635387927733 1387.4529924434096 V 1405.0529924434095 A 2 2 0 0 1 630.9635387927733 1407.0529924434095 H 590.9635387927733 A 2 2 0 0 1 588.9635387927733 1405.0529924434095 V 1387.4529924434096 A 2 2 0 0 1 590.9635387927733 1385.4529924434096 Z" class="transition-label-bg"/>
-      <text x="610.9635387927733" y="1396.2529924434095" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Error</text>
+      <path d="M 518.22 1269.00 C 502.98 1285.67, 487.74 1302.33, 480.84 1344.75 C 473.93 1387.17, 475.35 1455.33, 476.77 1523.50" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
+      <path d="M 454.11549191777334 1385.4529924434096 H 494.11549191777334 A 2 2 0 0 1 496.11549191777334 1387.4529924434096 V 1405.0529924434095 A 2 2 0 0 1 494.11549191777334 1407.0529924434095 H 454.11549191777334 A 2 2 0 0 1 452.11549191777334 1405.0529924434095 V 1387.4529924434096 A 2 2 0 0 1 454.11549191777334 1385.4529924434096 Z" class="transition-label-bg"/>
+      <text x="474.11549191777334" y="1396.2529924434095" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Error</text>
     </g>
     <g class="transition">
-      <path d="M 593.41 1269.00 C 650.01 1285.67, 706.62 1302.33, 706.62 1319.00 C 706.62 1335.67, 650.01 1352.33, 593.41 1369.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
-      <path d="M 686.1254630559454 1252.2852674963112 H 790.1254630559454 A 2 2 0 0 1 792.1254630559454 1254.2852674963112 V 1271.8852674963111 A 2 2 0 0 1 790.1254630559454 1273.8852674963111 H 686.1254630559454 A 2 2 0 0 1 684.1254630559454 1271.8852674963111 V 1254.2852674963112 A 2 2 0 0 1 686.1254630559454 1252.2852674963112 Z" class="transition-label-bg"/>
-      <text x="738.1254630559454" y="1263.0852674963112" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Pause Request</text>
+      <path d="M 518.22 1269.00 C 554.27 1285.67, 590.32 1302.33, 625.36 1319.00 C 660.40 1335.67, 694.43 1352.33, 728.45 1369.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 549.2774161809454 1252.2852674963112 H 653.2774161809454 A 2 2 0 0 1 655.2774161809454 1254.2852674963112 V 1271.8852674963111 A 2 2 0 0 1 653.2774161809454 1273.8852674963111 H 549.2774161809454 A 2 2 0 0 1 547.2774161809454 1271.8852674963111 V 1254.2852674963112 A 2 2 0 0 1 549.2774161809454 1252.2852674963112 Z" class="transition-label-bg"/>
+      <text x="601.2774161809454" y="1263.0852674963112" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Pause Request</text>
     </g>
     <g class="transition">
-      <path d="M 593.41 755.00 C 593.41 770.83, 593.41 786.67, 593.41 802.50 C 593.41 818.33, 593.41 834.17, 593.41 850.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 518.22 755.00 C 518.22 770.83, 518.22 786.67, 518.22 802.50 C 518.22 818.33, 518.22 834.17, 518.22 850.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 593.41 886.00 C 593.41 901.83, 593.41 917.67, 593.41 933.50 C 593.41 949.33, 593.41 965.17, 593.41 981.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 518.22 886.00 C 518.22 901.83, 518.22 917.67, 518.22 933.50 C 518.22 949.33, 518.22 965.17, 518.22 981.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 593.41 1017.00 C 593.41 1032.83, 593.41 1048.67, 593.41 1064.50 C 593.41 1080.33, 593.41 1096.17, 593.41 1112.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 518.22 1017.00 C 518.22 1032.83, 518.22 1048.67, 518.22 1064.50 C 518.22 1080.33, 518.22 1096.17, 518.22 1112.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 593.41 1148.00 C 593.41 1163.83, 593.41 1179.67, 593.41 1195.50 C 593.41 1211.33, 593.41 1227.17, 593.41 1243.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 518.22 1148.00 C 518.22 1163.83, 518.22 1179.67, 518.22 1195.50 C 518.22 1211.33, 518.22 1227.17, 518.22 1243.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 730.26 1420.00 C 730.26 1435.83, 730.26 1451.67, 730.26 1467.50 C 730.26 1483.33, 730.26 1499.17, 730.26 1515.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 728.45 1420.00 C 728.45 1435.83, 728.45 1451.67, 728.45 1467.50 C 728.45 1483.33, 728.45 1499.17, 728.45 1515.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 730.26 1551.00 C 730.26 1570.17, 730.26 1589.33, 730.26 1608.50 C 730.26 1627.67, 730.26 1646.83, 730.26 1666.00" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
-      <path d="M 706.25590625 1597.7 H 754.25590625 A 2 2 0 0 1 756.25590625 1599.7 V 1617.3 A 2 2 0 0 1 754.25590625 1619.3 H 706.25590625 A 2 2 0 0 1 704.25590625 1617.3 V 1599.7 A 2 2 0 0 1 706.25590625 1597.7 Z" class="transition-label-bg"/>
-      <text x="730.25590625" y="1608.5" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">1 hour</text>
+      <path d="M 728.45 1551.00 C 728.45 1570.17, 728.45 1589.33, 728.45 1608.50 C 728.45 1627.67, 728.45 1646.83, 728.45 1666.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 704.4512187499998 1597.7 H 752.4512187499998 A 2 2 0 0 1 754.4512187499998 1599.7 V 1617.3 A 2 2 0 0 1 752.4512187499998 1619.3 H 704.4512187499998 A 2 2 0 0 1 702.4512187499998 1617.3 V 1599.7 A 2 2 0 0 1 704.4512187499998 1597.7 Z" class="transition-label-bg"/>
+      <text x="728.4512187499998" y="1608.5" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">1 hour</text>
     </g>
     <g class="transition">
-      <path d="M 593.41 1714.00 C 690.68 1582.33, 787.95 1450.67, 787.95 1282.33 C 787.95 1114.00, 690.68 909.00, 593.41 704.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
-      <path d="M 780.8966707323762 1209.7315072202136 H 828.8966707323762 A 2 2 0 0 1 830.8966707323762 1211.7315072202136 V 1229.3315072202136 A 2 2 0 0 1 828.8966707323762 1231.3315072202136 H 780.8966707323762 A 2 2 0 0 1 778.8966707323762 1229.3315072202136 V 1211.7315072202136 A 2 2 0 0 1 780.8966707323762 1209.7315072202136 Z" class="transition-label-bg"/>
-      <text x="804.8966707323762" y="1220.5315072202136" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Resume</text>
+      <path d="M 728.45 1714.00 C 735.09 1582.33, 741.73 1450.67, 706.69 1282.33 C 671.65 1114.00, 594.94 909.00, 518.22 704.00" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 644.0486238573761 1209.7315072202136 H 692.0486238573761 A 2 2 0 0 1 694.0486238573761 1211.7315072202136 V 1229.3315072202136 A 2 2 0 0 1 692.0486238573761 1231.3315072202136 H 644.0486238573761 A 2 2 0 0 1 642.0486238573761 1229.3315072202136 V 1211.7315072202136 A 2 2 0 0 1 644.0486238573761 1209.7315072202136 Z" class="transition-label-bg"/>
+      <text x="668.0486238573761" y="1220.5315072202136" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Resume</text>
     </g>
     <g class="transition">
-      <path d="M 593.41 1714.00 C 593.41 1729.67, 593.41 1745.33, 593.41 1761.00 C 593.41 1776.67, 593.41 1792.33, 593.41 1808.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
-      <path d="M 537.4078593749999 1750.2 H 649.4078593749999 A 2 2 0 0 1 651.4078593749999 1752.2 V 1769.8 A 2 2 0 0 1 649.4078593749999 1771.8 H 537.4078593749999 A 2 2 0 0 1 535.4078593749999 1769.8 V 1752.2 A 2 2 0 0 1 537.4078593749999 1750.2 Z" class="transition-label-bg"/>
-      <text x="593.4078593749999" y="1761" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Cancel Request</text>
+      <path d="M 728.45 1714.00 C 705.94 1729.67, 683.44 1745.33, 660.93 1761.00 C 638.42 1776.67, 615.92 1792.33, 593.41 1808.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 604.9295390624999 1750.2 H 716.9295390624999 A 2 2 0 0 1 718.9295390624999 1752.2 V 1769.8 A 2 2 0 0 1 716.9295390624999 1771.8 H 604.9295390624999 A 2 2 0 0 1 602.9295390624999 1769.8 V 1752.2 A 2 2 0 0 1 604.9295390624999 1750.2 Z" class="transition-label-bg"/>
+      <text x="660.9295390624999" y="1761" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Cancel Request</text>
     </g>
     <g class="transition">
-      <path d="M 593.41 1702.00 C 593.41 1719.67, 593.41 1737.33, 593.41 1755.00 C 593.41 1772.67, 593.41 1790.33, 593.41 1808.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 728.45 1702.00 C 705.94 1719.67, 683.44 1737.33, 660.93 1755.00 C 638.42 1772.67, 615.92 1790.33, 593.41 1808.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 486.88 1523.50 C 504.63 1559.25, 522.39 1595.00, 540.14 1630.75 C 557.90 1666.50, 575.65 1702.25, 593.41 1738.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
-      <path d="M 520.143015625 1619.95 H 560.143015625 A 2 2 0 0 1 562.143015625 1621.95 V 1639.55 A 2 2 0 0 1 560.143015625 1641.55 H 520.143015625 A 2 2 0 0 1 518.143015625 1639.55 V 1621.95 A 2 2 0 0 1 520.143015625 1619.95 Z" class="transition-label-bg"/>
-      <text x="540.143015625" y="1630.75" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Reset</text>
+      <path d="M 391.11 1523.50 C 424.82 1559.25, 458.54 1595.00, 492.26 1630.75 C 525.97 1666.50, 559.69 1702.25, 593.41 1738.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
+      <path d="M 472.2580546874999 1619.95 H 512.2580546874999 A 2 2 0 0 1 514.2580546874999 1621.95 V 1639.55 A 2 2 0 0 1 512.2580546874999 1641.55 H 472.2580546874999 A 2 2 0 0 1 470.2580546874999 1639.55 V 1621.95 A 2 2 0 0 1 472.2580546874999 1619.95 Z" class="transition-label-bg"/>
+      <text x="492.2580546874999" y="1630.75" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Reset</text>
     </g>
     <g class="transition">
-      <path d="M 613.99 1523.50 C 610.56 1559.25, 607.13 1595.00, 603.70 1630.75 C 600.27 1666.50, 596.84 1702.25, 593.41 1738.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="1"/>
-      <path d="M 583.69809375 1619.95 H 623.69809375 A 2 2 0 0 1 625.69809375 1621.95 V 1639.55 A 2 2 0 0 1 623.69809375 1641.55 H 583.69809375 A 2 2 0 0 1 581.69809375 1639.55 V 1621.95 A 2 2 0 0 1 583.69809375 1619.95 Z" class="transition-label-bg"/>
-      <text x="603.69809375" y="1630.75" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Retry</text>
+      <path d="M 518.22 1523.50 C 530.75 1559.25, 543.28 1595.00, 555.81 1630.75 C 568.34 1666.50, 580.88 1702.25, 593.41 1738.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 535.8131328124998 1619.95 H 575.8131328124998 A 2 2 0 0 1 577.8131328124998 1621.95 V 1639.55 A 2 2 0 0 1 575.8131328124998 1641.55 H 535.8131328124998 A 2 2 0 0 1 533.8131328124998 1639.55 V 1621.95 A 2 2 0 0 1 535.8131328124998 1619.95 Z" class="transition-label-bg"/>
+      <text x="555.8131328124998" y="1630.75" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Retry</text>
     </g>
     <g class="transition">
-      <path d="M 605.80 1808.00 C 613.84 1796.33, 621.87 1784.67, 642.62 1494.00 C 663.36 1203.33, 696.81 633.67, 730.26 64.00" class="transition-path" fill="none" stroke-width="1" marker-end="url(#arrow)"/>
+      <path d="M 605.80 1808.00 C 613.84 1796.33, 621.87 1784.67, 619.81 1494.00 C 617.74 1203.33, 605.57 633.67, 593.41 64.00" class="transition-path" stroke-width="1" fill="none" marker-end="url(#arrow)"/>
       <path d="M 607.7904565700014 1765.2745848949294 H 647.7904565700014 A 2 2 0 0 1 649.7904565700014 1767.2745848949294 V 1784.8745848949293 A 2 2 0 0 1 647.7904565700014 1786.8745848949293 H 607.7904565700014 A 2 2 0 0 1 605.7904565700014 1784.8745848949293 V 1767.2745848949294 A 2 2 0 0 1 607.7904565700014 1765.2745848949294 Z" class="transition-label-bg"/>
-      <text x="627.7904565700014" y="1776.0745848949293" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Reset</text>
+      <text x="627.7904565700014" y="1776.0745848949293" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Reset</text>
     </g>
     <g class="transition">
-      <path d="M 486.88 1559.50 C 505.94 1615.31, 525.00 1671.11, 544.06 1726.92 C 563.13 1782.73, 582.19 1838.53, 601.25 1894.34" class="transition-path" stroke-width="1" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 391.11 1559.50 C 425.90 1615.41, 460.69 1671.32, 495.48 1727.24 C 530.27 1783.15, 565.06 1839.06, 599.85 1894.97" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
     </g>
     <g class="transition">
-      <path d="M 593.41 1844.00 C 593.41 1852.33, 593.41 1860.67, 594.73 1869.05 C 596.05 1877.44, 598.68 1885.88, 601.32 1894.32" class="transition-path" marker-end="url(#arrow)" stroke-width="1" fill="none"/>
+      <path d="M 593.41 1844.00 C 593.41 1852.33, 593.41 1860.67, 594.73 1869.05 C 596.05 1877.44, 598.68 1885.88, 601.32 1894.32" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="1"/>
     </g>
   </g>
 </svg>

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -714,38 +714,6 @@ fn center_composite_states(
     composite_offsets
 }
 
-/// Calculate the X bounds of a composite state including all nested children
-/// Calculate x bounds for a composite's content (excluding nested composites for centering)
-/// This is used during centering to find where to center nested composites within
-fn calculate_composite_x_bounds_for_centering(
-    comp_id: &str,
-    db: &StateDb,
-    state_positions: &HashMap<String, (f64, f64, f64, f64)>,
-    composite_ids: &std::collections::HashSet<&str>,
-) -> (f64, f64) {
-    let states = db.get_states();
-    let mut min_x = f64::MAX;
-    let mut max_x = f64::MIN;
-
-    // For centering, we only consider NON-composite direct children
-    // Nested composites will be centered within these bounds, so don't include them
-    for (id, state) in states.iter() {
-        if state.parent.as_deref() == Some(comp_id) {
-            let is_nested_composite = composite_ids.contains(id.as_str());
-
-            if !is_nested_composite {
-                // For non-composite children, use state_positions directly
-                if let Some(&(x, _, w, _)) = state_positions.get(id) {
-                    min_x = min_x.min(x);
-                    max_x = max_x.max(x + w);
-                }
-            }
-        }
-    }
-
-    (min_x, max_x)
-}
-
 fn calculate_composite_x_bounds(
     comp_id: &str,
     db: &StateDb,
@@ -846,57 +814,71 @@ fn center_nested_composites(
         })
         .collect();
 
-    // Sort by depth descending (deepest first) so inner composites are centered
-    // before their parents, ensuring consistent bounds calculations
-    nested_composites.sort_by(|a, b| b.2.cmp(&a.2));
+    // Sort by depth ascending (shallowest first) so outer parents are centered first.
+    // This ensures that when inner composites are centered, they account for the
+    // outer shifts that already happened. Deepest-first would break because outer
+    // shifts would undo inner centering.
+    nested_composites.sort_by(|a, b| a.2.cmp(&b.2));
 
-    // Process from innermost to outermost
-    for (nested_id, parent_id, _depth) in nested_composites {
-        // Calculate the parent's bounds from NON-COMPOSITE children only
-        // This gives us the "anchor" content that the nested composite should be centered with
-        let (parent_non_comp_min_x, parent_non_comp_max_x) =
-            calculate_composite_x_bounds_for_centering(
-                parent_id,
-                db,
-                state_positions,
-                composite_ids,
-            );
+    // Deduplicate by parent: process each parent composite only once.
+    // Track which parents have been processed.
+    let mut processed_parents: std::collections::HashSet<&str> = std::collections::HashSet::new();
 
-        // Calculate nested composite's RENDERED bounds (with padding)
-        let nested_rendered = calculate_composite_bounds_recursive(nested_id, db, state_positions);
+    for (_nested_id, parent_id, _depth) in &nested_composites {
+        if processed_parents.contains(parent_id) {
+            continue;
+        }
+        processed_parents.insert(parent_id);
 
-        let Some((nested_x, _, nested_w, _)) = nested_rendered else {
+        // Get the parent composite's dagre-assigned position and dimensions.
+        let Some(&(parent_x, _, parent_w, _)) = state_positions.get(*parent_id) else {
             continue;
         };
 
-        // If there are non-composite children, center the nested composite with them
-        // Otherwise, the nested composite is the only content and doesn't need centering
-        if parent_non_comp_min_x >= parent_non_comp_max_x {
+        // Calculate the parent's content bounds (from ALL children).
+        // render_composite_state centers the rendered rect on the content center,
+        // so aligning content center with the dagre center ensures proper centering.
+        let parent_content = calculate_composite_bounds_recursive(parent_id, db, state_positions);
+
+        let Some((content_x, _, content_w, _)) = parent_content else {
             continue;
-        }
+        };
 
-        // The non-composite children define the "anchor" center for the parent
-        // The nested composite should be centered around this same center
-        let non_comp_center_x = (parent_non_comp_min_x + parent_non_comp_max_x) / 2.0;
+        let content_center_x = content_x + content_w / 2.0;
+        let parent_center_x = parent_x + parent_w / 2.0;
 
-        // The nested composite's current center
-        let nested_center_x = nested_x + nested_w / 2.0;
+        let offset_x = parent_center_x - content_center_x;
 
-        // Calculate offset to align nested composite's center with non-composite center
-        let offset_x = non_comp_center_x - nested_center_x;
-
-        // Only shift if there's a meaningful offset
         if offset_x.abs() > 0.5 {
-            // Track the offset applied to this nested composite
-            nested_offsets.insert(nested_id.to_string(), offset_x);
-
-            // Shift the nested composite itself
-            if let Some((x, y, w, h)) = state_positions.get(nested_id).copied() {
-                state_positions.insert(nested_id.to_string(), (x + offset_x, y, w, h));
+            // Track the offset per nested composite within this parent (for edge adjustment)
+            for (nid, pid, _) in &nested_composites {
+                if *pid == *parent_id {
+                    nested_offsets.insert(nid.to_string(), offset_x);
+                }
             }
 
-            // Shift all children of the nested composite
-            shift_composite_and_children(nested_id, offset_x, db, state_positions, composite_ids);
+            // Shift ALL direct children of the parent (and their subtrees)
+            // so the content center aligns with the parent's dagre center.
+            let child_ids: Vec<String> = states
+                .iter()
+                .filter(|(_, s)| s.parent.as_deref() == Some(*parent_id))
+                .map(|(id, _)| id.clone())
+                .collect();
+
+            for child_id in &child_ids {
+                if let Some((x, y, w, h)) = state_positions.get(child_id.as_str()).copied() {
+                    state_positions.insert(child_id.clone(), (x + offset_x, y, w, h));
+                }
+                if composite_ids.contains(child_id.as_str()) {
+                    shift_composite_and_children(
+                        child_id,
+                        offset_x,
+                        db,
+                        state_positions,
+                        composite_ids,
+                    );
+                }
+            }
         }
     }
 
@@ -1032,15 +1014,15 @@ pub fn render_state(db: &StateDb, config: &RenderConfig) -> Result<String> {
     // Merge nested offsets into composite_offsets for edge bend point adjustment
     // Note: nested offsets need to include parent's offset for correct edge positioning
     let nested_offsets = center_nested_composites(db, &mut state_positions, &composite_ids);
-    for (id, nested_offset) in nested_offsets {
+    for (id, nested_offset) in &nested_offsets {
         // Get the parent's total offset (if any) and add to this nested offset
         let parent_offset = states
-            .get(&id)
+            .get(id)
             .and_then(|s| s.parent.as_ref())
-            .and_then(|parent| composite_offsets.get(parent))
+            .and_then(|parent| composite_offsets.get(parent.as_str()))
             .copied()
             .unwrap_or(0.0);
-        composite_offsets.insert(id, parent_offset + nested_offset);
+        composite_offsets.insert(id.clone(), parent_offset + nested_offset);
     }
 
     // Post-process: Center start nodes above the composite states they connect to

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -3657,3 +3657,81 @@ fn test_sequence_notes_have_inline_fill() {
         &svg[..svg.len().min(2000)]
     );
 }
+
+#[test]
+fn test_state_nested_composite_centered_in_parent_with_siblings() {
+    // Reproduces eval issue: state_complex2 "Nested composite Processing not centered in Idle: -137px offset (reference: 30px)"
+    // When a parent composite has both non-composite children and a nested composite,
+    // the nested composite should be horizontally centered within the parent's full width,
+    // not relative to just the non-composite siblings.
+    let input = std::fs::read_to_string("docs/sources/state_complex2.mmd")
+        .expect("Failed to read state_complex2.mmd");
+
+    let diagram = parse(&input).expect("Failed to parse");
+    let svg = render(&diagram).expect("Failed to render");
+
+    // Extract outer rect bounds for both composites
+    let extract_composite_bounds = |svg: &str, name: &str| -> Option<(f64, f64, f64)> {
+        let composite_marker = format!("id=\"composite-{}\"", name);
+        let composite_start = svg.find(&composite_marker)?;
+        let relevant_section = &svg[composite_start..composite_start.saturating_add(600)];
+
+        let x_pattern = regex::Regex::new(r#"x="([0-9.]+)""#).ok()?;
+        let w_pattern = regex::Regex::new(r#"width="([0-9.]+)""#).ok()?;
+
+        for line in relevant_section.lines() {
+            if line.contains("state-composite-outer") {
+                if let (Some(x_caps), Some(w_caps)) =
+                    (x_pattern.captures(line), w_pattern.captures(line))
+                {
+                    let x: f64 = x_caps.get(1)?.as_str().parse().ok()?;
+                    let w: f64 = w_caps.get(1)?.as_str().parse().ok()?;
+                    let center = x + w / 2.0;
+                    return Some((x, w, center));
+                }
+            }
+        }
+        None
+    };
+
+    let idle_bounds = extract_composite_bounds(&svg, "Idle");
+    let processing_bounds = extract_composite_bounds(&svg, "Processing");
+
+    eprintln!("Composite bounds:");
+    eprintln!("  Idle: {:?}", idle_bounds);
+    eprintln!("  Processing: {:?}", processing_bounds);
+
+    if let (Some((idle_x, idle_w, idle_center)), Some((_proc_x, _proc_w, proc_center))) =
+        (idle_bounds, processing_bounds)
+    {
+        // Processing should be centered within Idle
+        let offset = proc_center - idle_center;
+        eprintln!("  Offset of Processing center from Idle center: {}", offset);
+
+        // The offset should be small (within ~50px), not -137px
+        assert!(
+            offset.abs() < 50.0,
+            "Processing should be approximately centered in Idle: offset={} (should be near 0)",
+            offset
+        );
+
+        // Processing should be fully contained within Idle (with some padding)
+        assert!(
+            _proc_x >= idle_x,
+            "Processing should not extend left of Idle: proc_x={}, idle_x={}",
+            _proc_x,
+            idle_x
+        );
+        assert!(
+            _proc_x + _proc_w <= idle_x + idle_w + 1.0, // 1px tolerance
+            "Processing should not extend right of Idle: proc_right={}, idle_right={}",
+            _proc_x + _proc_w,
+            idle_x + idle_w
+        );
+    } else {
+        panic!(
+            "Could not extract composite bounds from SVG.\nIdle: {:?}\nProcessing: {:?}",
+            idle_bounds, processing_bounds
+        );
+    }
+}


### PR DESCRIPTION
<!-- midtown: houston -->

## Summary
- Fixed nested composite centering in state diagrams (resolves -137px offset for Processing within Idle in state_complex2)
- Changed centering algorithm to shift ALL parent children based on the parent's dagre-assigned center, rather than centering only the nested composite relative to non-composite siblings
- Process shallowest parents first so inner centering accounts for outer shifts
- Added integration test reproducing the eval-detected centering issue

## Test plan
- [x] New test `test_state_nested_composite_centered_in_parent_with_siblings` passes (offset ~0px)
- [x] All 1,931 existing tests pass
- [x] `cargo clippy --features all-formats -- -D warnings` passes
- [x] Eval confirms `nested_composite_centering` warning for Processing-in-Idle is resolved
- [x] State diagram SVGs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)