### PR TITLE
fix(eval): improve flowchart label extraction and stroke analysis

### DIFF
--- a/docs/images/example_flowchart_basic.svg
+++ b/docs/images/example_flowchart_basic.svg
@@ -87,7 +87,7 @@ marker path {
       <path d="M 0 5 L 10 10 L 10 0 z"/>
     </marker>
     <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
@@ -105,32 +105,32 @@ marker path {
     </g>
     <g class="edgePaths">
       <g class="edge" id="edge-L-A-B-0">
-        <path d="M 121.41 61.00 L 248.80 32.80" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 121.41 61.00 L 248.80 32.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-A-C-0">
-        <path d="M 121.41 113.80 L 217.60 142.00" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 121.41 113.80 L 217.60 142.00" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-B-D-0">
-        <path d="M 314.40 32.80 L 419.07 63.93" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 314.40 32.80 L 419.07 63.93" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-C-D-0">
-        <path d="M 345.60 142.00 L 419.07 110.87" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 345.60 142.00 L 419.07 110.87" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
     </g>
     <g class="edgeLabels">
       <g class="edgeLabel" id="edge-label-L-A-B-0">
         <rect x="145.36379895497905" y="21.80000000000001" width="72.8" height="22" class="edge-label-bg"/>
-        <text x="181.76379895497905" y="32.80000000000001" class="edge-label" dominant-baseline="central" text-anchor="middle">Link text</text>
+        <text x="181.76379895497905" y="32.80000000000001" class="edge-label" text-anchor="middle" dominant-baseline="central">Link text</text>
       </g>
     </g>
     <g class="nodes">
       <g class="node" id="node-A">
         <rect x="0" y="61.00000000000001" width="137.6" height="52.8"/>
-        <text x="68.8" y="87.4" class="label" dominant-baseline="central" text-anchor="middle">Square Rect</text>
+        <text x="68.8" y="87.4" class="label" text-anchor="middle" dominant-baseline="central">Square Rect</text>
       </g>
       <g class="node" id="node-B">
         <circle cx="281.6" cy="32.80000000000001" r="32.8"/>
-        <text x="281.6" y="32.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">Circle</text>
+        <text x="281.6" y="32.80000000000001" class="label" dominant-baseline="central" text-anchor="middle">Circle</text>
       </g>
       <g class="node" id="node-C">
         <path d="M 222.60000000000002 115.6 H 340.6 A 5 5 0 0 1 345.6 120.6 V 163.39999999999998 A 5 5 0 0 1 340.6 168.39999999999998 H 222.60000000000002 A 5 5 0 0 1 217.60000000000002 163.39999999999998 V 120.6 A 5 5 0 0 1 222.60000000000002 115.6 Z"/>
@@ -138,7 +138,7 @@ marker path {
       </g>
       <g class="node" id="node-D">
         <polygon points="455.6,27.400000000000006 515.6,87.4 455.6,147.4 395.6,87.4"/>
-        <text x="455.6" y="87.4" class="label" text-anchor="middle" dominant-baseline="central">Rhombus</text>
+        <text x="455.6" y="87.4" class="label" dominant-baseline="central" text-anchor="middle">Rhombus</text>
       </g>
     </g>
   </g>

--- a/docs/images/example_flowchart_styled.svg
+++ b/docs/images/example_flowchart_styled.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1403.0400000000002" height="560.8" viewBox="-8 -28.000000000000014 1403.0400000000002 560.8" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1206.8400000000001" height="556.8" viewBox="-8 -24.000000000000014 1206.8400000000001 556.8" class="mermaid">
   <style>
 
 .mermaid {
@@ -102,83 +102,83 @@ marker path {
   <g class="root">
     <g class="clusters">
       <g class="subgraph" id="subgraph-A">
-        <rect x="20.000000000000014" y="-20.000000000000014" width="574.04" height="532.8" class="cluster"/>
-        <text x="307.02" y="-4.000000000000014" class="cluster-label" text-anchor="middle">A</text>
+        <rect x="31.980000000000018" y="-16.000000000000014" width="436.2399999999999" height="524.8" class="cluster"/>
+        <text x="250.09999999999997" y="-0.000000000000014210854715202004" class="cluster-label" text-anchor="middle">A</text>
       </g>
     </g>
     <g class="edgePaths">
       <g class="edge" id="edge-L-sq-ci-0">
-        <path d="M 1313.44 158.60 C 1313.44 193.87, 1313.44 229.13, 1313.44 252.60 C 1313.44 276.07, 1313.44 287.73, 1313.44 305.00 C 1313.44 345.13, 1313.44 368.00, 1313.44 368.00" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 1130.02 158.60 C 1130.02 193.87, 1130.02 229.13, 1035.38 252.60 C 940.75 276.07, 751.47 287.73, 735.48 312.82 C 876.78 376.43, 1034.07 414.95, 1034.07 414.95" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-od-ro-0">
-        <path d="M 508.92 158.60 C 508.92 205.53, 508.92 252.47, 490.75 290.85 C 472.59 329.23, 436.25 359.05, 399.92 388.88" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 387.10 158.60 C 387.10 193.87, 387.10 229.13, 450.54 252.60 C 513.99 276.07, 640.87 287.73, 615.21 313.42 C 411.32 378.83, 233.10 418.55, 233.10 418.55" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-di-ro-0">
-        <path d="M 147.20 239.40 C 147.20 259.40, 147.20 279.40, 172.79 305.80 C 198.37 332.20, 249.55 365.00, 300.72 397.81" class="edge-path" stroke-width="2" marker-end="url(#arrow_point)" stroke-dasharray="3,3" fill="none"/>
+        <path d="M 159.98 239.40 C 159.98 247.73, 159.98 256.07, 230.35 266.07 C 300.72 276.07, 441.46 287.73, 453.65 312.57 C 349.47 375.40, 233.10 413.40, 233.10 413.40" class="edge-path" fill="none" stroke-width="2" stroke-dasharray="3,3" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-di-ro2-0">
-        <path d="M 254.40000000000003 132.2 L 169.8 132.2" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="3.5"/>
+        <path d="M 159.98000000000002 132.2 L 159.98000000000002 132.2" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="3.5"/>
       </g>
       <g class="edge" id="edge-L-e-od3-0">
-        <path d="M 1022.76 180.08 C 977.75 208.19, 932.73 236.29, 910.23 270.41 C 887.72 304.53, 887.72 344.67, 887.72 384.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 866.17 207.61 C 853.65 226.54, 841.14 245.47, 737.74 260.77 C 634.34 276.07, 440.06 287.73, 389.68 307.80 C 432.81 356.33, 526.33 384.80, 526.33 384.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-e-f-0">
-        <path d="M 1115.59 221.15 L 1123.44 403.20" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 969.50 205.08 C 984.01 224.86, 998.51 244.63, 920.29 260.35 C 842.07 276.07, 671.13 287.73, 647.87 312.51 C 749.06 375.16, 873.50 413.04, 873.50 413.04" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-cyr-cyr2-0">
-        <path d="M 592.52 158.60 C 592.52 193.87, 592.52 229.13, 592.52 252.60 C 592.52 276.07, 592.52 287.73, 592.52 299.40 C 592.52 322.73, 592.52 334.40, 592.52 334.40" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 721.22 158.60 C 721.22 193.87, 721.22 229.13, 601.02 252.60 C 480.81 276.07, 240.41 287.73, 168.25 310.10 C 192.19 365.55, 288.28 398.62, 288.28 398.62" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
     </g>
     <g class="edgeLabels">
       <g class="edgeLabel" id="edge-label-L-od-ro-0">
-        <rect x="461.6331476116933" y="279.4713000060374" width="94.39999999999999" height="40" class="edge-label-bg"/>
-        <text x="508.8331476116933" y="299.4713000060374" class="edge-label" text-anchor="middle" dominant-baseline="central"><tspan x="508.8331476116933" y="299.4713000060374" dy="-0.6em">Two line</tspan><tspan x="508.8331476116933" dy="1.2em">edge comment</tspan></text>
+        <rect x="691.4201861519787" y="285.89369075927215" width="94.39999999999999" height="40" class="edge-label-bg"/>
+        <text x="738.6201861519787" y="305.89369075927215" class="edge-label" text-anchor="middle" dominant-baseline="central"><tspan x="738.6201861519787" y="305.89369075927215" dy="-0.6em">Two line</tspan><tspan x="738.6201861519787" dy="1.2em">edge comment</tspan></text>
       </g>
     </g>
     <g class="nodes">
       <g class="node" id="node-ci">
-        <circle cx="1313.44" cy="429.6" r="61.599999999999994"/>
-        <text x="1313.44" y="429.6" class="label" text-anchor="middle" dominant-baseline="central">Circle shape</text>
+        <circle cx="1093.8999999999999" cy="429.6" r="61.599999999999994"/>
+        <text x="1093.8999999999999" y="429.6" class="label" dominant-baseline="central" text-anchor="middle">Circle shape</text>
       </g>
       <g class="node" id="node-cyr">
-        <rect x="538.1199999999999" y="105.79999999999998" width="108.8" height="52.8"/>
-        <text x="592.5199999999999" y="132.2" class="label" text-anchor="middle" dominant-baseline="central">Cyrillic</text>
+        <rect x="666.8199999999999" y="105.79999999999998" width="108.8" height="52.8"/>
+        <text x="721.2199999999999" y="132.2" class="label" dominant-baseline="central" text-anchor="middle">Cyrillic</text>
       </g>
       <g class="node" id="node-cyr2">
-        <circle cx="592.5199999999999" cy="429.59999999999997" r="95.2"/>
-        <text x="592.5199999999999" y="429.59999999999997" class="label" dominant-baseline="central" text-anchor="middle">Circle shape Начало</text>
+        <circle cx="378.29999999999995" cy="429.59999999999997" r="95.2"/>
+        <text x="378.29999999999995" y="429.59999999999997" class="label" text-anchor="middle" dominant-baseline="central">Circle shape Начало</text>
       </g>
       <g class="node" id="node-di">
-        <polygon points="147.20000000000002,24.999999999999986 254.40000000000003,132.2 147.20000000000002,239.39999999999998 40.000000000000014,132.2" style="fill:#f96 !important;stroke:#333 !important;stroke-width:4px !important"/>
-        <text x="147.20000000000002" y="132.2" class="label" dominant-baseline="central" text-anchor="middle"><tspan x="147.20000000000002" y="132.2" dy="-0.6em">Diamond with </tspan><tspan x="147.20000000000002" dy="1.2em"> line break</tspan></text>
+        <polygon points="159.98000000000002,24.999999999999986 267.18,132.2 159.98000000000002,239.39999999999998 52.780000000000015,132.2" style="fill:#f96 !important;stroke:#333 !important;stroke-width:4px !important"/>
+        <text x="159.98000000000002" y="132.2" class="label" text-anchor="middle" dominant-baseline="central"><tspan x="159.98000000000002" y="132.2" dy="-0.6em">Diamond with </tspan><tspan x="159.98000000000002" dy="1.2em"> line break</tspan></text>
       </g>
       <g class="node" id="node-e">
-        <circle cx="1099.44" cy="132.2" r="90.39999999999999" style="fill:#9f6 !important;stroke:#333 !important;stroke-width:2px !important"/>
-        <text x="1099.44" y="132.2" class="label" text-anchor="middle" dominant-baseline="central"><tspan x="1099.44" y="132.2" dy="-1.2em">Inner / circle</tspan><tspan x="1099.44" dy="1.2em">and some odd </tspan><tspan x="1099.44" dy="1.2em">special characters</tspan></text>
+        <circle cx="916.02" cy="132.2" r="90.39999999999999" style="fill:#9f6 !important;stroke:#333 !important;stroke-width:2px !important"/>
+        <text x="916.02" y="132.2" class="label" dominant-baseline="central" text-anchor="middle"><tspan x="916.02" y="132.2" dy="-1.2em">Inner / circle</tspan><tspan x="916.02" dy="1.2em">and some odd </tspan><tspan x="916.02" dy="1.2em">special characters</tspan></text>
       </g>
       <g class="node" id="node-f">
-        <path d="M 1074.04 403.2 H 1172.84 A 5 5 0 0 1 1177.84 408.2 V 451 A 5 5 0 0 1 1172.84 456 H 1074.04 A 5 5 0 0 1 1069.04 451 V 408.2 A 5 5 0 0 1 1074.04 403.2 Z"/>
-        <text x="1123.44" y="429.59999999999997" class="label" text-anchor="middle" dominant-baseline="central">,.?!+-*ز</text>
+        <path d="M 878.4999999999999 403.2 H 977.2999999999998 A 5 5 0 0 1 982.2999999999998 408.2 V 451 A 5 5 0 0 1 977.2999999999998 456 H 878.4999999999999 A 5 5 0 0 1 873.4999999999999 451 V 408.2 A 5 5 0 0 1 878.4999999999999 403.2 Z"/>
+        <text x="927.8999999999999" y="429.59999999999997" class="label" dominant-baseline="central" text-anchor="middle">,.?!+-*ز</text>
       </g>
       <g class="node" id="node-od">
-        <path d="M 443.79999999999995 105.79999999999998 L 574.04 105.79999999999998 L 554.5039999999999 132.2 L 574.04 158.59999999999997 L 443.79999999999995 158.59999999999997 Z"/>
-        <text x="508.91999999999996" y="132.2" class="label" dominant-baseline="central" text-anchor="middle">Odd shape</text>
+        <path d="M 321.9799999999999 105.79999999999998 L 452.2199999999999 105.79999999999998 L 432.6839999999999 132.2 L 452.2199999999999 158.59999999999997 L 321.9799999999999 158.59999999999997 Z"/>
+        <text x="387.0999999999999" y="132.2" class="label" text-anchor="middle" dominant-baseline="central">Odd shape</text>
       </g>
       <g class="node" id="node-od3">
-        <path d="M 737.7199999999999 384.79999999999995 L 1037.7199999999998 384.79999999999995 L 992.7199999999998 429.59999999999997 L 1037.7199999999998 474.4 L 737.7199999999999 474.4 Z"/>
-        <text x="887.7199999999999" y="429.59999999999997" class="label" text-anchor="middle" dominant-baseline="central"><tspan x="887.7199999999999" y="429.59999999999997" dy="-0.6em">Really long text with linebreak</tspan><tspan x="887.7199999999999" dy="1.2em">in an Odd shape</tspan></text>
+        <path d="M 523.5 384.79999999999995 L 823.5 384.79999999999995 L 778.5 429.59999999999997 L 823.5 474.4 L 523.5 474.4 Z"/>
+        <text x="673.5" y="429.59999999999997" class="label" text-anchor="middle" dominant-baseline="central"><tspan x="673.5" y="429.59999999999997" dy="-0.6em">Really long text with linebreak</tspan><tspan x="673.5" dy="1.2em">in an Odd shape</tspan></text>
       </g>
       <g class="node" id="node-ro">
-        <path d="M 305.72 366.4 H 394.92 A 5 5 0 0 1 399.92 371.4 V 487.79999999999995 A 5 5 0 0 1 394.92 492.79999999999995 H 305.72 A 5 5 0 0 1 300.72 487.79999999999995 V 371.4 A 5 5 0 0 1 305.72 366.4 Z"/>
-        <text x="350.32000000000005" y="429.59999999999997" class="label" text-anchor="middle" dominant-baseline="central"><tspan x="350.32000000000005" y="429.59999999999997" dy="-1.2em">Rounded</tspan><tspan x="350.32000000000005" dy="1.2em">square</tspan><tspan x="350.32000000000005" dy="1.2em">shape</tspan></text>
+        <path d="M 138.9 366.4 H 228.10000000000002 A 5 5 0 0 1 233.10000000000002 371.4 V 487.79999999999995 A 5 5 0 0 1 228.10000000000002 492.79999999999995 H 138.9 A 5 5 0 0 1 133.9 487.79999999999995 V 371.4 A 5 5 0 0 1 138.9 366.4 Z"/>
+        <text x="183.5" y="429.59999999999997" class="label" text-anchor="middle" dominant-baseline="central"><tspan x="183.5" y="429.59999999999997" dy="-1.2em">Rounded</tspan><tspan x="183.5" dy="1.2em">square</tspan><tspan x="183.5" dy="1.2em">shape</tspan></text>
       </g>
       <g class="node" id="node-ro2">
-        <path d="M 174.8 105.79999999999998 H 388.8 A 5 5 0 0 1 393.8 110.79999999999998 V 153.59999999999997 A 5 5 0 0 1 388.8 158.59999999999997 H 174.8 A 5 5 0 0 1 169.8 153.59999999999997 V 110.79999999999998 A 5 5 0 0 1 174.8 105.79999999999998 Z"/>
-        <text x="281.8" y="132.2" class="label" text-anchor="middle" dominant-baseline="central">Rounded square shape</text>
+        <path d="M 52.98000000000002 105.79999999999998 H 266.98 A 5 5 0 0 1 271.98 110.79999999999998 V 153.59999999999997 A 5 5 0 0 1 266.98 158.59999999999997 H 52.98000000000002 A 5 5 0 0 1 47.98000000000002 153.59999999999997 V 110.79999999999998 A 5 5 0 0 1 52.98000000000002 105.79999999999998 Z"/>
+        <text x="159.98000000000002" y="132.2" class="label" text-anchor="middle" dominant-baseline="central">Rounded square shape</text>
       </g>
       <g class="node" id="node-sq">
-        <rect x="1239.8400000000001" y="105.79999999999998" width="147.2" height="52.8" style="fill:#9f6 !important;stroke:#333 !important;stroke-width:2px !important"/>
-        <text x="1313.44" y="132.2" class="label" dominant-baseline="central" text-anchor="middle">Square shape</text>
+        <rect x="1056.42" y="105.79999999999998" width="147.2" height="52.8" style="fill:#9f6 !important;stroke:#333 !important;stroke-width:2px !important"/>
+        <text x="1130.02" y="132.2" class="label" text-anchor="middle" dominant-baseline="central">Square shape</text>
       </g>
     </g>
   </g>

--- a/docs/images/flowchart.svg
+++ b/docs/images/flowchart.svg
@@ -87,7 +87,7 @@ marker path {
       <path d="M 0 5 L 10 10 L 10 0 z"/>
     </marker>
     <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
@@ -105,41 +105,41 @@ marker path {
     </g>
     <g class="edgePaths">
       <g class="edge" id="edge-L-A-B-0">
-        <path d="M 80.00 77.80 C 88.33 77.80, 96.67 77.80, 105.00 77.80 C 113.33 77.80, 121.67 77.80, 130.00 77.80" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 80.00 77.80 C 88.33 77.80, 96.67 77.80, 105.00 77.80 C 113.33 77.80, 121.67 77.80, 130.00 77.80" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-B-C-0">
-        <path d="M 238.28 56.48 L 339.60 26.40" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 238.28 56.48 L 339.60 26.40" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-B-D-0">
-        <path d="M 238.28 99.12 L 339.60 129.20" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 238.28 99.12 L 339.60 129.20" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-C-E-0">
-        <path d="M 448.40 26.40 L 500.35 51.40" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 448.40 26.40 L 500.35 51.40" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-D-E-0">
-        <path d="M 448.40 129.20 L 500.35 104.20" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 448.40 129.20 L 500.35 104.20" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-E-F-0">
         <path d="M 559.20 77.80 C 567.53 77.80, 575.87 77.80, 584.20 77.80 C 592.53 77.80, 600.87 77.80, 609.20 77.80" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-F-G-0">
-        <path d="M 742.00 77.80 C 750.33 77.80, 758.67 77.80, 767.00 77.80 C 775.33 77.80, 783.67 77.80, 792.00 77.80" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 742.00 77.80 C 750.33 77.80, 758.67 77.80, 767.00 77.80 C 775.33 77.80, 783.67 77.80, 792.00 77.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-G-H-0">
-        <path d="M 940.00 77.80 C 948.33 77.80, 956.67 77.80, 965.00 77.80 C 973.33 77.80, 981.67 77.80, 990.00 77.80" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 940.00 77.80 C 948.33 77.80, 956.67 77.80, 965.00 77.80 C 973.33 77.80, 981.67 77.80, 990.00 77.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-H-I-0">
-        <path d="M 1098.80 77.80 C 1107.13 77.80, 1115.47 77.80, 1123.80 77.80 C 1132.13 77.80, 1140.47 77.80, 1148.80 77.80" class="edge-path" fill="none" marker-start="url(#arrow_circle_start)" stroke-width="1" marker-end="url(#arrow_circle)"/>
+        <path d="M 1098.80 77.80 C 1107.13 77.80, 1115.47 77.80, 1123.80 77.80 C 1132.13 77.80, 1140.47 77.80, 1148.80 77.80" class="edge-path" stroke-width="1" marker-start="url(#arrow_circle_start)" fill="none" marker-end="url(#arrow_circle)"/>
       </g>
     </g>
     <g class="edgeLabels">
       <g class="edgeLabel" id="edge-label-L-B-C-0">
-        <rect x="272.0948393648911" y="21.631347868746175" width="29.599999999999998" height="22" class="edge-label-bg"/>
-        <text x="286.8948393648911" y="32.631347868746175" class="edge-label" dominant-baseline="central" text-anchor="middle">Yes</text>
+        <rect x="272.0948393648911" y="21.631347868746182" width="29.599999999999998" height="22" class="edge-label-bg"/>
+        <text x="286.8948393648911" y="32.63134786874618" class="edge-label" dominant-baseline="central" text-anchor="middle">Yes</text>
       </g>
       <g class="edgeLabel" id="edge-label-L-B-D-0">
         <rect x="275.6948393648911" y="111.96865213125383" width="22.4" height="22" class="edge-label-bg"/>
-        <text x="286.8948393648911" y="122.96865213125383" class="edge-label" dominant-baseline="central" text-anchor="middle">No</text>
+        <text x="286.8948393648911" y="122.96865213125383" class="edge-label" text-anchor="middle" dominant-baseline="central">No</text>
       </g>
     </g>
     <g class="nodes">
@@ -152,8 +152,8 @@ marker path {
         <text x="194.8" y="77.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">Decision</text>
       </g>
       <g class="node" id="node-C">
-        <rect x="339.6" y="0" width="108.8" height="52.8"/>
-        <text x="394" y="26.4" class="label" text-anchor="middle" dominant-baseline="central">Action 1</text>
+        <rect x="339.6" y="0.000000000000007105427357601002" width="108.8" height="52.8"/>
+        <text x="394" y="26.400000000000006" class="label" dominant-baseline="central" text-anchor="middle">Action 1</text>
       </g>
       <g class="node" id="node-D">
         <rect x="339.6" y="102.80000000000001" width="108.8" height="52.8"/>
@@ -165,7 +165,7 @@ marker path {
       </g>
       <g class="node" id="node-F">
         <path d="M 635.6 51.40000000000001 H 715.6 A 26.4 26.4 0 0 1 715.6 104.20000000000002 H 635.6 A 26.4 26.4 0 0 1 635.6 51.40000000000001 Z"/>
-        <text x="675.6" y="77.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">Round</text>
+        <text x="675.6" y="77.80000000000001" class="label" dominant-baseline="central" text-anchor="middle">Round</text>
       </g>
       <g class="node" id="node-G">
         <polygon points="802,51.40000000000001 930,51.40000000000001 930,104.20000000000002 802,104.20000000000002 802,51.40000000000001 792,51.40000000000001 940,51.40000000000001 940,104.20000000000002 792,104.20000000000002 792,51.40000000000001"/>
@@ -177,7 +177,7 @@ marker path {
       </g>
       <g class="node" id="node-I">
         <circle cx="1181.6" cy="77.80000000000001" r="32.8"/>
-        <text x="1181.6" y="77.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">Circle</text>
+        <text x="1181.6" y="77.80000000000001" class="label" dominant-baseline="central" text-anchor="middle">Circle</text>
       </g>
     </g>
   </g>

--- a/docs/images/flowchart.svg
+++ b/docs/images/flowchart.svg
@@ -105,31 +105,31 @@ marker path {
     </g>
     <g class="edgePaths">
       <g class="edge" id="edge-L-A-B-0">
-        <path d="M 80.00 77.80 C 88.33 77.80, 96.67 77.80, 105.00 77.80 C 113.33 77.80, 121.67 77.80, 130.00 77.80" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 80.00 77.80 C 88.33 77.80, 96.67 77.80, 105.00 77.80 C 113.33 77.80, 121.67 77.80, 130.00 77.80" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-B-C-0">
-        <path d="M 238.28 56.48 L 339.60 26.40" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 238.28 56.48 L 339.60 26.40" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-B-D-0">
-        <path d="M 238.28 99.12 L 339.60 129.20" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 238.28 99.12 L 339.60 129.20" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-C-E-0">
-        <path d="M 448.40 26.40 L 500.35 51.40" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 448.40 26.40 L 500.35 51.40" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-D-E-0">
-        <path d="M 448.40 129.20 L 500.35 104.20" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 448.40 129.20 L 500.35 104.20" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-E-F-0">
-        <path d="M 559.20 77.80 C 567.53 77.80, 575.87 77.80, 584.20 77.80 C 592.53 77.80, 600.87 77.80, 609.20 77.80" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 559.20 77.80 C 567.53 77.80, 575.87 77.80, 584.20 77.80 C 592.53 77.80, 600.87 77.80, 609.20 77.80" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-F-G-0">
-        <path d="M 742.00 77.80 C 750.33 77.80, 758.67 77.80, 767.00 77.80 C 775.33 77.80, 783.67 77.80, 792.00 77.80" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 742.00 77.80 C 750.33 77.80, 758.67 77.80, 767.00 77.80 C 775.33 77.80, 783.67 77.80, 792.00 77.80" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-G-H-0">
-        <path d="M 940.00 77.80 C 948.33 77.80, 956.67 77.80, 965.00 77.80 C 973.33 77.80, 981.67 77.80, 990.00 77.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 940.00 77.80 C 948.33 77.80, 956.67 77.80, 965.00 77.80 C 973.33 77.80, 981.67 77.80, 990.00 77.80" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-H-I-0">
-        <path d="M 1098.80 77.80 C 1107.13 77.80, 1115.47 77.80, 1123.80 77.80 C 1132.13 77.80, 1140.47 77.80, 1148.80 77.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_circle)" marker-start="url(#arrow_circle_start)"/>
+        <path d="M 1098.80 77.80 C 1107.13 77.80, 1115.47 77.80, 1123.80 77.80 C 1132.13 77.80, 1140.47 77.80, 1148.80 77.80" class="edge-path" fill="none" marker-start="url(#arrow_circle_start)" stroke-width="1" marker-end="url(#arrow_circle)"/>
       </g>
     </g>
     <g class="edgeLabels">
@@ -139,17 +139,17 @@ marker path {
       </g>
       <g class="edgeLabel" id="edge-label-L-B-D-0">
         <rect x="275.6948393648911" y="111.96865213125383" width="22.4" height="22" class="edge-label-bg"/>
-        <text x="286.8948393648911" y="122.96865213125383" class="edge-label" text-anchor="middle" dominant-baseline="central">No</text>
+        <text x="286.8948393648911" y="122.96865213125383" class="edge-label" dominant-baseline="central" text-anchor="middle">No</text>
       </g>
     </g>
     <g class="nodes">
       <g class="node" id="node-A">
         <rect x="0" y="51.40000000000001" width="80" height="52.8"/>
-        <text x="40" y="77.80000000000001" class="label" dominant-baseline="central" text-anchor="middle">Start</text>
+        <text x="40" y="77.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">Start</text>
       </g>
       <g class="node" id="node-B">
         <polygon points="194.8,13.000000000000014 259.6,77.80000000000001 194.8,142.60000000000002 130,77.80000000000001"/>
-        <text x="194.8" y="77.80000000000001" class="label" dominant-baseline="central" text-anchor="middle">Decision</text>
+        <text x="194.8" y="77.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">Decision</text>
       </g>
       <g class="node" id="node-C">
         <rect x="339.6" y="0" width="108.8" height="52.8"/>
@@ -169,7 +169,7 @@ marker path {
       </g>
       <g class="node" id="node-G">
         <polygon points="802,51.40000000000001 930,51.40000000000001 930,104.20000000000002 802,104.20000000000002 802,51.40000000000001 792,51.40000000000001 940,51.40000000000001 940,104.20000000000002 792,104.20000000000002 792,51.40000000000001"/>
-        <text x="866" y="77.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">Subroutine</text>
+        <text x="866" y="77.80000000000001" class="label" dominant-baseline="central" text-anchor="middle">Subroutine</text>
       </g>
       <g class="node" id="node-H">
         <path d="M 990.0000000000001 53.77600000000001 a 54.4 10.296 0 0 0 108.8 0 a 54.4 10.296 0 0 0 -108.8 0 l 0 48.048 a 54.4 10.296 0 0 0 108.8 0 l 0 -48.048"/>

--- a/docs/images/flowchart_complex.svg
+++ b/docs/images/flowchart_complex.svg
@@ -87,7 +87,7 @@ marker path {
       <path d="M 0 5 L 10 10 L 10 0 z"/>
     </marker>
     <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
@@ -123,52 +123,52 @@ marker path {
         <path d="M 601.90 77.80 C 601.90 102.80, 601.90 127.80, 572.48 154.89 C 543.06 181.99, 484.21 211.18, 425.37 240.37" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-Mobile-Auth-0">
-        <path d="M 409.50 77.80 L 389.24 204.24" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 409.50 77.80 L 389.24 204.24" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-CLI-Auth-0">
-        <path d="M 241.10 77.80 L 315.40 225.20" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 241.10 77.80 L 315.40 225.20" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-Auth-Rate-0">
-        <path d="M 401.51 326.29 L 453.50 435.00" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 401.51 326.29 L 453.50 435.00" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-Auth-Reject-0">
-        <path d="M 334.19 336.39 C 324.86 357.60, 315.53 378.80, 287.57 395.81 C 259.60 412.83, 213.00 425.66, 166.40 438.49" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 334.19 336.39 C 324.86 357.60, 315.53 378.80, 287.57 395.81 C 259.60 412.83, 213.00 425.66, 166.40 438.49" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Rate-Cache-0">
-        <path d="M 453.50 487.80 C 453.50 496.13, 453.50 504.47, 453.50 512.80 C 453.50 521.13, 453.50 529.47, 453.50 537.80 C 453.50 554.47, 453.50 562.80, 453.50 562.80" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 453.50 487.80 C 453.50 496.13, 453.50 504.47, 453.50 512.80 C 453.50 521.13, 453.50 529.47, 453.50 537.80 C 453.50 554.47, 453.50 562.80, 453.50 562.80" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-Cache-Response-0">
-        <path d="M 400.85 631.44 L 362.50 726.44" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 400.85 631.44 L 362.50 726.44" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Cache-UserSvc-0">
-        <path d="M 516.39 631.44 C 566.33 651.44, 616.26 671.44, 641.23 687.27 C 666.20 703.11, 666.20 714.77, 666.20 726.44" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 516.39 631.44 C 566.33 651.44, 616.26 671.44, 641.23 687.27 C 666.20 703.11, 666.20 714.77, 666.20 726.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-UserSvc-DB-0">
-        <path d="M 715.61 779.24 L 798.73 879.24" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 715.61 779.24 L 798.73 879.24" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-UserSvc-Search-0">
-        <path d="M 661.06 779.24 C 659.44 787.57, 657.82 795.91, 657.01 804.24 C 656.20 812.57, 656.20 820.91, 656.20 829.24 C 656.20 837.57, 656.20 845.91, 656.20 854.24 C 656.20 870.91, 656.20 879.24, 656.20 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 661.06 779.24 C 659.44 787.57, 657.82 795.91, 657.01 804.24 C 656.20 812.57, 656.20 820.91, 656.20 829.24 C 656.20 837.57, 656.20 845.91, 656.20 854.24 C 656.20 870.91, 656.20 879.24, 656.20 879.24" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-OrderSvc-DB-0">
-        <path d="M 1148.40 766.64 C 1077.20 779.17, 1006.00 791.71, 964.35 810.47 C 922.69 829.24, 910.58 854.24, 898.47 879.24" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 1148.40 766.64 C 1077.20 779.17, 1006.00 791.71, 964.35 810.47 C 922.69 829.24, 910.58 854.24, 898.47 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-OrderSvc-Queue-0">
-        <path d="M 1226.80 779.24 L 1195.61 879.24" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 1226.80 779.24 L 1195.61 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-PaymentSvc-DB-0">
-        <path d="M 880.19 623.52 L 843.28 879.24" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 880.19 623.52 L 843.28 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-PaymentSvc-NotifySvc-0">
         <path d="M 945.61 623.52 L 986.40 726.44" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-NotifySvc-Queue-0">
-        <path d="M 986.40 779.24 C 986.40 804.24, 986.40 829.24, 1001.07 846.97 C 1015.73 864.70, 1045.07 875.15, 1074.40 885.61" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 986.40 779.24 C 986.40 804.24, 986.40 829.24, 1001.07 846.97 C 1015.73 864.70, 1045.07 875.15, 1074.40 885.61" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-Queue-EmailWorker-0">
-        <path d="M 1074.40 926.81 C 983.57 942.17, 892.73 957.52, 847.32 973.54 C 801.90 989.55, 801.90 1006.21, 801.90 1022.88" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 1074.40 926.81 C 983.57 942.17, 892.73 957.52, 847.32 973.54 C 801.90 989.55, 801.90 1006.21, 801.90 1022.88" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-Queue-SMSWorker-0">
-        <path d="M 1195.61 947.88 L 1226.80 1022.88" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 1195.61 947.88 L 1226.80 1022.88" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
     </g>
     <g class="edgeLabels">
@@ -186,17 +186,17 @@ marker path {
       </g>
       <g class="edgeLabel" id="edge-label-L-Cache-UserSvc-0">
         <rect x="566.0546670620357" y="660.1987821843388" width="80" height="22" class="edge-label-bg"/>
-        <text x="606.0546670620357" y="671.1987821843388" class="edge-label" text-anchor="middle" dominant-baseline="central">Cache Miss</text>
+        <text x="606.0546670620357" y="671.1987821843388" class="edge-label" dominant-baseline="central" text-anchor="middle">Cache Miss</text>
       </g>
     </g>
     <g class="nodes">
       <g class="node" id="node-Auth">
         <polygon points="362.79999999999995,177.79999999999998 456.3999999999999,271.4 362.79999999999995,365 269.19999999999993,271.4"/>
-        <text x="362.79999999999995" y="271.4" class="label" text-anchor="middle" dominant-baseline="central">Authentication</text>
+        <text x="362.79999999999995" y="271.4" class="label" dominant-baseline="central" text-anchor="middle">Authentication</text>
       </g>
       <g class="node" id="node-CLI">
         <rect x="186.70000000000013" y="25" width="108.8" height="52.8"/>
-        <text x="241.10000000000014" y="51.4" class="label" dominant-baseline="central" text-anchor="middle">CLI Tool</text>
+        <text x="241.10000000000014" y="51.4" class="label" text-anchor="middle" dominant-baseline="central">CLI Tool</text>
       </g>
       <g class="node" id="node-Cache">
         <path d="M 384.7 573.096 a 68.8 10.296 0 0 0 137.6 0 a 68.8 10.296 0 0 0 -137.6 0 l 0 48.048 a 68.8 10.296 0 0 0 137.6 0 l 0 -48.048"/>
@@ -204,11 +204,11 @@ marker path {
       </g>
       <g class="node" id="node-DB">
         <path d="M 784.6 889.536 a 64 10.296 0 0 0 128 0 a 64 10.296 0 0 0 -128 0 l 0 48.048 a 64 10.296 0 0 0 128 0 l 0 -48.048"/>
-        <text x="848.6" y="913.56" class="label" dominant-baseline="central" text-anchor="middle">PostgreSQL</text>
+        <text x="848.6" y="913.56" class="label" text-anchor="middle" dominant-baseline="central">PostgreSQL</text>
       </g>
       <g class="node" id="node-EmailWorker">
         <rect x="728.3000000000001" y="1022.88" width="147.2" height="52.8"/>
-        <text x="801.9000000000001" y="1049.28" class="label" dominant-baseline="central" text-anchor="middle">Email Worker</text>
+        <text x="801.9000000000001" y="1049.28" class="label" text-anchor="middle" dominant-baseline="central">Email Worker</text>
       </g>
       <g class="node" id="node-Mobile">
         <rect x="345.5" y="25" width="128" height="52.8"/>
@@ -220,7 +220,7 @@ marker path {
       </g>
       <g class="node" id="node-OrderSvc">
         <rect x="1148.3999999999999" y="726.4399999999999" width="156.8" height="52.8"/>
-        <text x="1226.8" y="752.8399999999999" class="label" text-anchor="middle" dominant-baseline="central">Order Service</text>
+        <text x="1226.8" y="752.8399999999999" class="label" dominant-baseline="central" text-anchor="middle">Order Service</text>
       </g>
       <g class="node" id="node-PaymentSvc">
         <rect x="824.9" y="570.72" width="176" height="52.8"/>
@@ -236,11 +236,11 @@ marker path {
       </g>
       <g class="node" id="node-Reject">
         <rect x="0.00000000000004263256414560601" y="435" width="166.4" height="52.8"/>
-        <text x="83.20000000000005" y="461.4" class="label" dominant-baseline="central" text-anchor="middle">Reject Request</text>
+        <text x="83.20000000000005" y="461.4" class="label" text-anchor="middle" dominant-baseline="central">Reject Request</text>
       </g>
       <g class="node" id="node-Response">
         <rect x="274.5" y="726.4399999999999" width="176" height="52.8"/>
-        <text x="362.5" y="752.8399999999999" class="label" dominant-baseline="central" text-anchor="middle">Return Response</text>
+        <text x="362.5" y="752.8399999999999" class="label" text-anchor="middle" dominant-baseline="central">Return Response</text>
       </g>
       <g class="node" id="node-SMSWorker">
         <rect x="1162.8" y="1022.88" width="128" height="52.8"/>
@@ -252,7 +252,7 @@ marker path {
       </g>
       <g class="node" id="node-UI">
         <rect x="523.5000000000001" y="25" width="156.8" height="52.8"/>
-        <text x="601.9000000000001" y="51.4" class="label" text-anchor="middle" dominant-baseline="central">Web Interface</text>
+        <text x="601.9000000000001" y="51.4" class="label" dominant-baseline="central" text-anchor="middle">Web Interface</text>
       </g>
       <g class="node" id="node-UserSvc">
         <rect x="592.6" y="726.4399999999999" width="147.2" height="52.8"/>

--- a/docs/images/flowchart_complex.svg
+++ b/docs/images/flowchart_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1361.2000000000003" height="1111.68" viewBox="-8 -28 1361.2000000000003 1111.68" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1361.2000000000003" height="1107.68" viewBox="-8 -24 1361.2000000000003 1107.68" class="mermaid">
   <style>
 
 .mermaid {
@@ -87,10 +87,10 @@ marker path {
       <path d="M 0 5 L 10 10 L 10 0 z"/>
     </marker>
     <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
     </marker>
     <marker id="arrow_circle" viewBox="0 0 10 10" refX="11" refY="5" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <circle cx="5" cy="5" r="5"/>
@@ -102,31 +102,31 @@ marker path {
   <g class="root">
     <g class="clusters">
       <g class="subgraph" id="subgraph-Frontend">
-        <rect x="166.70000000000013" y="-20" width="533.6" height="117.8" class="cluster"/>
-        <text x="433.5000000000001" y="-4" class="cluster-label" text-anchor="middle">Frontend Layer</text>
+        <rect x="170.70000000000013" y="-16" width="525.6" height="109.8" class="cluster"/>
+        <text x="433.5000000000001" y="0" class="cluster-label" text-anchor="middle">Frontend Layer</text>
       </g>
       <g class="subgraph" id="subgraph-API">
-        <rect x="249.19999999999993" y="132.79999999999998" width="297.9" height="518.64" class="cluster"/>
-        <text x="398.1499999999999" y="148.79999999999998" class="cluster-label" text-anchor="middle">API Gateway</text>
+        <rect x="253.19999999999993" y="136.79999999999998" width="289.9" height="510.64" class="cluster"/>
+        <text x="398.1499999999999" y="152.79999999999998" class="cluster-label" text-anchor="middle">API Gateway</text>
       </g>
       <g class="subgraph" id="subgraph-Services">
-        <rect x="572.6" y="525.72" width="752.5999999999998" height="273.51999999999987" class="cluster"/>
-        <text x="948.8999999999999" y="541.72" class="cluster-label" text-anchor="middle">Microservices</text>
+        <rect x="576.6" y="529.72" width="744.5999999999998" height="265.51999999999987" class="cluster"/>
+        <text x="948.8999999999999" y="545.72" class="cluster-label" text-anchor="middle">Microservices</text>
       </g>
       <g class="subgraph" id="subgraph-Data">
-        <rect x="557.8000000000001" y="834.2399999999999" width="693.3999999999997" height="133.64" class="cluster"/>
-        <text x="904.5" y="850.2399999999999" class="cluster-label" text-anchor="middle">Data Layer</text>
+        <rect x="561.8000000000001" y="838.2399999999999" width="685.3999999999997" height="125.63999999999999" class="cluster"/>
+        <text x="904.5" y="854.2399999999999" class="cluster-label" text-anchor="middle">Data Layer</text>
       </g>
     </g>
     <g class="edgePaths">
       <g class="edge" id="edge-L-UI-Auth-0">
-        <path d="M 601.90 77.80 C 601.90 102.80, 601.90 127.80, 572.48 154.89 C 543.06 181.99, 484.21 211.18, 425.37 240.37" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 601.90 77.80 C 601.90 102.80, 601.90 127.80, 572.48 154.89 C 543.06 181.99, 484.21 211.18, 425.37 240.37" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Mobile-Auth-0">
-        <path d="M 409.50 77.80 L 389.24 204.24" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 409.50 77.80 L 389.24 204.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-CLI-Auth-0">
-        <path d="M 241.10 77.80 L 315.40 225.20" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 241.10 77.80 L 315.40 225.20" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Auth-Rate-0">
         <path d="M 401.51 326.29 L 453.50 435.00" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
@@ -135,25 +135,25 @@ marker path {
         <path d="M 334.19 336.39 C 324.86 357.60, 315.53 378.80, 287.57 395.81 C 259.60 412.83, 213.00 425.66, 166.40 438.49" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Rate-Cache-0">
-        <path d="M 453.50 487.80 C 453.50 496.13, 453.50 504.47, 453.50 512.80 C 453.50 521.13, 453.50 529.47, 453.50 537.80 C 453.50 554.47, 453.50 562.80, 453.50 562.80" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 453.50 487.80 C 453.50 496.13, 453.50 504.47, 453.50 512.80 C 453.50 521.13, 453.50 529.47, 453.50 537.80 C 453.50 554.47, 453.50 562.80, 453.50 562.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Cache-Response-0">
-        <path d="M 400.85 631.44 L 362.50 726.44" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 400.85 631.44 L 362.50 726.44" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-Cache-UserSvc-0">
-        <path d="M 516.39 631.44 C 566.33 651.44, 616.26 671.44, 641.23 687.27 C 666.20 703.11, 666.20 714.77, 666.20 726.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 516.39 631.44 C 566.33 651.44, 616.26 671.44, 641.23 687.27 C 666.20 703.11, 666.20 714.77, 666.20 726.44" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-UserSvc-DB-0">
-        <path d="M 715.61 779.24 L 798.73 879.24" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 715.61 779.24 L 798.73 879.24" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-UserSvc-Search-0">
         <path d="M 661.06 779.24 C 659.44 787.57, 657.82 795.91, 657.01 804.24 C 656.20 812.57, 656.20 820.91, 656.20 829.24 C 656.20 837.57, 656.20 845.91, 656.20 854.24 C 656.20 870.91, 656.20 879.24, 656.20 879.24" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-OrderSvc-DB-0">
-        <path d="M 1148.40 766.64 C 1077.20 779.17, 1006.00 791.71, 964.35 810.47 C 922.69 829.24, 910.58 854.24, 898.47 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 1148.40 766.64 C 1077.20 779.17, 1006.00 791.71, 964.35 810.47 C 922.69 829.24, 910.58 854.24, 898.47 879.24" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-OrderSvc-Queue-0">
-        <path d="M 1226.80 779.24 L 1195.61 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 1226.80 779.24 L 1195.61 879.24" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-PaymentSvc-DB-0">
         <path d="M 880.19 623.52 L 843.28 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
@@ -162,19 +162,19 @@ marker path {
         <path d="M 945.61 623.52 L 986.40 726.44" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-NotifySvc-Queue-0">
-        <path d="M 986.40 779.24 C 986.40 804.24, 986.40 829.24, 1001.07 846.97 C 1015.73 864.70, 1045.07 875.15, 1074.40 885.61" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 986.40 779.24 C 986.40 804.24, 986.40 829.24, 1001.07 846.97 C 1015.73 864.70, 1045.07 875.15, 1074.40 885.61" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-Queue-EmailWorker-0">
         <path d="M 1074.40 926.81 C 983.57 942.17, 892.73 957.52, 847.32 973.54 C 801.90 989.55, 801.90 1006.21, 801.90 1022.88" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-Queue-SMSWorker-0">
-        <path d="M 1195.61 947.88 L 1226.80 1022.88" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 1195.61 947.88 L 1226.80 1022.88" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
     </g>
     <g class="edgeLabels">
       <g class="edgeLabel" id="edge-label-L-Auth-Rate-0">
         <rect x="415.5922301020454" y="366.4449921843775" width="44" height="22" class="edge-label-bg"/>
-        <text x="437.5922301020454" y="377.4449921843775" class="edge-label" text-anchor="middle" dominant-baseline="central">Valid</text>
+        <text x="437.5922301020454" y="377.4449921843775" class="edge-label" dominant-baseline="central" text-anchor="middle">Valid</text>
       </g>
       <g class="edgeLabel" id="edge-label-L-Auth-Reject-0">
         <rect x="240.60016784660485" y="399.0221959381994" width="58.4" height="22" class="edge-label-bg"/>
@@ -182,11 +182,11 @@ marker path {
       </g>
       <g class="edgeLabel" id="edge-label-L-Cache-Response-0">
         <rect x="326.1" y="657.5499183338633" width="72.8" height="22" class="edge-label-bg"/>
-        <text x="362.5" y="668.5499183338633" class="edge-label" text-anchor="middle" dominant-baseline="central">Cache Hit</text>
+        <text x="362.5" y="668.5499183338633" class="edge-label" dominant-baseline="central" text-anchor="middle">Cache Hit</text>
       </g>
       <g class="edgeLabel" id="edge-label-L-Cache-UserSvc-0">
         <rect x="566.0546670620357" y="660.1987821843388" width="80" height="22" class="edge-label-bg"/>
-        <text x="606.0546670620357" y="671.1987821843388" class="edge-label" dominant-baseline="central" text-anchor="middle">Cache Miss</text>
+        <text x="606.0546670620357" y="671.1987821843388" class="edge-label" text-anchor="middle" dominant-baseline="central">Cache Miss</text>
       </g>
     </g>
     <g class="nodes">
@@ -204,11 +204,11 @@ marker path {
       </g>
       <g class="node" id="node-DB">
         <path d="M 784.6 889.536 a 64 10.296 0 0 0 128 0 a 64 10.296 0 0 0 -128 0 l 0 48.048 a 64 10.296 0 0 0 128 0 l 0 -48.048"/>
-        <text x="848.6" y="913.56" class="label" text-anchor="middle" dominant-baseline="central">PostgreSQL</text>
+        <text x="848.6" y="913.56" class="label" dominant-baseline="central" text-anchor="middle">PostgreSQL</text>
       </g>
       <g class="node" id="node-EmailWorker">
         <rect x="728.3000000000001" y="1022.88" width="147.2" height="52.8"/>
-        <text x="801.9000000000001" y="1049.28" class="label" text-anchor="middle" dominant-baseline="central">Email Worker</text>
+        <text x="801.9000000000001" y="1049.28" class="label" dominant-baseline="central" text-anchor="middle">Email Worker</text>
       </g>
       <g class="node" id="node-Mobile">
         <rect x="345.5" y="25" width="128" height="52.8"/>
@@ -228,11 +228,11 @@ marker path {
       </g>
       <g class="node" id="node-Queue">
         <path d="M 1074.3999999999999 889.536 a 78.4 10.296 0 0 0 156.8 0 a 78.4 10.296 0 0 0 -156.8 0 l 0 48.048 a 78.4 10.296 0 0 0 156.8 0 l 0 -48.048"/>
-        <text x="1152.8" y="913.56" class="label" text-anchor="middle" dominant-baseline="central">Message Queue</text>
+        <text x="1152.8" y="913.56" class="label" dominant-baseline="central" text-anchor="middle">Message Queue</text>
       </g>
       <g class="node" id="node-Rate">
         <rect x="379.9" y="435" width="147.2" height="52.8"/>
-        <text x="453.5" y="461.4" class="label" text-anchor="middle" dominant-baseline="central">Rate Limiter</text>
+        <text x="453.5" y="461.4" class="label" dominant-baseline="central" text-anchor="middle">Rate Limiter</text>
       </g>
       <g class="node" id="node-Reject">
         <rect x="0.00000000000004263256414560601" y="435" width="166.4" height="52.8"/>
@@ -240,11 +240,11 @@ marker path {
       </g>
       <g class="node" id="node-Response">
         <rect x="274.5" y="726.4399999999999" width="176" height="52.8"/>
-        <text x="362.5" y="752.8399999999999" class="label" text-anchor="middle" dominant-baseline="central">Return Response</text>
+        <text x="362.5" y="752.8399999999999" class="label" dominant-baseline="central" text-anchor="middle">Return Response</text>
       </g>
       <g class="node" id="node-SMSWorker">
         <rect x="1162.8" y="1022.88" width="128" height="52.8"/>
-        <text x="1226.8" y="1049.28" class="label" dominant-baseline="central" text-anchor="middle">SMS Worker</text>
+        <text x="1226.8" y="1049.28" class="label" text-anchor="middle" dominant-baseline="central">SMS Worker</text>
       </g>
       <g class="node" id="node-Search">
         <path d="M 577.8000000000001 889.536 a 78.4 10.296 0 0 0 156.8 0 a 78.4 10.296 0 0 0 -156.8 0 l 0 48.048 a 78.4 10.296 0 0 0 156.8 0 l 0 -48.048"/>
@@ -256,7 +256,7 @@ marker path {
       </g>
       <g class="node" id="node-UserSvc">
         <rect x="592.6" y="726.4399999999999" width="147.2" height="52.8"/>
-        <text x="666.2" y="752.8399999999999" class="label" text-anchor="middle" dominant-baseline="central">User Service</text>
+        <text x="666.2" y="752.8399999999999" class="label" dominant-baseline="central" text-anchor="middle">User Service</text>
       </g>
     </g>
   </g>

--- a/docs/images/flowchart_full.svg
+++ b/docs/images/flowchart_full.svg
@@ -116,83 +116,83 @@ marker path {
     </g>
     <g class="edgePaths">
       <g class="edge" id="edge-L-A-B-0">
-        <path d="M 415.00 77.80 C 415.00 86.13, 415.00 94.47, 415.00 102.80 C 415.00 111.13, 415.00 119.47, 415.00 127.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 415.00 77.80 C 415.00 86.13, 415.00 94.47, 415.00 102.80 C 415.00 111.13, 415.00 119.47, 415.00 127.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-B-C-0">
-        <path d="M 415.00 180.60 C 415.00 188.93, 415.00 197.27, 415.00 205.60 C 415.00 213.93, 415.00 222.27, 415.00 230.60" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 415.00 180.60 C 415.00 188.93, 415.00 197.27, 415.00 205.60 C 415.00 213.93, 415.00 222.27, 415.00 230.60" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-C-D-0">
-        <path d="M 371.68 393.68 L 315.00 507.00" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 371.68 393.68 L 315.00 507.00" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-C-E-0">
-        <path d="M 458.32 393.68 L 515.00 507.00" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 458.32 393.68 L 515.00 507.00" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-D-F-0">
         <path d="M 315.00 559.80 L 357.14 609.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-E-F-0">
-        <path d="M 515.00 559.80 L 472.86 609.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 515.00 559.80 L 472.86 609.80" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-G-H-0">
-        <path d="M 415.00 844.04 C 415.00 852.37, 415.00 860.71, 415.00 869.04 C 415.00 877.37, 415.00 885.71, 415.00 894.04" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 415.00 844.04 C 415.00 852.37, 415.00 860.71, 415.00 869.04 C 415.00 877.37, 415.00 885.71, 415.00 894.04" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-H-I-0">
         <path d="M 415.00 946.84 C 415.00 955.17, 415.00 963.51, 415.00 971.84 C 415.00 980.17, 415.00 988.51, 415.00 996.84" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-I-J-0">
-        <path d="M 415.00 1049.64 C 415.00 1057.97, 415.00 1066.31, 415.00 1074.64 C 415.00 1082.97, 415.00 1091.31, 415.00 1099.64" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 415.00 1049.64 C 415.00 1057.97, 415.00 1066.31, 415.00 1074.64 C 415.00 1082.97, 415.00 1091.31, 415.00 1099.64" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-J-K-0">
-        <path d="M 415.00 1152.44 C 415.00 1160.77, 415.00 1169.11, 415.00 1177.44 C 415.00 1185.77, 415.00 1194.11, 415.00 1202.44" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 415.00 1152.44 C 415.00 1160.77, 415.00 1169.11, 415.00 1177.44 C 415.00 1185.77, 415.00 1194.11, 415.00 1202.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-K-L-0">
         <path d="M 415.00 1255.24 C 415.00 1263.57, 415.00 1271.91, 415.00 1280.24 C 415.00 1288.57, 415.00 1296.91, 415.00 1305.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-L-M-0">
-        <path d="M 415.00 1358.04 C 415.00 1366.37, 415.00 1374.71, 415.00 1383.04 C 415.00 1391.37, 415.00 1399.71, 415.00 1408.04" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 415.00 1358.04 C 415.00 1366.37, 415.00 1374.71, 415.00 1383.04 C 415.00 1391.37, 415.00 1399.71, 415.00 1408.04" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-M-N-0">
         <path d="M 415.00 1460.84 C 415.00 1469.17, 415.00 1477.51, 415.00 1485.84 C 415.00 1494.17, 415.00 1502.51, 415.00 1510.84" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-O-P-0">
-        <path d="M 390.00 1773.71 C 281.67 1789.62, 173.33 1805.53, 119.17 1817.65 C 65.00 1829.77, 65.00 1838.11, 65.00 1846.44" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 390.00 1773.71 C 281.67 1789.62, 173.33 1805.53, 119.17 1817.65 C 65.00 1829.77, 65.00 1838.11, 65.00 1846.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-O-Q-0">
-        <path d="M 390.00 1775.18 C 315.00 1790.60, 240.00 1806.02, 202.50 1817.90 C 165.00 1829.77, 165.00 1838.11, 165.00 1846.44" class="edge-path" stroke-width="1" fill="none"/>
+        <path d="M 390.00 1775.18 C 315.00 1790.60, 240.00 1806.02, 202.50 1817.90 C 165.00 1829.77, 165.00 1838.11, 165.00 1846.44" class="edge-path" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-O-R-0">
-        <path d="M 390.00 1778.61 C 348.33 1792.88, 306.67 1807.16, 285.83 1818.47 C 265.00 1829.77, 265.00 1838.11, 265.00 1846.44" class="edge-path" stroke-dasharray="3,3" fill="none" stroke-width="2"/>
+        <path d="M 390.00 1778.61 C 348.33 1792.88, 306.67 1807.16, 285.83 1818.47 C 265.00 1829.77, 265.00 1838.11, 265.00 1846.44" class="edge-path" stroke-dasharray="3,3" stroke-width="2" fill="none"/>
       </g>
       <g class="edge" id="edge-L-O-S-0">
-        <path d="M 390.00 1795.74 L 365.00 1846.44" class="edge-path" marker-end="url(#arrow_point)" stroke-width="2" stroke-dasharray="3,3" fill="none"/>
+        <path d="M 390.00 1795.74 L 365.00 1846.44" class="edge-path" fill="none" stroke-dasharray="3,3" stroke-width="2" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-O-T-0">
-        <path d="M 440.00 1795.74 L 465.00 1846.44" class="edge-path" stroke-width="3.5" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 440.00 1795.74 L 465.00 1846.44" class="edge-path" fill="none" stroke-width="3.5" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-O-U-0">
-        <path d="M 440.00 1778.61 C 481.67 1792.88, 523.33 1807.16, 544.17 1818.47 C 565.00 1829.77, 565.00 1838.11, 565.00 1846.44" class="edge-path" marker-start="url(#arrow_point_start)" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 440.00 1778.61 C 481.67 1792.88, 523.33 1807.16, 544.17 1818.47 C 565.00 1829.77, 565.00 1838.11, 565.00 1846.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" marker-start="url(#arrow_point_start)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-O-V-0">
-        <path d="M 440.00 1775.18 C 515.00 1790.60, 590.00 1806.02, 627.50 1817.90 C 665.00 1829.77, 665.00 1838.11, 665.00 1846.44" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_cross)" marker-start="url(#arrow_cross_start)"/>
+        <path d="M 440.00 1775.18 C 515.00 1790.60, 590.00 1806.02, 627.50 1817.90 C 665.00 1829.77, 665.00 1838.11, 665.00 1846.44" class="edge-path" fill="none" marker-end="url(#arrow_cross)" marker-start="url(#arrow_cross_start)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-O-W-0">
-        <path d="M 440.00 1773.71 C 548.33 1789.62, 656.67 1805.53, 710.83 1817.65 C 765.00 1829.77, 765.00 1838.11, 765.00 1846.44" class="edge-path" fill="none" marker-end="url(#arrow_circle)" stroke-width="1" marker-start="url(#arrow_circle_start)"/>
+        <path d="M 440.00 1773.71 C 548.33 1789.62, 656.67 1805.53, 710.83 1817.65 C 765.00 1829.77, 765.00 1838.11, 765.00 1846.44" class="edge-path" marker-end="url(#arrow_circle)" marker-start="url(#arrow_circle_start)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-F-G-0">
         <path d="M 415.00 678.44 C 415.00 686.77, 415.00 695.11, 415.00 703.44 C 415.00 711.77, 415.00 720.11, 415.00 728.44 C 415.00 736.77, 415.00 745.11, 415.00 753.44 C 415.00 770.11, 415.00 778.44, 415.00 778.44" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-N-O-0">
-        <path d="M 415.00 1643.64 C 415.00 1651.97, 415.00 1660.31, 415.00 1668.64 C 415.00 1676.97, 415.00 1685.31, 415.00 1693.64 C 415.00 1701.97, 415.00 1710.31, 415.00 1718.64 C 415.00 1735.31, 415.00 1743.64, 415.00 1743.64" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 415.00 1643.64 C 415.00 1651.97, 415.00 1660.31, 415.00 1668.64 C 415.00 1676.97, 415.00 1685.31, 415.00 1693.64 C 415.00 1701.97, 415.00 1710.31, 415.00 1718.64 C 415.00 1735.31, 415.00 1743.64, 415.00 1743.64" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
     </g>
     <g class="edgeLabels">
       <g class="edgeLabel" id="edge-label-L-C-D-0">
         <rect x="318.2787158405461" y="436.01521470836525" width="29.599999999999998" height="22" class="edge-label-bg"/>
-        <text x="333.0787158405461" y="447.01521470836525" class="edge-label" text-anchor="middle" dominant-baseline="central">Yes</text>
+        <text x="333.0787158405461" y="447.01521470836525" class="edge-label" dominant-baseline="central" text-anchor="middle">Yes</text>
       </g>
       <g class="edgeLabel" id="edge-label-L-C-E-0">
         <rect x="485.7212841594539" y="436.01521470836525" width="22.4" height="22" class="edge-label-bg"/>
-        <text x="496.9212841594539" y="447.01521470836525" class="edge-label" text-anchor="middle" dominant-baseline="central">No</text>
+        <text x="496.9212841594539" y="447.01521470836525" class="edge-label" dominant-baseline="central" text-anchor="middle">No</text>
       </g>
     </g>
     <g class="nodes">
@@ -206,15 +206,15 @@ marker path {
       </g>
       <g class="node" id="node-C">
         <polygon points="415,230.60000000000002 518.2,333.8 415,437 311.8,333.8"/>
-        <text x="415" y="333.8" class="label" text-anchor="middle" dominant-baseline="central">Diamond Decision</text>
+        <text x="415" y="333.8" class="label" dominant-baseline="central" text-anchor="middle">Diamond Decision</text>
       </g>
       <g class="node" id="node-D">
         <path d="M 265.4 507 H 364.6 A 26.4 26.4 0 0 1 364.6 559.8 H 265.4 A 26.4 26.4 0 0 1 265.4 507 Z"/>
-        <text x="315" y="533.4" class="label" text-anchor="middle" dominant-baseline="central">Stadium</text>
+        <text x="315" y="533.4" class="label" dominant-baseline="central" text-anchor="middle">Stadium</text>
       </g>
       <g class="node" id="node-E">
         <polygon points="451,507 579,507 579,559.8 451,559.8 451,507 441,507 589,507 589,559.8 441,559.8 441,507"/>
-        <text x="515" y="533.4" class="label" dominant-baseline="central" text-anchor="middle">Subroutine</text>
+        <text x="515" y="533.4" class="label" text-anchor="middle" dominant-baseline="central">Subroutine</text>
       </g>
       <g class="node" id="node-F">
         <path d="M 346.2 620.096 a 68.8 10.296 0 0 0 137.6 0 a 68.8 10.296 0 0 0 -137.6 0 l 0 48.048 a 68.8 10.296 0 0 0 137.6 0 l 0 -48.048"/>
@@ -226,7 +226,7 @@ marker path {
       </g>
       <g class="node" id="node-H">
         <path d="M 344.6 894.04 L 485.40000000000003 894.04 L 464.28000000000003 920.4399999999999 L 485.40000000000003 946.8399999999999 L 344.6 946.8399999999999 Z"/>
-        <text x="415" y="920.4399999999999" class="label" text-anchor="middle" dominant-baseline="central">Asymmetric</text>
+        <text x="415" y="920.4399999999999" class="label" dominant-baseline="central" text-anchor="middle">Asymmetric</text>
       </g>
       <g class="node" id="node-I">
         <polygon points="349.144,996.84 509.08000000000004,996.84 480.85600000000005,1049.64 320.92,1049.64"/>
@@ -246,7 +246,7 @@ marker path {
       </g>
       <g class="node" id="node-M">
         <path d="M 373.336 1408.0399999999997 L 456.664 1408.0399999999997 L 474.52 1434.4399999999998 L 456.664 1460.8399999999997 L 373.336 1460.8399999999997 L 355.48 1434.4399999999998 Z"/>
-        <text x="415" y="1434.4399999999998" class="label" dominant-baseline="central" text-anchor="middle">Hexagon</text>
+        <text x="415" y="1434.4399999999998" class="label" text-anchor="middle" dominant-baseline="central">Hexagon</text>
       </g>
       <g class="node" id="node-N">
         <g>
@@ -257,7 +257,7 @@ marker path {
       </g>
       <g class="node" id="node-O">
         <rect x="390" y="1743.6399999999996" width="50" height="52.8"/>
-        <text x="415" y="1770.0399999999997" class="label" dominant-baseline="central" text-anchor="middle">O</text>
+        <text x="415" y="1770.0399999999997" class="label" text-anchor="middle" dominant-baseline="central">O</text>
       </g>
       <g class="node" id="node-P">
         <rect x="40" y="1846.4399999999996" width="50" height="52.8"/>
@@ -289,7 +289,7 @@ marker path {
       </g>
       <g class="node" id="node-W">
         <rect x="740" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="765" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">W</text>
+        <text x="765" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">W</text>
       </g>
     </g>
   </g>

--- a/docs/images/flowchart_full.svg
+++ b/docs/images/flowchart_full.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="846" height="1960.2399999999996" viewBox="-8 -27.999999999999993 846 1960.2399999999996" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="846" height="1956.2399999999996" viewBox="-8 -23.999999999999993 846 1956.2399999999996" class="mermaid">
   <style>
 
 .mermaid {
@@ -102,16 +102,16 @@ marker path {
   <g class="root">
     <g class="clusters">
       <g class="subgraph" id="subgraph-main">
-        <rect x="219" y="-19.999999999999993" width="390" height="718.4399999999999" class="cluster"/>
-        <text x="414" y="-3.999999999999993" class="cluster-label" text-anchor="middle">Main Flow</text>
+        <rect x="223" y="-15.999999999999993" width="382" height="710.4399999999999" class="cluster"/>
+        <text x="414" y="0.000000000000007105427357601002" class="cluster-label" text-anchor="middle">Main Flow</text>
       </g>
       <g class="subgraph" id="subgraph-shapes">
-        <rect x="300.92" y="733.4399999999999" width="228.16000000000003" height="930.1999999999997" class="cluster"/>
-        <text x="415" y="749.4399999999999" class="cluster-label" text-anchor="middle">All Shapes</text>
+        <rect x="304.92" y="737.4399999999999" width="220.16000000000003" height="922.1999999999997" class="cluster"/>
+        <text x="415" y="753.4399999999999" class="cluster-label" text-anchor="middle">All Shapes</text>
       </g>
       <g class="subgraph" id="subgraph-edges">
-        <rect x="20" y="1698.6399999999996" width="790" height="220.5999999999999" class="cluster"/>
-        <text x="415" y="1714.6399999999996" class="cluster-label" text-anchor="middle">Edge Types</text>
+        <rect x="24" y="1702.6399999999996" width="782" height="212.5999999999999" class="cluster"/>
+        <text x="415" y="1718.6399999999996" class="cluster-label" text-anchor="middle">Edge Types</text>
       </g>
     </g>
     <g class="edgePaths">
@@ -119,37 +119,37 @@ marker path {
         <path d="M 415.00 77.80 C 415.00 86.13, 415.00 94.47, 415.00 102.80 C 415.00 111.13, 415.00 119.47, 415.00 127.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-B-C-0">
-        <path d="M 415.00 180.60 C 415.00 188.93, 415.00 197.27, 415.00 205.60 C 415.00 213.93, 415.00 222.27, 415.00 230.60" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 415.00 180.60 C 415.00 188.93, 415.00 197.27, 415.00 205.60 C 415.00 213.93, 415.00 222.27, 415.00 230.60" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-C-D-0">
-        <path d="M 371.68 393.68 L 315.00 507.00" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 371.68 393.68 L 315.00 507.00" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-C-E-0">
-        <path d="M 458.32 393.68 L 515.00 507.00" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 458.32 393.68 L 515.00 507.00" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-D-F-0">
-        <path d="M 315.00 559.80 L 357.14 609.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 315.00 559.80 L 357.14 609.80" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-E-F-0">
-        <path d="M 515.00 559.80 L 472.86 609.80" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 515.00 559.80 L 472.86 609.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-G-H-0">
-        <path d="M 415.00 844.04 C 415.00 852.37, 415.00 860.71, 415.00 869.04 C 415.00 877.37, 415.00 885.71, 415.00 894.04" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 415.00 844.04 C 415.00 852.37, 415.00 860.71, 415.00 869.04 C 415.00 877.37, 415.00 885.71, 415.00 894.04" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-H-I-0">
-        <path d="M 415.00 946.84 C 415.00 955.17, 415.00 963.51, 415.00 971.84 C 415.00 980.17, 415.00 988.51, 415.00 996.84" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 415.00 946.84 C 415.00 955.17, 415.00 963.51, 415.00 971.84 C 415.00 980.17, 415.00 988.51, 415.00 996.84" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-I-J-0">
-        <path d="M 415.00 1049.64 C 415.00 1057.97, 415.00 1066.31, 415.00 1074.64 C 415.00 1082.97, 415.00 1091.31, 415.00 1099.64" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 415.00 1049.64 C 415.00 1057.97, 415.00 1066.31, 415.00 1074.64 C 415.00 1082.97, 415.00 1091.31, 415.00 1099.64" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-J-K-0">
-        <path d="M 415.00 1152.44 C 415.00 1160.77, 415.00 1169.11, 415.00 1177.44 C 415.00 1185.77, 415.00 1194.11, 415.00 1202.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 415.00 1152.44 C 415.00 1160.77, 415.00 1169.11, 415.00 1177.44 C 415.00 1185.77, 415.00 1194.11, 415.00 1202.44" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-K-L-0">
-        <path d="M 415.00 1255.24 C 415.00 1263.57, 415.00 1271.91, 415.00 1280.24 C 415.00 1288.57, 415.00 1296.91, 415.00 1305.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 415.00 1255.24 C 415.00 1263.57, 415.00 1271.91, 415.00 1280.24 C 415.00 1288.57, 415.00 1296.91, 415.00 1305.24" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-L-M-0">
-        <path d="M 415.00 1358.04 C 415.00 1366.37, 415.00 1374.71, 415.00 1383.04 C 415.00 1391.37, 415.00 1399.71, 415.00 1408.04" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 415.00 1358.04 C 415.00 1366.37, 415.00 1374.71, 415.00 1383.04 C 415.00 1391.37, 415.00 1399.71, 415.00 1408.04" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-M-N-0">
         <path d="M 415.00 1460.84 C 415.00 1469.17, 415.00 1477.51, 415.00 1485.84 C 415.00 1494.17, 415.00 1502.51, 415.00 1510.84" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
@@ -161,68 +161,68 @@ marker path {
         <path d="M 390.00 1775.18 C 315.00 1790.60, 240.00 1806.02, 202.50 1817.90 C 165.00 1829.77, 165.00 1838.11, 165.00 1846.44" class="edge-path" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-O-R-0">
-        <path d="M 390.00 1778.61 C 348.33 1792.88, 306.67 1807.16, 285.83 1818.47 C 265.00 1829.77, 265.00 1838.11, 265.00 1846.44" class="edge-path" stroke-dasharray="3,3" stroke-width="2" fill="none"/>
+        <path d="M 390.00 1778.61 C 348.33 1792.88, 306.67 1807.16, 285.83 1818.47 C 265.00 1829.77, 265.00 1838.11, 265.00 1846.44" class="edge-path" fill="none" stroke-dasharray="3,3" stroke-width="2"/>
       </g>
       <g class="edge" id="edge-L-O-S-0">
-        <path d="M 390.00 1795.74 L 365.00 1846.44" class="edge-path" fill="none" stroke-dasharray="3,3" stroke-width="2" marker-end="url(#arrow_point)"/>
+        <path d="M 390.00 1795.74 L 365.00 1846.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-dasharray="3,3" stroke-width="2"/>
       </g>
       <g class="edge" id="edge-L-O-T-0">
-        <path d="M 440.00 1795.74 L 465.00 1846.44" class="edge-path" fill="none" stroke-width="3.5" marker-end="url(#arrow_point)"/>
+        <path d="M 440.00 1795.74 L 465.00 1846.44" class="edge-path" stroke-width="3.5" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-O-U-0">
-        <path d="M 440.00 1778.61 C 481.67 1792.88, 523.33 1807.16, 544.17 1818.47 C 565.00 1829.77, 565.00 1838.11, 565.00 1846.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" marker-start="url(#arrow_point_start)" stroke-width="1"/>
+        <path d="M 440.00 1778.61 C 481.67 1792.88, 523.33 1807.16, 544.17 1818.47 C 565.00 1829.77, 565.00 1838.11, 565.00 1846.44" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none" marker-start="url(#arrow_point_start)"/>
       </g>
       <g class="edge" id="edge-L-O-V-0">
-        <path d="M 440.00 1775.18 C 515.00 1790.60, 590.00 1806.02, 627.50 1817.90 C 665.00 1829.77, 665.00 1838.11, 665.00 1846.44" class="edge-path" fill="none" marker-end="url(#arrow_cross)" marker-start="url(#arrow_cross_start)" stroke-width="1"/>
+        <path d="M 440.00 1775.18 C 515.00 1790.60, 590.00 1806.02, 627.50 1817.90 C 665.00 1829.77, 665.00 1838.11, 665.00 1846.44" class="edge-path" marker-end="url(#arrow_cross)" marker-start="url(#arrow_cross_start)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-O-W-0">
-        <path d="M 440.00 1773.71 C 548.33 1789.62, 656.67 1805.53, 710.83 1817.65 C 765.00 1829.77, 765.00 1838.11, 765.00 1846.44" class="edge-path" marker-end="url(#arrow_circle)" marker-start="url(#arrow_circle_start)" stroke-width="1" fill="none"/>
+        <path d="M 440.00 1773.71 C 548.33 1789.62, 656.67 1805.53, 710.83 1817.65 C 765.00 1829.77, 765.00 1838.11, 765.00 1846.44" class="edge-path" fill="none" stroke-width="1" marker-start="url(#arrow_circle_start)" marker-end="url(#arrow_circle)"/>
       </g>
       <g class="edge" id="edge-L-F-G-0">
         <path d="M 415.00 678.44 C 415.00 686.77, 415.00 695.11, 415.00 703.44 C 415.00 711.77, 415.00 720.11, 415.00 728.44 C 415.00 736.77, 415.00 745.11, 415.00 753.44 C 415.00 770.11, 415.00 778.44, 415.00 778.44" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-N-O-0">
-        <path d="M 415.00 1643.64 C 415.00 1651.97, 415.00 1660.31, 415.00 1668.64 C 415.00 1676.97, 415.00 1685.31, 415.00 1693.64 C 415.00 1701.97, 415.00 1710.31, 415.00 1718.64 C 415.00 1735.31, 415.00 1743.64, 415.00 1743.64" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 415.00 1643.64 C 415.00 1651.97, 415.00 1660.31, 415.00 1668.64 C 415.00 1676.97, 415.00 1685.31, 415.00 1693.64 C 415.00 1701.97, 415.00 1710.31, 415.00 1718.64 C 415.00 1735.31, 415.00 1743.64, 415.00 1743.64" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
     </g>
     <g class="edgeLabels">
       <g class="edgeLabel" id="edge-label-L-C-D-0">
         <rect x="318.2787158405461" y="436.01521470836525" width="29.599999999999998" height="22" class="edge-label-bg"/>
-        <text x="333.0787158405461" y="447.01521470836525" class="edge-label" dominant-baseline="central" text-anchor="middle">Yes</text>
+        <text x="333.0787158405461" y="447.01521470836525" class="edge-label" text-anchor="middle" dominant-baseline="central">Yes</text>
       </g>
       <g class="edgeLabel" id="edge-label-L-C-E-0">
         <rect x="485.7212841594539" y="436.01521470836525" width="22.4" height="22" class="edge-label-bg"/>
-        <text x="496.9212841594539" y="447.01521470836525" class="edge-label" dominant-baseline="central" text-anchor="middle">No</text>
+        <text x="496.9212841594539" y="447.01521470836525" class="edge-label" text-anchor="middle" dominant-baseline="central">No</text>
       </g>
     </g>
     <g class="nodes">
       <g class="node" id="node-A">
         <rect x="355.8" y="25.000000000000007" width="118.39999999999999" height="52.8"/>
-        <text x="415" y="51.400000000000006" class="label" dominant-baseline="central" text-anchor="middle">Rectangle</text>
+        <text x="415" y="51.400000000000006" class="label" text-anchor="middle" dominant-baseline="central">Rectangle</text>
       </g>
       <g class="node" id="node-B">
         <path d="M 370.4 127.80000000000001 H 459.59999999999997 A 5 5 0 0 1 464.59999999999997 132.8 V 175.60000000000002 A 5 5 0 0 1 459.59999999999997 180.60000000000002 H 370.4 A 5 5 0 0 1 365.4 175.60000000000002 V 132.8 A 5 5 0 0 1 370.4 127.80000000000001 Z"/>
-        <text x="415" y="154.20000000000002" class="label" text-anchor="middle" dominant-baseline="central">Rounded</text>
+        <text x="415" y="154.20000000000002" class="label" dominant-baseline="central" text-anchor="middle">Rounded</text>
       </g>
       <g class="node" id="node-C">
         <polygon points="415,230.60000000000002 518.2,333.8 415,437 311.8,333.8"/>
-        <text x="415" y="333.8" class="label" dominant-baseline="central" text-anchor="middle">Diamond Decision</text>
+        <text x="415" y="333.8" class="label" text-anchor="middle" dominant-baseline="central">Diamond Decision</text>
       </g>
       <g class="node" id="node-D">
         <path d="M 265.4 507 H 364.6 A 26.4 26.4 0 0 1 364.6 559.8 H 265.4 A 26.4 26.4 0 0 1 265.4 507 Z"/>
-        <text x="315" y="533.4" class="label" dominant-baseline="central" text-anchor="middle">Stadium</text>
+        <text x="315" y="533.4" class="label" text-anchor="middle" dominant-baseline="central">Stadium</text>
       </g>
       <g class="node" id="node-E">
         <polygon points="451,507 579,507 579,559.8 451,559.8 451,507 441,507 589,507 589,559.8 441,559.8 441,507"/>
-        <text x="515" y="533.4" class="label" text-anchor="middle" dominant-baseline="central">Subroutine</text>
+        <text x="515" y="533.4" class="label" dominant-baseline="central" text-anchor="middle">Subroutine</text>
       </g>
       <g class="node" id="node-F">
         <path d="M 346.2 620.096 a 68.8 10.296 0 0 0 137.6 0 a 68.8 10.296 0 0 0 -137.6 0 l 0 48.048 a 68.8 10.296 0 0 0 137.6 0 l 0 -48.048"/>
-        <text x="415" y="644.12" class="label" dominant-baseline="central" text-anchor="middle">Cylinder DB</text>
+        <text x="415" y="644.12" class="label" text-anchor="middle" dominant-baseline="central">Cylinder DB</text>
       </g>
       <g class="node" id="node-G">
         <circle cx="415" cy="811.2399999999999" r="32.8"/>
-        <text x="415" y="811.2399999999999" class="label" dominant-baseline="central" text-anchor="middle">Circle</text>
+        <text x="415" y="811.2399999999999" class="label" text-anchor="middle" dominant-baseline="central">Circle</text>
       </g>
       <g class="node" id="node-H">
         <path d="M 344.6 894.04 L 485.40000000000003 894.04 L 464.28000000000003 920.4399999999999 L 485.40000000000003 946.8399999999999 L 344.6 946.8399999999999 Z"/>
@@ -230,7 +230,7 @@ marker path {
       </g>
       <g class="node" id="node-I">
         <polygon points="349.144,996.84 509.08000000000004,996.84 480.85600000000005,1049.64 320.92,1049.64"/>
-        <text x="415" y="1023.24" class="label" text-anchor="middle" dominant-baseline="central">Parallelogram</text>
+        <text x="415" y="1023.24" class="label" dominant-baseline="central" text-anchor="middle">Parallelogram</text>
       </g>
       <g class="node" id="node-J">
         <polygon points="326.68,1099.6399999999999 476.824,1099.6399999999999 503.32,1152.4399999999998 353.176,1152.4399999999998"/>
@@ -238,7 +238,7 @@ marker path {
       </g>
       <g class="node" id="node-K">
         <polygon points="365.27200000000005,1202.4399999999998 464.728,1202.4399999999998 486.04,1255.2399999999998 343.96000000000004,1255.2399999999998"/>
-        <text x="415" y="1228.84" class="label" text-anchor="middle" dominant-baseline="central">Trapezoid</text>
+        <text x="415" y="1228.84" class="label" dominant-baseline="central" text-anchor="middle">Trapezoid</text>
       </g>
       <g class="node" id="node-L">
         <polygon points="320.92,1305.2399999999998 509.08000000000004,1305.2399999999998 480.85600000000005,1358.0399999999997 349.144,1358.0399999999997"/>
@@ -261,7 +261,7 @@ marker path {
       </g>
       <g class="node" id="node-P">
         <rect x="40" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="65" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">P</text>
+        <text x="65" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">P</text>
       </g>
       <g class="node" id="node-Q">
         <rect x="140" y="1846.4399999999996" width="50" height="52.8"/>
@@ -269,11 +269,11 @@ marker path {
       </g>
       <g class="node" id="node-R">
         <rect x="240" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="265" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">R</text>
+        <text x="265" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">R</text>
       </g>
       <g class="node" id="node-S">
         <rect x="340" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="365" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">S</text>
+        <text x="365" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">S</text>
       </g>
       <g class="node" id="node-T">
         <rect x="440" y="1846.4399999999996" width="50" height="52.8"/>
@@ -281,7 +281,7 @@ marker path {
       </g>
       <g class="node" id="node-U">
         <rect x="540" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="565" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">U</text>
+        <text x="565" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">U</text>
       </g>
       <g class="node" id="node-V">
         <rect x="640" y="1846.4399999999996" width="50" height="52.8"/>
@@ -289,7 +289,7 @@ marker path {
       </g>
       <g class="node" id="node-W">
         <rect x="740" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="765" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">W</text>
+        <text x="765" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">W</text>
       </g>
     </g>
   </g>

--- a/src/render/svg/structure.rs
+++ b/src/render/svg/structure.rs
@@ -434,15 +434,14 @@ fn extract_labels(doc: &roxmltree::Document) -> Vec<String> {
             }
         }
         // For tspan directly under text, handled above
-        // For p/span (mermaid.js foreignObject HTML), get direct text content
+        // For p/span (mermaid.js foreignObject HTML), collect ALL text content
+        // including text after <br> elements, matching how we handle <text> with tspans
         else if tag == "p" || tag == "span" {
-            // Only get direct text, not combined content, to avoid duplicates
-            if let Some(text) = node.text() {
-                let text = text.trim();
-                if !text.is_empty() && !seen.contains(text) {
-                    seen.insert(text.to_string());
-                    labels.push(text.to_string());
-                }
+            let combined = collect_text_content(&node);
+            let combined: String = combined.split_whitespace().collect::<Vec<_>>().join(" ");
+            if !combined.is_empty() && !seen.contains(&combined) {
+                seen.insert(combined.clone());
+                labels.push(combined);
             }
         }
     }
@@ -576,6 +575,11 @@ fn analyze_stroke_widths(doc: &roxmltree::Document) -> StrokeAnalysis {
 
         // Use inline if present, otherwise CSS, otherwise check if has stroke
         let stroke_width = inline_stroke_width.or(css_stroke_width);
+
+        // Skip elements with stroke explicitly set to "none"
+        if node.attribute("stroke") == Some("none") {
+            continue;
+        }
 
         // Only count if element has a visible stroke
         let has_stroke = node
@@ -2438,5 +2442,42 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_extract_labels_from_foreignobject_with_br() {
+        // Mermaid.js uses foreignObject with <p> and <br> for multi-line text.
+        // The label extractor must collect ALL text content from <p> elements,
+        // not just the first text node before a <br/>.
+        let mermaid_html_svg = r#"<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 500 200">
+            <g class="node">
+                <foreignObject width="200" height="100">
+                    <div xmlns="http://www.w3.org/1999/xhtml">
+                        <span class="nodeLabel"><p>Inner / circle<br/>and some odd <br/>special characters</p></span>
+                    </div>
+                </foreignObject>
+            </g>
+        </svg>"#;
+
+        let structure = SvgStructure::from_svg(mermaid_html_svg).unwrap();
+
+        // Should extract the full multi-line text, not just "Inner / circle"
+        let has_full_text = structure
+            .labels
+            .iter()
+            .any(|l| l.contains("Inner / circle") && l.contains("special characters"));
+        assert!(
+            has_full_text,
+            "Should extract full text from <p> with <br/> tags. Got: {:?}",
+            structure.labels
+        );
+
+        // Should NOT have a partial label like just "Inner / circle"
+        let has_partial = structure.labels.iter().any(|l| l == "Inner / circle");
+        assert!(
+            !has_partial,
+            "Should not extract partial label from first text node only. Got: {:?}",
+            structure.labels
+        );
     }
 }

--- a/src/render/svg/structure.rs
+++ b/src/render/svg/structure.rs
@@ -460,14 +460,16 @@ fn collect_text_content(node: &roxmltree::Node) -> String {
             if let Some(text) = child.text() {
                 result.push_str(text);
             }
-        } else if child.tag_name().name() == "tspan" {
-            // Add a space before tspan content if result doesn't already end with space
-            // This ensures proper word boundaries when tspans are concatenated
-            if !result.is_empty() && !result.ends_with(' ') && !result.ends_with('\n') {
+        } else {
+            let tag = child.tag_name().name();
+            // <br>, <tspan>, and other block-like elements act as word boundaries
+            if !result.is_empty()
+                && !result.ends_with(' ')
+                && !result.ends_with('\n')
+                && (tag == "tspan" || tag == "br")
+            {
                 result.push(' ');
             }
-            result.push_str(&collect_text_content(&child));
-        } else {
             result.push_str(&collect_text_content(&child));
         }
     }


### PR DESCRIPTION
<!-- midtown: madison -->

## Summary
- Fixed label extraction from `<foreignObject>` HTML: `<p>` elements with `<br/>` tags now correctly extract full text using recursive `collect_text_content()` instead of `node.text()` which only captured first text node
- Fixed space insertion at `<br>` element boundaries in `collect_text_content()` to prevent words from running together
- Fixed stroke width analysis to skip paths with `stroke="none"`, which were incorrectly dragging the average stroke width down to 0.1
- Regenerated all flowchart SVGs in docs/images/

## Eval results
| Sample | Before | After | Structural |
|--------|--------|-------|------------|
| example_flowchart_basic | warning | warning | 98.4% |
| example_flowchart_styled | **error** | **warning** | 94.2% |
| flowchart | warning | warning | 97.9% |
| flowchart_complex | error | error (aspect_ratio) | 98.3% |
| flowchart_full | warning | warning | 95.6% |

The `example_flowchart_styled` sample went from error to warning by fixing label extraction. The `flowchart_complex` aspect_ratio error remains — it's caused by character-based text estimation producing ~7% wider layouts than browser getBBox. This requires more sophisticated font metrics to resolve and should be tracked as a follow-up.

## Test plan
- [x] Added test `test_extract_labels_from_foreignobject_with_br` for HTML label extraction
- [x] All 1560+ tests pass
- [x] cargo clippy clean
- [x] Eval confirms example_flowchart_styled downgraded from error to warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)