### PR TITLE
fix(sequence): match mermaid.js SVG structure for rendering

### DIFF
--- a/docs/images/example_sequence_basic.svg
+++ b/docs/images/example_sequence_basic.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="690" height="483" viewBox="-50 -10 690 483" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="670" height="483" viewBox="-50 -10 670 483" class="mermaid">
   <style>
 
 .mermaid {
@@ -213,57 +213,57 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
     <g class="clusters">
       <line x1="75" y1="65" x2="75" y2="398" class="actor-line" stroke-width="0.5px"/>
       <line x1="295" y1="65" x2="295" y2="398" class="actor-line" stroke-width="0.5px"/>
-      <line x1="515" y1="65" x2="515" y2="398" class="actor-line" stroke-width="0.5px"/>
+      <line x1="495" y1="65" x2="495" y2="398" class="actor-line" stroke-width="0.5px"/>
     </g>
     <g class="edgePaths">
-      <line x1="75" y1="109" x2="295" y2="109" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="295" y1="153" x2="515" y2="153" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
-      <line x1="295" y1="197" x2="75" y2="197" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-cross)"/>
-      <line x1="295" y1="241" x2="515" y2="241" class="message-line" stroke-width="1.5" marker-end="url(#arrow-cross)"/>
-      <line x1="295" y1="334" x2="75" y2="334" class="message-line" stroke-dasharray="3,3" stroke-width="1.5"/>
-      <line x1="75" y1="378" x2="515" y2="378" class="message-line" stroke-width="1.5"/>
+      <line x1="75" y1="109" x2="295" y2="109" class="messageLine0" stroke-width="2" marker-end="url(#arrow-filled)" style="fill: none;" stroke="none"/>
+      <line x1="295" y1="153" x2="495" y2="153" class="messageLine1" stroke="none" stroke-width="2" marker-end="url(#arrow-filled)" style="stroke-dasharray: 3, 3; fill: none;"/>
+      <line x1="295" y1="197" x2="75" y2="197" class="messageLine1" stroke="none" style="stroke-dasharray: 3, 3; fill: none;" stroke-width="2" marker-end="url(#arrow-cross)"/>
+      <line x1="295" y1="241" x2="495" y2="241" class="messageLine0" style="fill: none;" stroke="none" stroke-width="2" marker-end="url(#arrow-cross)"/>
+      <line x1="295" y1="334" x2="75" y2="334" class="messageLine1" style="stroke-dasharray: 3, 3; fill: none;" stroke-width="2" stroke="none"/>
+      <line x1="75" y1="378" x2="495" y2="378" class="messageLine0" stroke-width="2" stroke="none" style="fill: none;"/>
     </g>
     <g class="edgeLabels">
       <text x="185" y="99" class="message-label" font-size="16" text-anchor="middle">Hello Bob, how are you?</text>
-      <text x="405" y="143" class="message-label" text-anchor="middle" font-size="16">How about you John?</text>
-      <text x="185" y="187" class="message-label" text-anchor="middle" font-size="16">I am good thanks!</text>
-      <text x="405" y="231" class="message-label" text-anchor="middle" font-size="16">I am good thanks!</text>
-      <text x="185" y="324" class="message-label" font-size="16" text-anchor="middle">Checking with John...</text>
-      <text x="295" y="368" class="message-label" text-anchor="middle" font-size="16">Yes... John, how are you?</text>
+      <text x="395" y="143" class="message-label" font-size="16" text-anchor="middle">How about you John?</text>
+      <text x="185" y="187" class="message-label" font-size="16" text-anchor="middle">I am good thanks!</text>
+      <text x="395" y="231" class="message-label" font-size="16" text-anchor="middle">I am good thanks!</text>
+      <text x="185" y="324" class="message-label" text-anchor="middle" font-size="16">Checking with John...</text>
+      <text x="285" y="368" class="message-label" text-anchor="middle" font-size="16">Yes... John, how are you?</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
       <text x="75" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Alice</text>
     </g>
     <g class="actor">
-      <rect x="220" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="295" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Bob</text>
+      <rect x="220" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="295" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Bob</text>
     </g>
     <g class="actor">
-      <rect x="440" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="515" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">John</text>
+      <rect x="420" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="495" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">John</text>
     </g>
     <g class="note">
-      <rect x="540" y="251" width="150" height="96" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="615" y="256" class="noteText" alignment-baseline="middle" text-anchor="middle" dominant-baseline="middle" font-size="16" dy="1em">Bob thinks a long</text>
-      <text x="615" y="275" class="noteText" dominant-baseline="middle" text-anchor="middle" alignment-baseline="middle" dy="1em" font-size="16">long time, so long</text>
-      <text x="615" y="294" class="noteText" text-anchor="middle" alignment-baseline="middle" dominant-baseline="middle" font-size="16" dy="1em">that the text does</text>
-      <text x="615" y="313" class="noteText" text-anchor="middle" dy="1em" alignment-baseline="middle" dominant-baseline="middle" font-size="16">not fit on a row.</text>
+      <rect x="520" y="251" width="150" height="96" class="note" stroke="#666" fill="#EDF2AE"/>
+      <text x="595" y="256" class="noteText" dominant-baseline="middle" dy="1em" alignment-baseline="middle" font-size="16" text-anchor="middle">Bob thinks a long</text>
+      <text x="595" y="275" class="noteText" text-anchor="middle" dominant-baseline="middle" alignment-baseline="middle" dy="1em" font-size="16">long time, so long</text>
+      <text x="595" y="294" class="noteText" alignment-baseline="middle" text-anchor="middle" dy="1em" font-size="16" dominant-baseline="middle">that the text does</text>
+      <text x="595" y="313" class="noteText" font-size="16" alignment-baseline="middle" text-anchor="middle" dominant-baseline="middle" dy="1em">not fit on a row.</text>
     </g>
     <g class="actor">
-      <rect x="0" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="75" y="430.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
+      <rect x="0" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="75" y="430.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Alice</text>
     </g>
     <g class="actor">
-      <rect x="220" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="295" y="430.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Bob</text>
+      <rect x="220" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="295" y="430.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Bob</text>
     </g>
     <g class="actor">
-      <rect x="440" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="515" y="430.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">John</text>
+      <rect x="420" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="495" y="430.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">John</text>
     </g>
   </g>
 </svg>

--- a/docs/images/example_sequence_blogging.svg
+++ b/docs/images/example_sequence_blogging.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1274" height="884" viewBox="-50 -10 1274 884" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1146" height="884" viewBox="-50 -10 1146 884" class="mermaid">
   <style>
 
 .mermaid {
@@ -211,100 +211,110 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
   </defs>
   <g class="root">
     <g class="clusters">
-      <line x1="-10" y1="378" x2="672" y2="378" class="loopLine" stroke-dasharray="3,3"/>
-      <line x1="256" y1="735" x2="1174" y2="735" class="loopLine" stroke-dasharray="3,3"/>
-      <rect x="0" y="581" width="1174" height="220" rx="3" ry="3" class="loopLine" fill="none"/>
+      <line x1="-10" y1="378" x2="636" y2="378" class="loopLine" stroke-dasharray="3,3"/>
+      <line x1="220" y1="735" x2="1046" y2="735" class="loopLine" stroke-dasharray="3,3"/>
+      <g>
+        <line x1="0" y1="581" x2="1046" y2="581" class="loopLine"/>
+        <line x1="1046" y1="581" x2="1046" y2="801" class="loopLine"/>
+        <line x1="0" y1="801" x2="1046" y2="801" class="loopLine"/>
+        <line x1="0" y1="581" x2="0" y2="801" class="loopLine"/>
+      </g>
       <polygon points="10,581 60,581 60,594 52,601 10,601" class="labelBox"/>
-      <rect x="-10" y="268" width="1194" height="533" rx="3" ry="3" class="loopLine" fill="none"/>
+      <g>
+        <line x1="-10" y1="268" x2="1056" y2="268" class="loopLine"/>
+        <line x1="1056" y1="268" x2="1056" y2="801" class="loopLine"/>
+        <line x1="-10" y1="801" x2="1056" y2="801" class="loopLine"/>
+        <line x1="-10" y1="268" x2="-10" y2="801" class="loopLine"/>
+      </g>
       <polygon points="0,268 50,268 50,281 42,288 0,288" class="labelBox"/>
       <line x1="75" y1="65" x2="75" y2="799" class="actor-line" stroke-width="0.5px"/>
-      <line x1="331" y1="65" x2="331" y2="799" class="actor-line" stroke-width="0.5px"/>
-      <line x1="587" y1="65" x2="587" y2="799" class="actor-line" stroke-width="0.5px"/>
-      <line x1="843" y1="65" x2="843" y2="799" class="actor-line" stroke-width="0.5px"/>
-      <line x1="1099" y1="65" x2="1099" y2="799" class="actor-line" stroke-width="0.5px"/>
-      <rect x="582" y="158" width="10" height="264" rx="1" ry="1" class="activation"/>
-      <rect x="326" y="515" width="10" height="264" rx="1" ry="1" class="activation"/>
+      <line x1="295" y1="65" x2="295" y2="799" class="actor-line" stroke-width="0.5px"/>
+      <line x1="551" y1="65" x2="551" y2="799" class="actor-line" stroke-width="0.5px"/>
+      <line x1="771" y1="65" x2="771" y2="799" class="actor-line" stroke-width="0.5px"/>
+      <line x1="971" y1="65" x2="971" y2="799" class="actor-line" stroke-width="0.5px"/>
+      <rect x="546" y="158" width="10" height="264" rx="1" ry="1" class="activation"/>
+      <rect x="290" y="515" width="10" height="264" rx="1" ry="1" class="activation"/>
     </g>
     <g class="edgePaths">
-      <line x1="75" y1="158" x2="587" y2="158" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="587" y1="202" x2="1099" y2="202" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="1099" y1="246" x2="587" y2="246" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="587" y1="334" x2="75" y2="334" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="587" y1="422" x2="75" y2="422" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="75" y1="515" x2="331" y2="515" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="331" y1="559" x2="1099" y2="559" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <path d="M 331 647 L 371 647 L 371 677 L 331 677" class="message-line" marker-end="url(#arrow-filled)" stroke-dasharray="3,3" fill="none" stroke-width="1.5"/>
-      <path d="M 331 691 L 371 691 L 371 721 L 331 721" class="message-line" fill="none" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="331" y1="779" x2="75" y2="779" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
+      <line x1="75" y1="158" x2="551" y2="158" class="messageLine0" style="fill: none;" stroke="none" marker-end="url(#arrow-filled)" stroke-width="2"/>
+      <line x1="551" y1="202" x2="971" y2="202" class="messageLine0" marker-end="url(#arrow-filled)" stroke-width="2" stroke="none" style="fill: none;"/>
+      <line x1="971" y1="246" x2="551" y2="246" class="messageLine0" style="fill: none;" stroke-width="2" marker-end="url(#arrow-filled)" stroke="none"/>
+      <line x1="551" y1="334" x2="75" y2="334" class="messageLine0" stroke="none" stroke-width="2" marker-end="url(#arrow-filled)" style="fill: none;"/>
+      <line x1="551" y1="422" x2="75" y2="422" class="messageLine0" style="fill: none;" marker-end="url(#arrow-filled)" stroke="none" stroke-width="2"/>
+      <line x1="75" y1="515" x2="295" y2="515" class="messageLine0" stroke="none" marker-end="url(#arrow-filled)" style="fill: none;" stroke-width="2"/>
+      <line x1="295" y1="559" x2="971" y2="559" class="messageLine0" stroke="none" style="fill: none;" stroke-width="2" marker-end="url(#arrow-filled)"/>
+      <path d="M 295 647 L 335 647 L 335 677 L 295 677" class="message-line" stroke-width="1.5" stroke-dasharray="3,3" fill="none" marker-end="url(#arrow-filled)"/>
+      <path d="M 295 691 L 335 691 L 335 721 L 295 721" class="message-line" stroke-dasharray="3,3" fill="none" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="295" y1="779" x2="75" y2="779" class="messageLine1" marker-end="url(#arrow-filled)" style="stroke-dasharray: 3, 3; fill: none;" stroke-width="2" stroke="none"/>
     </g>
     <g class="edgeLabels">
-      <text x="331" y="148" class="message-label" text-anchor="middle" font-size="16">Logs in using credentials</text>
-      <text x="843" y="192" class="message-label" text-anchor="middle" font-size="16">Query stored accounts</text>
-      <text x="843" y="236" class="message-label" font-size="16" text-anchor="middle">Respond with query result</text>
-      <text x="331" y="324" class="message-label" font-size="16" text-anchor="middle">Invalid credentials</text>
-      <text x="331" y="396" class="loopText" text-anchor="middle" font-size="16">[Credentials found]</text>
-      <text x="331" y="412" class="message-label" text-anchor="middle" font-size="16">Successfully logged in</text>
-      <text x="203" y="505" class="message-label" text-anchor="middle" font-size="16">Submit new post</text>
-      <text x="715" y="549" class="message-label" font-size="16" text-anchor="middle">Store post data</text>
-      <text x="376" y="662" class="message-label" text-anchor="start" font-size="16">Send mail to blog subscribers</text>
-      <text x="376" y="706" class="message-label" font-size="16" text-anchor="start">Store in-site notifications</text>
-      <text x="715" y="753" class="loopText" font-size="16" text-anchor="middle">[Response]</text>
-      <text x="203" y="769" class="message-label" font-size="16" text-anchor="middle">Successfully posted</text>
-      <text x="35" y="594" class="labelText" font-size="16" text-anchor="middle">par</text>
-      <text x="587" y="599" class="loopText" font-size="16" text-anchor="middle">[Notifications]</text>
-      <text x="25" y="281" class="labelText" font-size="16" text-anchor="middle">alt</text>
-      <text x="587" y="286" class="loopText" text-anchor="middle" font-size="16">[Credentials not found]</text>
+      <text x="313" y="148" class="message-label" text-anchor="middle" font-size="16">Logs in using credentials</text>
+      <text x="761" y="192" class="message-label" text-anchor="middle" font-size="16">Query stored accounts</text>
+      <text x="761" y="236" class="message-label" font-size="16" text-anchor="middle">Respond with query result</text>
+      <text x="313" y="324" class="message-label" font-size="16" text-anchor="middle">Invalid credentials</text>
+      <text x="313" y="396" class="loopText" text-anchor="middle" font-size="16">[Credentials found]</text>
+      <text x="313" y="412" class="message-label" font-size="16" text-anchor="middle">Successfully logged in</text>
+      <text x="185" y="505" class="message-label" text-anchor="middle" font-size="16">Submit new post</text>
+      <text x="633" y="549" class="message-label" text-anchor="middle" font-size="16">Store post data</text>
+      <text x="340" y="662" class="message-label" font-size="16" text-anchor="start">Send mail to blog subscribers</text>
+      <text x="340" y="706" class="message-label" font-size="16" text-anchor="start">Store in-site notifications</text>
+      <text x="633" y="753" class="loopText" text-anchor="middle" font-size="16">[Response]</text>
+      <text x="185" y="769" class="message-label" text-anchor="middle" font-size="16">Successfully posted</text>
+      <text x="35" y="594" class="labelText" text-anchor="middle" font-size="16">par</text>
+      <text x="523" y="599" class="loopText" font-size="16" text-anchor="middle">[Notifications]</text>
+      <text x="25" y="281" class="labelText" text-anchor="middle" font-size="16">alt</text>
+      <text x="523" y="286" class="loopText" text-anchor="middle" font-size="16">[Credentials not found]</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="75" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Web Browser</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="75" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Web Browser</text>
     </g>
     <g class="actor">
-      <rect x="256" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="331" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Blog Service</text>
+      <rect x="220" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="295" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Blog Service</text>
     </g>
     <g class="actor">
-      <rect x="512" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="587" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Account Service</text>
+      <rect x="476" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="551" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Account Service</text>
     </g>
     <g class="actor">
-      <rect x="768" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="843" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Mail Service</text>
+      <rect x="696" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="771" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Mail Service</text>
     </g>
     <g class="actor">
-      <rect x="1024" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="1099" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Storage</text>
+      <rect x="896" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="971" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Storage</text>
     </g>
     <g class="note">
-      <rect x="50" y="75" width="1074" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="587" y="80" class="noteText" alignment-baseline="middle" text-anchor="middle" font-size="16" dominant-baseline="middle" dy="1em">The user must be logged in to submit blog posts</text>
+      <rect x="50" y="75" width="946" height="39" class="note" stroke="#666" fill="#EDF2AE"/>
+      <text x="523" y="80" class="noteText" font-size="16" alignment-baseline="middle" text-anchor="middle" dy="1em" dominant-baseline="middle">The user must be logged in to submit blog posts</text>
     </g>
     <g class="note">
-      <rect x="50" y="432" width="1074" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="587" y="437" class="noteText" alignment-baseline="middle" text-anchor="middle" font-size="16" dominant-baseline="middle" dy="1em">When the user is authenticated, they can now submit new posts</text>
+      <rect x="50" y="432" width="946" height="39" class="note" stroke="#666" fill="#EDF2AE"/>
+      <text x="523" y="437" class="noteText" text-anchor="middle" dominant-baseline="middle" alignment-baseline="middle" dy="1em" font-size="16">When the user is authenticated, they can now submit new posts</text>
     </g>
     <g class="actor">
-      <rect x="0" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="75" y="831.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Web Browser</text>
+      <rect x="0" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="75" y="831.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Web Browser</text>
     </g>
     <g class="actor">
-      <rect x="256" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="331" y="831.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Blog Service</text>
+      <rect x="220" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="295" y="831.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Blog Service</text>
     </g>
     <g class="actor">
-      <rect x="512" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="587" y="831.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Account Service</text>
+      <rect x="476" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="551" y="831.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Account Service</text>
     </g>
     <g class="actor">
-      <rect x="768" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="843" y="831.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Mail Service</text>
+      <rect x="696" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="771" y="831.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Mail Service</text>
     </g>
     <g class="actor">
-      <rect x="1024" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="1099" y="831.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Storage</text>
+      <rect x="896" y="799" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="971" y="831.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Storage</text>
     </g>
   </g>
 </svg>

--- a/docs/images/example_sequence_loops.svg
+++ b/docs/images/example_sequence_loops.svg
@@ -212,30 +212,45 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
   <g class="root">
     <g class="clusters">
       <line x1="0" y1="285" x2="379" y2="285" class="loopLine" stroke-dasharray="3,3"/>
-      <rect x="0" y="175" width="379" height="176" rx="3" ry="3" class="loopLine" fill="none"/>
+      <g>
+        <line x1="0" y1="175" x2="379" y2="175" class="loopLine"/>
+        <line x1="379" y1="175" x2="379" y2="351" class="loopLine"/>
+        <line x1="0" y1="351" x2="379" y2="351" class="loopLine"/>
+        <line x1="0" y1="175" x2="0" y2="351" class="loopLine"/>
+      </g>
       <polygon points="10,175 60,175 60,188 52,195 10,195" class="labelBox"/>
-      <rect x="0" y="351" width="379" height="88" rx="3" ry="3" class="loopLine" fill="none"/>
+      <g>
+        <line x1="0" y1="351" x2="379" y2="351" class="loopLine"/>
+        <line x1="379" y1="351" x2="379" y2="439" class="loopLine"/>
+        <line x1="0" y1="439" x2="379" y2="439" class="loopLine"/>
+        <line x1="0" y1="351" x2="0" y2="439" class="loopLine"/>
+      </g>
       <polygon points="10,351 60,351 60,364 52,371 10,371" class="labelBox"/>
-      <rect x="-10" y="87" width="399" height="352" rx="3" ry="3" class="loopLine" fill="none"/>
+      <g>
+        <line x1="-10" y1="87" x2="389" y2="87" class="loopLine"/>
+        <line x1="389" y1="87" x2="389" y2="439" class="loopLine"/>
+        <line x1="-10" y1="439" x2="389" y2="439" class="loopLine"/>
+        <line x1="-10" y1="87" x2="-10" y2="439" class="loopLine"/>
+      </g>
       <polygon points="0,87 50,87 50,100 42,107 0,107" class="labelBox"/>
       <line x1="75" y1="65" x2="75" y2="437" class="actor-line" stroke-width="0.5px"/>
       <line x1="304" y1="65" x2="304" y2="437" class="actor-line" stroke-width="0.5px"/>
     </g>
     <g class="edgePaths">
-      <line x1="75" y1="153" x2="304" y2="153" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="304" y1="241" x2="75" y2="241" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="304" y1="329" x2="75" y2="329" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="304" y1="417" x2="75" y2="417" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
+      <line x1="75" y1="153" x2="304" y2="153" class="messageLine0" stroke="none" style="fill: none;" marker-end="url(#arrow-filled)" stroke-width="2"/>
+      <line x1="304" y1="241" x2="75" y2="241" class="messageLine0" marker-end="url(#arrow-filled)" stroke-width="2" stroke="none" style="fill: none;"/>
+      <line x1="304" y1="329" x2="75" y2="329" class="messageLine0" marker-end="url(#arrow-filled)" style="fill: none;" stroke="none" stroke-width="2"/>
+      <line x1="304" y1="417" x2="75" y2="417" class="messageLine0" style="fill: none;" marker-end="url(#arrow-filled)" stroke="none" stroke-width="2"/>
     </g>
     <g class="edgeLabels">
       <text x="189.5" y="143" class="message-label" text-anchor="middle" font-size="16">Hello Bob, how are you?</text>
-      <text x="189.5" y="231" class="message-label" font-size="16" text-anchor="middle">Not so good :(</text>
+      <text x="189.5" y="231" class="message-label" text-anchor="middle" font-size="16">Not so good :(</text>
       <text x="189.5" y="303" class="loopText" text-anchor="middle" font-size="16">[is well]</text>
-      <text x="189.5" y="319" class="message-label" text-anchor="middle" font-size="16">Feeling fresh like a daisy</text>
+      <text x="189.5" y="319" class="message-label" font-size="16" text-anchor="middle">Feeling fresh like a daisy</text>
       <text x="35" y="188" class="labelText" font-size="16" text-anchor="middle">alt</text>
-      <text x="189.5" y="193" class="loopText" font-size="16" text-anchor="middle">[is sick]</text>
+      <text x="189.5" y="193" class="loopText" text-anchor="middle" font-size="16">[is sick]</text>
       <text x="189.5" y="407" class="message-label" text-anchor="middle" font-size="16">Thanks for asking</text>
-      <text x="35" y="364" class="labelText" font-size="16" text-anchor="middle">opt</text>
+      <text x="35" y="364" class="labelText" text-anchor="middle" font-size="16">opt</text>
       <text x="189.5" y="369" class="loopText" text-anchor="middle" font-size="16">[Extra response]</text>
       <text x="25" y="100" class="labelText" text-anchor="middle" font-size="16">loop</text>
       <text x="189.5" y="105" class="loopText" font-size="16" text-anchor="middle">[Daily query]</text>
@@ -244,20 +259,20 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
 
     </g>
     <g class="actor">
-      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="75" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Alice</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="75" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="229" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="304" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Bob</text>
+      <rect x="229" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="304" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Bob</text>
     </g>
     <g class="actor">
-      <rect x="0" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <rect x="0" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
       <text x="75" y="469.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="229" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="304" y="469.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Bob</text>
+      <rect x="229" y="437" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="304" y="469.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Bob</text>
     </g>
   </g>
 </svg>

--- a/docs/images/example_sequence_self_loop.svg
+++ b/docs/images/example_sequence_self_loop.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="672" height="483" viewBox="-50 -10 672 483" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="661" height="483" viewBox="-50 -10 661 483" class="mermaid">
   <style>
 
 .mermaid {
@@ -211,59 +211,64 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
   </defs>
   <g class="root">
     <g class="clusters">
-      <rect x="412" y="131" width="170" height="88" rx="3" ry="3" class="loopLine" fill="none"/>
-      <polygon points="422,131 472,131 472,144 464,151 422,151" class="labelBox"/>
+      <g>
+        <line x1="401" y1="131" x2="571" y2="131" class="loopLine"/>
+        <line x1="571" y1="131" x2="571" y2="219" class="loopLine"/>
+        <line x1="401" y1="219" x2="571" y2="219" class="loopLine"/>
+        <line x1="401" y1="131" x2="401" y2="219" class="loopLine"/>
+      </g>
+      <polygon points="411,131 461,131 461,144 453,151 411,151" class="labelBox"/>
       <line x1="75" y1="65" x2="75" y2="398" class="actor-line" stroke-width="0.5px"/>
       <line x1="286" y1="65" x2="286" y2="398" class="actor-line" stroke-width="0.5px"/>
-      <line x1="497" y1="65" x2="497" y2="398" class="actor-line" stroke-width="0.5px"/>
+      <line x1="486" y1="65" x2="486" y2="398" class="actor-line" stroke-width="0.5px"/>
     </g>
     <g class="edgePaths">
-      <line x1="75" y1="109" x2="497" y2="109" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <path d="M 497 197 L 537 197 L 537 227 L 497 227" class="message-line" marker-end="url(#arrow-filled)" fill="none" stroke-width="1.5"/>
-      <line x1="497" y1="290" x2="75" y2="290" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="497" y1="334" x2="286" y2="334" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="286" y1="378" x2="497" y2="378" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
+      <line x1="75" y1="109" x2="486" y2="109" class="messageLine0" stroke-width="2" stroke="none" marker-end="url(#arrow-filled)" style="fill: none;"/>
+      <path d="M 486 197 L 526 197 L 526 227 L 486 227" class="message-line" stroke-width="1.5" fill="none" marker-end="url(#arrow-filled)"/>
+      <line x1="486" y1="290" x2="75" y2="290" class="messageLine1" style="stroke-dasharray: 3, 3; fill: none;" marker-end="url(#arrow-filled)" stroke-width="2" stroke="none"/>
+      <line x1="486" y1="334" x2="286" y2="334" class="messageLine0" stroke="none" stroke-width="2" style="fill: none;" marker-end="url(#arrow-filled)"/>
+      <line x1="286" y1="378" x2="486" y2="378" class="messageLine1" marker-end="url(#arrow-filled)" style="stroke-dasharray: 3, 3; fill: none;" stroke-width="2" stroke="none"/>
     </g>
     <g class="edgeLabels">
-      <text x="286" y="99" class="message-label" font-size="16" text-anchor="middle">Hello John, how are you?</text>
-      <text x="542" y="212" class="message-label" text-anchor="start" font-size="16">Fight against hypochondria</text>
-      <text x="447" y="144" class="labelText" text-anchor="middle" font-size="16">loop</text>
-      <text x="497" y="149" class="loopText" font-size="16" text-anchor="middle">[HealthCheck]</text>
-      <text x="286" y="280" class="message-label" font-size="16" text-anchor="middle">Great!</text>
-      <text x="391.5" y="324" class="message-label" text-anchor="middle" font-size="16">How about you?</text>
-      <text x="391.5" y="368" class="message-label" text-anchor="middle" font-size="16">Jolly good!</text>
+      <text x="280.5" y="99" class="message-label" text-anchor="middle" font-size="16">Hello John, how are you?</text>
+      <text x="531" y="212" class="message-label" font-size="16" text-anchor="start">Fight against hypochondria</text>
+      <text x="436" y="144" class="labelText" text-anchor="middle" font-size="16">loop</text>
+      <text x="486" y="149" class="loopText" font-size="16" text-anchor="middle">[HealthCheck]</text>
+      <text x="280.5" y="280" class="message-label" text-anchor="middle" font-size="16">Great!</text>
+      <text x="386" y="324" class="message-label" text-anchor="middle" font-size="16">How about you?</text>
+      <text x="386" y="368" class="message-label" font-size="16" text-anchor="middle">Jolly good!</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
       <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="75" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Alice</text>
+      <text x="75" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="211" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <rect x="211" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
       <text x="286" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Bob</text>
     </g>
     <g class="actor">
-      <rect x="422" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="497" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">John</text>
+      <rect x="411" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="486" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">John</text>
     </g>
     <g class="note">
-      <rect x="522" y="207" width="150" height="58" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="597" y="212" class="noteText" text-anchor="middle" alignment-baseline="middle" dy="1em" font-size="16" dominant-baseline="middle">Rational thoughts</text>
-      <text x="597" y="231" class="noteText" dominant-baseline="middle" alignment-baseline="middle" dy="1em" font-size="16" text-anchor="middle">prevail...</text>
+      <rect x="511" y="207" width="150" height="58" class="note" stroke="#666" fill="#EDF2AE"/>
+      <text x="586" y="212" class="noteText" text-anchor="middle" alignment-baseline="middle" dy="1em" dominant-baseline="middle" font-size="16">Rational thoughts</text>
+      <text x="586" y="231" class="noteText" text-anchor="middle" dominant-baseline="middle" font-size="16" dy="1em" alignment-baseline="middle">prevail...</text>
     </g>
     <g class="actor">
-      <rect x="0" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="75" y="430.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Alice</text>
+      <rect x="0" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="75" y="430.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
     </g>
     <g class="actor">
-      <rect x="211" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="286" y="430.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Bob</text>
+      <rect x="211" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="286" y="430.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Bob</text>
     </g>
     <g class="actor">
-      <rect x="422" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="497" y="430.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">John</text>
+      <rect x="411" y="398" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="486" y="430.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">John</text>
     </g>
   </g>
 </svg>

--- a/docs/images/sequence.svg
+++ b/docs/images/sequence.svg
@@ -217,55 +217,55 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
       <rect x="470" y="246" width="10" height="44" rx="1" ry="1" class="activation"/>
     </g>
     <g class="edgePaths">
-      <line x1="75" y1="109" x2="275" y2="109" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="275" y1="153" x2="75" y2="153" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <line x1="75" y1="246" x2="475" y2="246" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="475" y1="290" x2="75" y2="290" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
-      <line x1="75" y1="334" x2="275" y2="334" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <line x1="275" y1="378" x2="75" y2="378" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
+      <line x1="75" y1="109" x2="275" y2="109" class="messageLine0" style="fill: none;" stroke-width="2" marker-end="url(#arrow-filled)" stroke="none"/>
+      <line x1="275" y1="153" x2="75" y2="153" class="messageLine1" stroke-width="2" style="stroke-dasharray: 3, 3; fill: none;" stroke="none" marker-end="url(#arrow-filled)"/>
+      <line x1="75" y1="246" x2="475" y2="246" class="messageLine0" stroke-width="2" stroke="none" style="fill: none;" marker-end="url(#arrow-filled)"/>
+      <line x1="475" y1="290" x2="75" y2="290" class="messageLine1" stroke="none" style="stroke-dasharray: 3, 3; fill: none;" marker-end="url(#arrow-filled)" stroke-width="2"/>
+      <line x1="75" y1="334" x2="275" y2="334" class="messageLine0" style="fill: none;" stroke-width="2" marker-end="url(#arrow-filled)" stroke="none"/>
+      <line x1="275" y1="378" x2="75" y2="378" class="messageLine1" stroke="none" style="stroke-dasharray: 3, 3; fill: none;" marker-end="url(#arrow-filled)" stroke-width="2"/>
     </g>
     <g class="edgeLabels">
-      <text x="175" y="99" class="message-label" font-size="16" text-anchor="middle">Hello Bob!</text>
+      <text x="175" y="99" class="message-label" text-anchor="middle" font-size="16">Hello Bob!</text>
       <text x="175" y="143" class="message-label" text-anchor="middle" font-size="16">Hi Alice!</text>
       <text x="275" y="236" class="message-label" font-size="16" text-anchor="middle">Login request</text>
       <text x="275" y="280" class="message-label" font-size="16" text-anchor="middle">Token</text>
       <text x="175" y="324" class="message-label" font-size="16" text-anchor="middle">How are you?</text>
-      <text x="175" y="368" class="message-label" text-anchor="middle" font-size="16">I&apos;m good, thanks!</text>
+      <text x="175" y="368" class="message-label" font-size="16" text-anchor="middle">I&apos;m good, thanks!</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
       <text x="75" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Alice</text>
     </g>
     <g class="actor">
       <rect x="200" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="275" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Bob</text>
+      <text x="275" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Bob</text>
     </g>
     <g class="actor">
-      <rect x="400" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="475" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Server</text>
+      <rect x="400" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="475" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">Server</text>
     </g>
     <g class="note">
       <rect x="50" y="163" width="250" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="175" y="168" class="noteText" text-anchor="middle" dominant-baseline="middle" font-size="16" alignment-baseline="middle" dy="1em">Authentication</text>
+      <text x="175" y="168" class="noteText" alignment-baseline="middle" dy="1em" font-size="16" text-anchor="middle" dominant-baseline="middle">Authentication</text>
     </g>
     <g class="note">
-      <rect x="300" y="388" width="150" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="375" y="393" class="noteText" alignment-baseline="middle" text-anchor="middle" dy="1em" font-size="16" dominant-baseline="middle">Bob thinks</text>
+      <rect x="300" y="388" width="150" height="39" class="note" stroke="#666" fill="#EDF2AE"/>
+      <text x="375" y="393" class="noteText" dominant-baseline="middle" dy="1em" alignment-baseline="middle" font-size="16" text-anchor="middle">Bob thinks</text>
     </g>
     <g class="actor">
-      <rect x="0" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <rect x="0" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
       <text x="75" y="479.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Alice</text>
     </g>
     <g class="actor">
-      <rect x="200" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="275" y="479.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Bob</text>
+      <rect x="200" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
+      <text x="275" y="479.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Bob</text>
     </g>
     <g class="actor">
-      <rect x="400" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="475" y="479.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Server</text>
+      <rect x="400" y="447" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="475" y="479.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Server</text>
     </g>
   </g>
 </svg>

--- a/docs/images/sequence_complex.svg
+++ b/docs/images/sequence_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1305" height="1285" viewBox="-50 -10 1305 1285" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1261" height="1285" viewBox="-50 -10 1261 1285" class="mermaid">
   <style>
 
 .mermaid {
@@ -211,167 +211,182 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {
   </defs>
   <g class="root">
     <g class="clusters">
-      <line x1="-10" y1="603" x2="582" y2="603" class="loopLine" stroke-dasharray="3,3"/>
-      <line x1="422" y1="823" x2="1205" y2="823" class="loopLine" stroke-dasharray="3,3"/>
-      <rect x="422" y="669" width="783" height="220" rx="3" ry="3" class="loopLine" fill="none"/>
-      <polygon points="432,669 482,669 482,682 474,689 432,689" class="labelBox"/>
-      <rect x="422" y="933" width="783" height="132" rx="3" ry="3" class="loopLine" fill="none"/>
-      <polygon points="432,933 482,933 482,946 474,953 432,953" class="labelBox"/>
-      <rect x="-10" y="449" width="1225" height="753" rx="3" ry="3" class="loopLine" fill="none"/>
+      <line x1="-10" y1="603" x2="560" y2="603" class="loopLine" stroke-dasharray="3,3"/>
+      <line x1="400" y1="823" x2="1161" y2="823" class="loopLine" stroke-dasharray="3,3"/>
+      <g>
+        <line x1="400" y1="669" x2="1161" y2="669" class="loopLine"/>
+        <line x1="1161" y1="669" x2="1161" y2="889" class="loopLine"/>
+        <line x1="400" y1="889" x2="1161" y2="889" class="loopLine"/>
+        <line x1="400" y1="669" x2="400" y2="889" class="loopLine"/>
+      </g>
+      <polygon points="410,669 460,669 460,682 452,689 410,689" class="labelBox"/>
+      <g>
+        <line x1="400" y1="933" x2="1161" y2="933" class="loopLine"/>
+        <line x1="1161" y1="933" x2="1161" y2="1065" class="loopLine"/>
+        <line x1="400" y1="1065" x2="1161" y2="1065" class="loopLine"/>
+        <line x1="400" y1="933" x2="400" y2="1065" class="loopLine"/>
+      </g>
+      <polygon points="410,933 460,933 460,946 452,953 410,953" class="labelBox"/>
+      <g>
+        <line x1="-10" y1="449" x2="1171" y2="449" class="loopLine"/>
+        <line x1="1171" y1="449" x2="1171" y2="1202" class="loopLine"/>
+        <line x1="-10" y1="1202" x2="1171" y2="1202" class="loopLine"/>
+        <line x1="-10" y1="449" x2="-10" y2="1202" class="loopLine"/>
+      </g>
       <polygon points="0,449 50,449 50,462 42,469 0,469" class="labelBox"/>
       <line x1="75" y1="65" x2="75" y2="1200" class="actor-line" stroke-width="0.5px"/>
-      <line x1="286" y1="65" x2="286" y2="1200" class="actor-line" stroke-width="0.5px"/>
-      <line x1="497" y1="65" x2="497" y2="1200" class="actor-line" stroke-width="0.5px"/>
-      <line x1="708" y1="65" x2="708" y2="1200" class="actor-line" stroke-width="0.5px"/>
-      <line x1="919" y1="65" x2="919" y2="1200" class="actor-line" stroke-width="0.5px"/>
-      <line x1="1130" y1="65" x2="1130" y2="1200" class="actor-line" stroke-width="0.5px"/>
-      <rect x="703" y="295" width="10" height="132" rx="1" ry="1" class="activation"/>
-      <rect x="914" y="647" width="10" height="264" rx="1" ry="1" class="activation"/>
-      <rect x="492" y="202" width="10" height="934" rx="1" ry="1" class="activation"/>
-      <rect x="281" y="158" width="10" height="1022" rx="1" ry="1" class="activation"/>
+      <line x1="275" y1="65" x2="275" y2="1200" class="actor-line" stroke-width="0.5px"/>
+      <line x1="475" y1="65" x2="475" y2="1200" class="actor-line" stroke-width="0.5px"/>
+      <line x1="686" y1="65" x2="686" y2="1200" class="actor-line" stroke-width="0.5px"/>
+      <line x1="886" y1="65" x2="886" y2="1200" class="actor-line" stroke-width="0.5px"/>
+      <line x1="1086" y1="65" x2="1086" y2="1200" class="actor-line" stroke-width="0.5px"/>
+      <rect x="681" y="295" width="10" height="132" rx="1" ry="1" class="activation"/>
+      <rect x="881" y="647" width="10" height="264" rx="1" ry="1" class="activation"/>
+      <rect x="470" y="202" width="10" height="934" rx="1" ry="1" class="activation"/>
+      <rect x="270" y="158" width="10" height="1022" rx="1" ry="1" class="activation"/>
     </g>
     <g class="edgePaths">
-      <line x1="75" y1="158" x2="286" y2="158" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="75" cy="158" r="11" class="sequenceNumber-circle"/>
-      <line x1="286" y1="202" x2="497" y2="202" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="286" cy="202" r="11" class="sequenceNumber-circle"/>
-      <line x1="497" y1="295" x2="708" y2="295" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <circle cx="497" cy="295" r="11" class="sequenceNumber-circle"/>
-      <line x1="708" y1="339" x2="919" y2="339" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="708" cy="339" r="11" class="sequenceNumber-circle"/>
-      <line x1="919" y1="383" x2="708" y2="383" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="919" cy="383" r="11" class="sequenceNumber-circle"/>
-      <line x1="708" y1="427" x2="497" y2="427" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
-      <circle cx="708" cy="427" r="11" class="sequenceNumber-circle"/>
-      <line x1="497" y1="515" x2="286" y2="515" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="497" cy="515" r="11" class="sequenceNumber-circle"/>
-      <line x1="286" y1="559" x2="75" y2="559" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
-      <circle cx="286" cy="559" r="11" class="sequenceNumber-circle"/>
-      <line x1="497" y1="647" x2="919" y2="647" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="497" cy="647" r="11" class="sequenceNumber-circle"/>
-      <line x1="497" y1="735" x2="1130" y2="735" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <circle cx="497" cy="735" r="11" class="sequenceNumber-circle"/>
-      <line x1="1130" y1="779" x2="497" y2="779" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" stroke-dasharray="3,3"/>
-      <circle cx="1130" cy="779" r="11" class="sequenceNumber-circle"/>
-      <path d="M 497 867 L 537 867 L 537 897 L 497 897" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)" fill="none" stroke-dasharray="3,3"/>
-      <circle cx="497" cy="867" r="11" class="sequenceNumber-circle"/>
-      <line x1="919" y1="911" x2="497" y2="911" class="message-line" marker-end="url(#arrow-filled)" stroke-width="1.5" stroke-dasharray="3,3"/>
-      <circle cx="919" cy="911" r="11" class="sequenceNumber-circle"/>
-      <line x1="497" y1="999" x2="1130" y2="999" class="message-line" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="497" cy="999" r="11" class="sequenceNumber-circle"/>
-      <line x1="1130" y1="1043" x2="497" y2="1043" class="message-line" stroke-dasharray="3,3" marker-end="url(#arrow-filled)" stroke-width="1.5"/>
-      <circle cx="1130" cy="1043" r="11" class="sequenceNumber-circle"/>
-      <line x1="497" y1="1136" x2="286" y2="1136" class="message-line" stroke-width="1.5" stroke-dasharray="3,3" marker-end="url(#arrow-filled)"/>
-      <circle cx="497" cy="1136" r="11" class="sequenceNumber-circle"/>
-      <line x1="286" y1="1180" x2="75" y2="1180" class="message-line" stroke-dasharray="3,3" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
-      <circle cx="286" cy="1180" r="11" class="sequenceNumber-circle"/>
+      <line x1="75" y1="158" x2="275" y2="158" class="messageLine0" stroke="none" stroke-width="2" style="fill: none;" marker-end="url(#arrow-filled)"/>
+      <line x1="75" y1="158" x2="75" y2="158" stroke-width="0" marker-start="url(#sequencenumber)"/>
+      <line x1="275" y1="202" x2="475" y2="202" class="messageLine0" stroke-width="2" style="fill: none;" marker-end="url(#arrow-filled)" stroke="none"/>
+      <line x1="275" y1="202" x2="275" y2="202" stroke-width="0" marker-start="url(#sequencenumber)"/>
+      <line x1="475" y1="295" x2="686" y2="295" class="messageLine0" stroke-width="2" stroke="none" style="fill: none;" marker-end="url(#arrow-filled)"/>
+      <line x1="475" y1="295" x2="475" y2="295" marker-start="url(#sequencenumber)" stroke-width="0"/>
+      <line x1="686" y1="339" x2="886" y2="339" class="messageLine0" stroke-width="2" style="fill: none;" marker-end="url(#arrow-filled)" stroke="none"/>
+      <line x1="686" y1="339" x2="686" y2="339" marker-start="url(#sequencenumber)" stroke-width="0"/>
+      <line x1="886" y1="383" x2="686" y2="383" class="messageLine1" marker-end="url(#arrow-filled)" style="stroke-dasharray: 3, 3; fill: none;" stroke="none" stroke-width="2"/>
+      <line x1="886" y1="383" x2="886" y2="383" stroke-width="0" marker-start="url(#sequencenumber)"/>
+      <line x1="686" y1="427" x2="475" y2="427" class="messageLine1" stroke-width="2" stroke="none" style="stroke-dasharray: 3, 3; fill: none;" marker-end="url(#arrow-filled)"/>
+      <line x1="686" y1="427" x2="686" y2="427" marker-start="url(#sequencenumber)" stroke-width="0"/>
+      <line x1="475" y1="515" x2="275" y2="515" class="messageLine1" stroke-width="2" stroke="none" style="stroke-dasharray: 3, 3; fill: none;" marker-end="url(#arrow-filled)"/>
+      <line x1="475" y1="515" x2="475" y2="515" marker-start="url(#sequencenumber)" stroke-width="0"/>
+      <line x1="275" y1="559" x2="75" y2="559" class="messageLine1" marker-end="url(#arrow-filled)" stroke-width="2" style="stroke-dasharray: 3, 3; fill: none;" stroke="none"/>
+      <line x1="275" y1="559" x2="275" y2="559" marker-start="url(#sequencenumber)" stroke-width="0"/>
+      <line x1="475" y1="647" x2="886" y2="647" class="messageLine0" stroke-width="2" stroke="none" marker-end="url(#arrow-filled)" style="fill: none;"/>
+      <line x1="475" y1="647" x2="475" y2="647" marker-start="url(#sequencenumber)" stroke-width="0"/>
+      <line x1="475" y1="735" x2="1086" y2="735" class="messageLine0" stroke-width="2" stroke="none" style="fill: none;" marker-end="url(#arrow-filled)"/>
+      <line x1="475" y1="735" x2="475" y2="735" stroke-width="0" marker-start="url(#sequencenumber)"/>
+      <line x1="1086" y1="779" x2="475" y2="779" class="messageLine1" stroke="none" stroke-width="2" style="stroke-dasharray: 3, 3; fill: none;" marker-end="url(#arrow-filled)"/>
+      <line x1="1086" y1="779" x2="1086" y2="779" stroke-width="0" marker-start="url(#sequencenumber)"/>
+      <path d="M 475 867 L 515 867 L 515 897 L 475 897" class="message-line" stroke-dasharray="3,3" fill="none" stroke-width="1.5" marker-end="url(#arrow-filled)"/>
+      <line x1="475" y1="867" x2="475" y2="867" stroke-width="0" marker-start="url(#sequencenumber)"/>
+      <line x1="886" y1="911" x2="475" y2="911" class="messageLine1" stroke="none" style="stroke-dasharray: 3, 3; fill: none;" stroke-width="2" marker-end="url(#arrow-filled)"/>
+      <line x1="886" y1="911" x2="886" y2="911" marker-start="url(#sequencenumber)" stroke-width="0"/>
+      <line x1="475" y1="999" x2="1086" y2="999" class="messageLine0" stroke-width="2" stroke="none" style="fill: none;" marker-end="url(#arrow-filled)"/>
+      <line x1="475" y1="999" x2="475" y2="999" stroke-width="0" marker-start="url(#sequencenumber)"/>
+      <line x1="1086" y1="1043" x2="475" y2="1043" class="messageLine1" stroke="none" marker-end="url(#arrow-filled)" stroke-width="2" style="stroke-dasharray: 3, 3; fill: none;"/>
+      <line x1="1086" y1="1043" x2="1086" y2="1043" stroke-width="0" marker-start="url(#sequencenumber)"/>
+      <line x1="475" y1="1136" x2="275" y2="1136" class="messageLine1" stroke="none" marker-end="url(#arrow-filled)" stroke-width="2" style="stroke-dasharray: 3, 3; fill: none;"/>
+      <line x1="475" y1="1136" x2="475" y2="1136" marker-start="url(#sequencenumber)" stroke-width="0"/>
+      <line x1="275" y1="1180" x2="75" y2="1180" class="messageLine1" stroke="none" marker-end="url(#arrow-filled)" stroke-width="2" style="stroke-dasharray: 3, 3; fill: none;"/>
+      <line x1="275" y1="1180" x2="275" y2="1180" marker-start="url(#sequencenumber)" stroke-width="0"/>
     </g>
     <g class="edgeLabels">
-      <text x="75" y="162" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">1</text>
-      <text x="180.5" y="148" class="message-label" font-size="16" text-anchor="middle">Click Checkout</text>
-      <text x="286" y="206" class="sequenceNumber" font-family="sans-serif" font-size="12" text-anchor="middle">2</text>
-      <text x="391.5" y="192" class="message-label" text-anchor="middle" font-size="16">POST /checkout</text>
-      <text x="497" y="299" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">3</text>
-      <text x="602.5" y="285" class="message-label" text-anchor="middle" font-size="16">Verify session</text>
-      <text x="708" y="343" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">4</text>
-      <text x="813.5" y="329" class="message-label" text-anchor="middle" font-size="16">Query user</text>
-      <text x="919" y="387" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">5</text>
-      <text x="813.5" y="373" class="message-label" text-anchor="middle" font-size="16">User record</text>
-      <text x="708" y="431" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">6</text>
-      <text x="602.5" y="417" class="message-label" text-anchor="middle" font-size="16">Session valid</text>
-      <text x="497" y="519" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">7</text>
-      <text x="391.5" y="505" class="message-label" font-size="16" text-anchor="middle">Error: Empty cart</text>
-      <text x="286" y="563" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">8</text>
-      <text x="180.5" y="549" class="message-label" text-anchor="middle" font-size="16">Show error</text>
-      <text x="286" y="621" class="loopText" font-size="16" text-anchor="middle">[Cart Valid]</text>
-      <text x="497" y="651" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">9</text>
-      <text x="708" y="637" class="message-label" font-size="16" text-anchor="middle">Reserve inventory</text>
-      <text x="497" y="739" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">10</text>
-      <text x="813.5" y="725" class="message-label" text-anchor="middle" font-size="16">Queue payment job</text>
-      <text x="1130" y="783" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">11</text>
-      <text x="813.5" y="769" class="message-label" text-anchor="middle" font-size="16">Job queued</text>
-      <text x="813.5" y="841" class="loopText" font-size="16" text-anchor="middle">[Send Notifications]</text>
-      <text x="497" y="871" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">12</text>
-      <text x="542" y="882" class="message-label" font-size="16" text-anchor="start">Queue email confirmation</text>
-      <text x="457" y="682" class="labelText" text-anchor="middle" font-size="16">par</text>
-      <text x="813.5" y="687" class="loopText" text-anchor="middle" font-size="16">[Process Payment]</text>
-      <text x="919" y="915" class="sequenceNumber" font-family="sans-serif" font-size="12" text-anchor="middle">13</text>
-      <text x="708" y="901" class="message-label" font-size="16" text-anchor="middle">Inventory reserved</text>
-      <text x="497" y="1003" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">14</text>
-      <text x="813.5" y="989" class="message-label" text-anchor="middle" font-size="16">Check payment status</text>
-      <text x="1130" y="1047" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">15</text>
-      <text x="813.5" y="1033" class="message-label" text-anchor="middle" font-size="16">Payment pending</text>
-      <text x="457" y="946" class="labelText" text-anchor="middle" font-size="16">loop</text>
-      <text x="813.5" y="951" class="loopText" font-size="16" text-anchor="middle">[Retry up to 3 times]</text>
-      <text x="497" y="1140" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">16</text>
-      <text x="391.5" y="1126" class="message-label" text-anchor="middle" font-size="16">Order confirmed</text>
-      <text x="286" y="1184" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">17</text>
-      <text x="180.5" y="1170" class="message-label" text-anchor="middle" font-size="16">Show confirmation</text>
-      <text x="25" y="462" class="labelText" text-anchor="middle" font-size="16">alt</text>
-      <text x="602.5" y="467" class="loopText" font-size="16" text-anchor="middle">[Cart Empty]</text>
+      <text x="75" y="162" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">1</text>
+      <text x="175" y="148" class="message-label" font-size="16" text-anchor="middle">Click Checkout</text>
+      <text x="275" y="206" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">2</text>
+      <text x="375" y="192" class="message-label" font-size="16" text-anchor="middle">POST /checkout</text>
+      <text x="475" y="299" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">3</text>
+      <text x="580.5" y="285" class="message-label" text-anchor="middle" font-size="16">Verify session</text>
+      <text x="686" y="343" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">4</text>
+      <text x="786" y="329" class="message-label" text-anchor="middle" font-size="16">Query user</text>
+      <text x="886" y="387" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">5</text>
+      <text x="786" y="373" class="message-label" font-size="16" text-anchor="middle">User record</text>
+      <text x="686" y="431" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">6</text>
+      <text x="580.5" y="417" class="message-label" text-anchor="middle" font-size="16">Session valid</text>
+      <text x="475" y="519" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">7</text>
+      <text x="375" y="505" class="message-label" text-anchor="middle" font-size="16">Error: Empty cart</text>
+      <text x="275" y="563" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">8</text>
+      <text x="175" y="549" class="message-label" text-anchor="middle" font-size="16">Show error</text>
+      <text x="275" y="621" class="loopText" font-size="16" text-anchor="middle">[Cart Valid]</text>
+      <text x="475" y="651" class="sequenceNumber" font-family="sans-serif" font-size="12" text-anchor="middle">9</text>
+      <text x="680.5" y="637" class="message-label" text-anchor="middle" font-size="16">Reserve inventory</text>
+      <text x="475" y="739" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">10</text>
+      <text x="780.5" y="725" class="message-label" font-size="16" text-anchor="middle">Queue payment job</text>
+      <text x="1086" y="783" class="sequenceNumber" font-family="sans-serif" text-anchor="middle" font-size="12">11</text>
+      <text x="780.5" y="769" class="message-label" font-size="16" text-anchor="middle">Job queued</text>
+      <text x="780.5" y="841" class="loopText" text-anchor="middle" font-size="16">[Send Notifications]</text>
+      <text x="475" y="871" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">12</text>
+      <text x="520" y="882" class="message-label" text-anchor="start" font-size="16">Queue email confirmation</text>
+      <text x="435" y="682" class="labelText" font-size="16" text-anchor="middle">par</text>
+      <text x="780.5" y="687" class="loopText" text-anchor="middle" font-size="16">[Process Payment]</text>
+      <text x="886" y="915" class="sequenceNumber" text-anchor="middle" font-size="12" font-family="sans-serif">13</text>
+      <text x="680.5" y="901" class="message-label" text-anchor="middle" font-size="16">Inventory reserved</text>
+      <text x="475" y="1003" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">14</text>
+      <text x="780.5" y="989" class="message-label" text-anchor="middle" font-size="16">Check payment status</text>
+      <text x="1086" y="1047" class="sequenceNumber" font-size="12" font-family="sans-serif" text-anchor="middle">15</text>
+      <text x="780.5" y="1033" class="message-label" text-anchor="middle" font-size="16">Payment pending</text>
+      <text x="435" y="946" class="labelText" font-size="16" text-anchor="middle">loop</text>
+      <text x="780.5" y="951" class="loopText" text-anchor="middle" font-size="16">[Retry up to 3 times]</text>
+      <text x="475" y="1140" class="sequenceNumber" text-anchor="middle" font-family="sans-serif" font-size="12">16</text>
+      <text x="375" y="1126" class="message-label" font-size="16" text-anchor="middle">Order confirmed</text>
+      <text x="275" y="1184" class="sequenceNumber" font-size="12" text-anchor="middle" font-family="sans-serif">17</text>
+      <text x="175" y="1170" class="message-label" text-anchor="middle" font-size="16">Show confirmation</text>
+      <text x="25" y="462" class="labelText" font-size="16" text-anchor="middle">alt</text>
+      <text x="580.5" y="467" class="loopText" text-anchor="middle" font-size="16">[Cart Empty]</text>
     </g>
     <g class="nodes">
 
     </g>
     <g class="actor">
-      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="75" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">User</text>
+      <rect x="0" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="75" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">User</text>
     </g>
     <g class="actor">
-      <rect x="211" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
-      <text x="286" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Browser</text>
+      <rect x="200" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="275" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Browser</text>
     </g>
     <g class="actor">
-      <rect x="422" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="497" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">API</text>
+      <rect x="400" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="475" y="32.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">API</text>
     </g>
     <g class="actor">
-      <rect x="633" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="708" y="32.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Auth</text>
+      <rect x="611" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
+      <text x="686" y="32.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Auth</text>
     </g>
     <g class="actor">
-      <rect x="844" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="919" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">DB</text>
+      <rect x="811" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="886" y="32.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">DB</text>
     </g>
     <g class="actor">
-      <rect x="1055" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
-      <text x="1130" y="32.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">Queue</text>
+      <rect x="1011" y="0" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="1086" y="32.5" class="actor actor-box" text-anchor="middle" font-size="16" dominant-baseline="central">Queue</text>
     </g>
     <g class="note">
-      <rect x="50" y="75" width="1105" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="602.5" y="80" class="noteText" text-anchor="middle" font-size="16" alignment-baseline="middle" dominant-baseline="middle" dy="1em">E-Commerce Checkout Flow</text>
+      <rect x="50" y="75" width="1061" height="39" class="note" stroke="#666" fill="#EDF2AE"/>
+      <text x="580.5" y="80" class="noteText" dy="1em" font-size="16" text-anchor="middle" alignment-baseline="middle" dominant-baseline="middle">E-Commerce Checkout Flow</text>
     </g>
     <g class="note">
-      <rect x="522" y="212" width="150" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="597" y="217" class="noteText" font-size="16" alignment-baseline="middle" text-anchor="middle" dominant-baseline="middle" dy="1em">Validate cart items</text>
+      <rect x="500" y="212" width="150" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
+      <text x="575" y="217" class="noteText" dy="1em" text-anchor="middle" dominant-baseline="middle" alignment-baseline="middle" font-size="16">Validate cart items</text>
     </g>
     <g class="note">
-      <rect x="472" y="1053" width="683" height="39" class="note" fill="#EDF2AE" stroke="#666"/>
-      <text x="813.5" y="1058" class="noteText" dy="1em" text-anchor="middle" dominant-baseline="middle" alignment-baseline="middle" font-size="16">Payment confirmed</text>
+      <rect x="450" y="1053" width="661" height="39" class="note" stroke="#666" fill="#EDF2AE"/>
+      <text x="780.5" y="1058" class="noteText" alignment-baseline="middle" font-size="16" dy="1em" dominant-baseline="middle" text-anchor="middle">Payment confirmed</text>
     </g>
     <g class="actor">
-      <rect x="0" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="75" y="1232.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">User</text>
+      <rect x="0" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="75" y="1232.5" class="actor actor-box" font-size="16" text-anchor="middle" dominant-baseline="central">User</text>
     </g>
     <g class="actor">
-      <rect x="211" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
-      <text x="286" y="1232.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Browser</text>
+      <rect x="200" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="275" y="1232.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Browser</text>
     </g>
     <g class="actor">
-      <rect x="422" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="497" y="1232.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">API</text>
+      <rect x="400" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
+      <text x="475" y="1232.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">API</text>
     </g>
     <g class="actor">
-      <rect x="633" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" fill="#eaeaea" stroke-width="1"/>
-      <text x="708" y="1232.5" class="actor actor-box" text-anchor="middle" dominant-baseline="central" font-size="16">Auth</text>
+      <rect x="611" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke="#666" stroke-width="1" fill="#eaeaea"/>
+      <text x="686" y="1232.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Auth</text>
     </g>
     <g class="actor">
-      <rect x="844" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke-width="1" stroke="#666"/>
-      <text x="919" y="1232.5" class="actor actor-box" font-size="16" dominant-baseline="central" text-anchor="middle">DB</text>
+      <rect x="811" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" fill="#eaeaea" stroke="#666"/>
+      <text x="886" y="1232.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">DB</text>
     </g>
     <g class="actor">
-      <rect x="1055" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" stroke-width="1" stroke="#666" fill="#eaeaea"/>
-      <text x="1130" y="1232.5" class="actor actor-box" dominant-baseline="central" font-size="16" text-anchor="middle">Queue</text>
+      <rect x="1011" y="1200" width="150" height="65" rx="3" ry="3" class="actor actor-box" fill="#eaeaea" stroke="#666" stroke-width="1"/>
+      <text x="1086" y="1232.5" class="actor actor-box" dominant-baseline="central" text-anchor="middle" font-size="16">Queue</text>
     </g>
   </g>
 </svg>

--- a/src/render/sequence.rs
+++ b/src/render/sequence.rs
@@ -26,9 +26,9 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
     let actors = db.get_actors_in_order();
     let messages = db.get_messages();
 
-    // Calculate dynamic actor spacing based on message text widths (mermaid.js style)
-    // Mermaid adjusts spacing to accommodate long message text
-    let actor_spacing = calculate_actor_spacing(
+    // Calculate per-gap actor spacing based on message text widths (mermaid.js style)
+    // Each pair of adjacent actors can have different spacing
+    let gap_spacings = calculate_per_gap_spacing(
         &actors,
         messages,
         base_actor_spacing,
@@ -57,9 +57,8 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
         return Ok(doc.to_string());
     }
 
-    // Calculate dimensions (mimicking mermaid.js layout)
-    // mermaid.js uses negative viewBox offset for visual padding
-    let content_width = (actors.len() as f64 - 1.0) * actor_spacing + actor_width;
+    // Calculate content width from per-gap spacings
+    let content_width: f64 = gap_spacings.iter().sum::<f64>() + actor_width;
     // Height will be set later after we know the actual content height
 
     // Add theme styles
@@ -106,22 +105,29 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
     let actor_y = padding_y + title_offset;
     let lifeline_start_y = actor_y + actor_height;
 
-    // Create actor position map
+    // Create actor position map using cumulative per-gap spacing
     let mut actor_positions: std::collections::HashMap<String, f64> =
         std::collections::HashMap::new();
     let mut actor_centers: Vec<f64> = Vec::with_capacity(actors.len());
     let mut actor_index: std::collections::HashMap<String, usize> =
         std::collections::HashMap::new();
+    // Precompute cumulative x offsets for each actor
+    let mut actor_x_offsets: Vec<f64> = Vec::with_capacity(actors.len());
+    let mut cumulative_x = padding_x;
     for (i, actor) in actors.iter().enumerate() {
-        let center_x = padding_x + (i as f64) * actor_spacing + actor_width / 2.0;
+        actor_x_offsets.push(cumulative_x);
+        let center_x = cumulative_x + actor_width / 2.0;
         actor_positions.insert(actor.name.clone(), center_x);
         actor_centers.push(center_x);
         actor_index.insert(actor.name.clone(), i);
+        if i < gap_spacings.len() {
+            cumulative_x += gap_spacings[i];
+        }
     }
 
     // Render top actors only (bottom actors rendered after we know the final height)
     for (i, actor) in actors.iter().enumerate() {
-        let x = padding_x + (i as f64) * actor_spacing;
+        let x = actor_x_offsets[i];
         let center_x = x + actor_width / 2.0;
 
         // Top actor box/stick figure
@@ -402,7 +408,7 @@ pub fn render_sequence(db: &SequenceDb, config: &RenderConfig) -> Result<String>
 
     // Render lifelines and bottom actors now that we know the final height
     for (i, actor) in actors.iter().enumerate() {
-        let x = padding_x + (i as f64) * actor_spacing;
+        let x = actor_x_offsets[i];
         let center_x = x + actor_width / 2.0;
 
         // Lifeline (mermaid.js style) - rendered in clusters layer (back)
@@ -739,15 +745,26 @@ fn render_message(
     }
 
     // Message line (shape - rendered first in edge_paths)
+    // Use messageLine0 (solid) or messageLine1 (dotted) classes matching mermaid.js
+    let line_class = if is_dotted {
+        "messageLine1"
+    } else {
+        "messageLine0"
+    };
     let mut line_attrs = Attrs::new()
-        .with_stroke_width(1.5) // Match mermaid.js default
-        .with_class("message-line");
+        .with_stroke_width(2.0) // Match mermaid.js default (stroke-width: 2)
+        .with_class(line_class)
+        .with_attr("stroke", "none") // Stroke comes from CSS class
+        .with_attr(
+            "style",
+            if is_dotted {
+                "stroke-dasharray: 3, 3; fill: none;"
+            } else {
+                "fill: none;"
+            },
+        );
     if let Some(marker_id) = marker_id {
         line_attrs = line_attrs.with_attr("marker-end", &format!("url(#{})", marker_id));
-    }
-
-    if is_dotted {
-        line_attrs = line_attrs.with_stroke_dasharray("3,3");
     }
 
     shapes.push(SvgElement::Line {
@@ -758,17 +775,20 @@ fn render_message(
         attrs: line_attrs,
     });
 
-    // Sequence number circle and text - always at the sender's position (from_x)
+    // Sequence number using zero-length line with marker-start (matching mermaid.js)
     if let Some(num) = sequence_num {
-        // Circle background (shape - rendered first)
-        shapes.push(SvgElement::Circle {
-            cx: from_x,
-            cy: y,
-            r: 11.0, // Slightly larger for better visibility
-            attrs: Attrs::new().with_class("sequenceNumber-circle"),
+        // Zero-length line that triggers the sequencenumber marker
+        shapes.push(SvgElement::Line {
+            x1: from_x,
+            y1: y,
+            x2: from_x,
+            y2: y,
+            attrs: Attrs::new()
+                .with_stroke_width(0.0)
+                .with_attr("marker-start", "url(#sequencenumber)"),
         });
 
-        // Number text (label - rendered after shapes in edge_labels)
+        // Number text label (rendered on top in edge_labels)
         labels.push(SvgElement::Text {
             x: from_x,
             y: y + 4.0,
@@ -813,6 +833,8 @@ fn render_activation(actor_x: f64, start_y: f64, end_y: f64) -> SvgElement {
     }
 }
 
+/// Render a fragment frame as 4 individual lines (top/right/bottom/left) matching mermaid.js.
+/// Returns a group containing the 4 border lines (and optionally a fill rect for rect fragments).
 fn render_fragment_frame(
     x: f64,
     width: f64,
@@ -820,21 +842,58 @@ fn render_fragment_frame(
     end_y: f64,
     fill: Option<&str>,
 ) -> SvgElement {
-    let height = (end_y - start_y).max(1.0);
-    let mut attrs = Attrs::new().with_class("loopLine");
+    let right = x + width;
+    let mut children = Vec::new();
+
+    // If fill color specified (rect fragments), add a background rect
     if let Some(color) = fill {
-        attrs = attrs.with_fill(color);
-    } else {
-        attrs = attrs.with_fill("none");
+        children.push(SvgElement::Rect {
+            x,
+            y: start_y,
+            width,
+            height: (end_y - start_y).max(1.0),
+            rx: None,
+            ry: None,
+            attrs: Attrs::new().with_fill(color).with_stroke("none"),
+        });
     }
-    SvgElement::Rect {
-        x,
-        y: start_y,
-        width,
-        height,
-        rx: Some(3.0),
-        ry: Some(3.0),
-        attrs,
+
+    // Top line
+    children.push(SvgElement::Line {
+        x1: x,
+        y1: start_y,
+        x2: right,
+        y2: start_y,
+        attrs: Attrs::new().with_class("loopLine"),
+    });
+    // Right line
+    children.push(SvgElement::Line {
+        x1: right,
+        y1: start_y,
+        x2: right,
+        y2: end_y,
+        attrs: Attrs::new().with_class("loopLine"),
+    });
+    // Bottom line
+    children.push(SvgElement::Line {
+        x1: x,
+        y1: end_y,
+        x2: right,
+        y2: end_y,
+        attrs: Attrs::new().with_class("loopLine"),
+    });
+    // Left line
+    children.push(SvgElement::Line {
+        x1: x,
+        y1: start_y,
+        x2: x,
+        y2: end_y,
+        attrs: Attrs::new().with_class("loopLine"),
+    });
+
+    SvgElement::Group {
+        children,
+        attrs: Attrs::new(),
     }
 }
 
@@ -1030,17 +1089,18 @@ fn render_self_message(
         attrs: path_attrs,
     });
 
-    // Sequence number circle and text - at the actor's position
+    // Sequence number using zero-length line with marker-start (matching mermaid.js)
     if let Some(num) = sequence_num {
-        // Circle background (shape - rendered first)
-        shapes.push(SvgElement::Circle {
-            cx: x,
-            cy: y,
-            r: 11.0, // Match regular message size
-            attrs: Attrs::new().with_class("sequenceNumber-circle"),
+        shapes.push(SvgElement::Line {
+            x1: x,
+            y1: y,
+            x2: x,
+            y2: y,
+            attrs: Attrs::new()
+                .with_stroke_width(0.0)
+                .with_attr("marker-start", "url(#sequencenumber)"),
         });
 
-        // Number text (label - rendered after shapes in edge_labels)
         labels.push(SvgElement::Text {
             x,
             y: y + 4.0,
@@ -1385,9 +1445,10 @@ text.actor, text.actor > tspan, text.actor-box, text.actor-label {{
     )
 }
 
-/// Calculate dynamic actor spacing based on message text widths
-/// Mimics mermaid.js getMaxMessageWidthPerActor and calculateActorMargins logic
-fn calculate_actor_spacing(
+/// Calculate per-gap actor spacing based on message text widths.
+/// Returns a Vec of spacing values, one for each gap between adjacent actors.
+/// This matches mermaid.js behavior where each actor pair can have different spacing.
+fn calculate_per_gap_spacing(
     actors: &[&crate::diagrams::sequence::Actor],
     messages: &[crate::diagrams::sequence::Message],
     base_spacing: f64,
@@ -1395,7 +1456,13 @@ fn calculate_actor_spacing(
     char_width: f64,
     wrap_padding: f64,
     actor_margin: f64,
-) -> f64 {
+) -> Vec<f64> {
+    let num_gaps = if actors.len() > 1 {
+        actors.len() - 1
+    } else {
+        return vec![];
+    };
+
     // Build actor name to index mapping
     let actor_index: std::collections::HashMap<&str, usize> = actors
         .iter()
@@ -1403,11 +1470,10 @@ fn calculate_actor_spacing(
         .map(|(i, a)| (a.name.as_str(), i))
         .collect();
 
-    // Calculate max message width per actor (between adjacent actors)
-    let mut max_width_per_actor: Vec<f64> = vec![0.0; actors.len()];
+    // Track max required width per gap (between adjacent actors i and i+1)
+    let mut max_width_per_gap: Vec<f64> = vec![0.0; num_gaps];
 
     for msg in messages {
-        // Get from and to indices (handling Option<String>)
         let from_idx = msg
             .from
             .as_ref()
@@ -1419,26 +1485,27 @@ fn calculate_actor_spacing(
 
         if let (Some(from), Some(to)) = (from_idx, to_idx) {
             if from != to {
-                // Calculate message text width
                 let text_width =
                     msg.message.chars().count() as f64 * char_width + 2.0 * wrap_padding;
 
-                // Determine which actor to assign the width to (the one with the smaller index)
                 let min_idx = std::cmp::min(from, to);
-                let current_max: f64 = max_width_per_actor[min_idx];
-                max_width_per_actor[min_idx] = current_max.max(text_width);
+
+                // Assign the full text width to the first gap between sender/receiver.
+                max_width_per_gap[min_idx] = max_width_per_gap[min_idx].max(text_width);
             }
         }
     }
 
-    // Calculate required spacing: max of base_spacing or (message_width + actor_margin - actor_width/2)
-    let mut max_required_spacing = base_spacing;
-    for width in max_width_per_actor {
-        if width > 0.0 {
-            let required = width + actor_margin - actor_width / 2.0;
-            max_required_spacing = max_required_spacing.max(required);
-        }
-    }
-
-    max_required_spacing
+    // Convert text widths to spacing values
+    max_width_per_gap
+        .iter()
+        .map(|&width| {
+            if width > 0.0 {
+                let required = width + actor_margin - actor_width / 2.0;
+                base_spacing.max(required)
+            } else {
+                base_spacing
+            }
+        })
+        .collect()
 }

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -2414,16 +2414,51 @@ fn test_sequence_loop_scopes_to_single_actor() {
     let svg = render_with_config(&diagram, &RenderConfig::default())
         .expect("Failed to render sequence diagram");
 
+    // Fragment frames use line elements (not rects) matching mermaid.js.
+    // Find the horizontal top line of the loop frame (first loopLine) and compute its width.
     let loop_width = svg
-        .split("<rect")
-        .find_map(|chunk| {
-            if !chunk.contains("class=\"loopLine\"") {
+        .split("<line")
+        .filter_map(|chunk| {
+            if !chunk.contains("loopLine") {
                 return None;
             }
-            let width = chunk.split("width=\"").nth(1)?.split('"').next()?;
-            width.parse::<f64>().ok()
+            let x1 = chunk
+                .split("x1=\"")
+                .nth(1)?
+                .split('"')
+                .next()?
+                .parse::<f64>()
+                .ok()?;
+            let x2 = chunk
+                .split("x2=\"")
+                .nth(1)?
+                .split('"')
+                .next()?
+                .parse::<f64>()
+                .ok()?;
+            let y1 = chunk
+                .split("y1=\"")
+                .nth(1)?
+                .split('"')
+                .next()?
+                .parse::<f64>()
+                .ok()?;
+            let y2 = chunk
+                .split("y2=\"")
+                .nth(1)?
+                .split('"')
+                .next()?
+                .parse::<f64>()
+                .ok()?;
+            // Horizontal line (y1 == y2) indicates top or bottom of frame
+            if (y1 - y2).abs() < 0.1 {
+                Some((x2 - x1).abs())
+            } else {
+                None
+            }
         })
-        .expect("Failed to parse loop frame width");
+        .next()
+        .expect("Failed to find loop frame horizontal line");
 
     assert!(
         loop_width < 300.0,

--- a/tests/sequence_rendering.rs
+++ b/tests/sequence_rendering.rs
@@ -1,0 +1,172 @@
+//! Tests for sequence diagram rendering to match mermaid.js reference output
+
+use selkie::{parse, render};
+
+fn render_sequence(input: &str) -> String {
+    let diagram = parse(input).expect("Failed to parse");
+    render(&diagram).expect("Failed to render")
+}
+
+#[test]
+fn sequence_fragment_frames_use_lines_not_rects() {
+    // Mermaid.js renders fragment frames as 4 line elements (top/right/bottom/left)
+    // not as a single rect element with loopLine class
+    let input = r#"sequenceDiagram
+    Alice->>Bob: Hello
+    loop Every minute
+        Bob->>Alice: Reply
+    end"#;
+
+    let svg = render_sequence(input);
+
+    // Should NOT have rect elements with loopLine class (that's selkie's old approach)
+    // Instead should have line elements forming the frame border
+    let has_rect_loop = svg.contains("<rect") && {
+        // Check if any rect has loopLine class
+        svg.split("<rect").skip(1).any(|s| {
+            s.split('>')
+                .next()
+                .map_or(false, |attrs| attrs.contains("loopLine"))
+        })
+    };
+    assert!(
+        !has_rect_loop,
+        "Fragment frames should NOT use rect elements; should use 4 line elements like mermaid.js"
+    );
+}
+
+#[test]
+fn sequence_message_lines_use_mermaid_classes() {
+    // Mermaid.js uses class="messageLine0" for solid and class="messageLine1" for dotted
+    // on the actual <line> elements, not "message-line"
+    let input = r#"sequenceDiagram
+    Alice->>Bob: Solid message
+    Bob-->>Alice: Dotted message"#;
+
+    let svg = render_sequence(input);
+
+    // Check that line elements use messageLine0/messageLine1 classes
+    let lines: Vec<&str> = svg
+        .split("<line")
+        .skip(1)
+        .filter_map(|s| s.split('>').next())
+        .collect();
+
+    let has_message_line0 = lines.iter().any(|l| l.contains("messageLine0"));
+    let has_message_line1 = lines.iter().any(|l| l.contains("messageLine1"));
+
+    assert!(
+        has_message_line0,
+        "Solid message lines should have messageLine0 class on line element"
+    );
+    assert!(
+        has_message_line1,
+        "Dotted message lines should have messageLine1 class on line element"
+    );
+}
+
+#[test]
+fn sequence_autonumber_uses_marker_not_circles() {
+    // Mermaid.js uses zero-length line with marker-start="url(#sequencenumber)"
+    // instead of explicit circle + text elements for sequence numbers
+    let input = r#"sequenceDiagram
+    autonumber
+    Alice->>Bob: First
+    Bob-->>Alice: Second"#;
+
+    let svg = render_sequence(input);
+
+    // Should use marker-start for sequence numbers
+    assert!(
+        svg.contains("marker-start=\"url(#sequencenumber)\""),
+        "Sequence numbers should use marker-start on a zero-length line"
+    );
+
+    // Should NOT have explicit sequenceNumber-circle elements in the body
+    // (only in the marker def is fine)
+    let body_circles = svg
+        .split("<circle")
+        .skip(1)
+        .filter(|s| {
+            s.split('>')
+                .next()
+                .map_or(false, |a| a.contains("sequenceNumber-circle"))
+        })
+        .count();
+    assert_eq!(
+        body_circles, 0,
+        "Should not render explicit sequenceNumber-circle elements in body"
+    );
+}
+
+#[test]
+fn sequence_basic_structure() {
+    let input = r#"sequenceDiagram
+    participant A as Alice
+    participant B as Bob
+    A->>B: Hello Bob!
+    B-->>A: Hi Alice!"#;
+
+    let svg = render_sequence(input);
+
+    // Should have actor boxes (top and bottom)
+    assert!(svg.contains("actor-box"), "Should render actor boxes");
+
+    // Should have lifelines
+    assert!(svg.contains("actor-line"), "Should render actor lifelines");
+
+    // Should have message labels
+    assert!(svg.contains("Hello Bob!"), "Should render message text");
+    assert!(svg.contains("Hi Alice!"), "Should render reply text");
+}
+
+#[test]
+fn sequence_alt_fragment_has_divider() {
+    let input = r#"sequenceDiagram
+    Alice->>Bob: Request
+    alt Success
+        Bob-->>Alice: OK
+    else Failure
+        Bob-->>Alice: Error
+    end"#;
+
+    let svg = render_sequence(input);
+
+    // Should have alt label
+    assert!(svg.contains(">alt<"), "Should render alt fragment label");
+    // Should have divider line with loopLine class
+    assert!(
+        svg.contains("loopLine"),
+        "Should render fragment elements with loopLine class"
+    );
+}
+
+#[test]
+fn sequence_activation_renders() {
+    let input = r#"sequenceDiagram
+    Alice->>+Bob: Request
+    Bob-->>-Alice: Response"#;
+
+    let svg = render_sequence(input);
+
+    assert!(svg.contains("activation"), "Should render activation box");
+}
+
+#[test]
+fn sequence_self_message_uses_path() {
+    // Mermaid.js renders self-messages as path elements
+    let input = r#"sequenceDiagram
+    Alice->>Alice: Self message"#;
+
+    let svg = render_sequence(input);
+
+    assert!(
+        svg.contains("Self message"),
+        "Should render self message text"
+    );
+    // Self messages use a path element (the loop shape)
+    assert!(
+        svg.contains("<path"),
+        "Self messages should use path elements"
+    );
+}


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Render fragment frames as 4 line elements (top/right/bottom/left) instead of rect, matching mermaid.js structure
- Use `messageLine0`/`messageLine1` CSS classes on message lines matching mermaid.js naming
- Replace explicit circle+text autonumber with marker-based zero-length line approach matching mermaid.js
- Add per-gap actor spacing (variable spacing between adjacent actor pairs)
- Add sequence rendering test suite and regenerate SVGs

## Eval results
- Warnings reduced from 29 to 24
- Element count alignment improved significantly:
  - Complex diagram circles: 18 → 1 (target: 1)
  - Complex diagram rects: 22 → 19 (target: 19)
  - Complex diagram lines: 26 → 55 (target: 54)

## Test plan
- [x] All existing tests pass (1559+ tests)
- [x] New sequence_rendering.rs tests pass (7 tests)
- [x] cargo fmt clean
- [x] cargo clippy clean (no warnings)
- [x] Eval runs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)