### PR TITLE
fix(c4): match mermaid.js colors and add symbol defs

### DIFF
--- a/docs/images/c4.svg
+++ b/docs/images/c4.svg
@@ -48,11 +48,21 @@
 
   </style>
   <defs>
+    <symbol id="computer" width="24" height="24"><path transform="scale(.5)" d="M2 2v13h20v-13h-20zm18 11h-16v-9h16v9zm-10.228 6l.466-1h3.524l.467 1h-4.457zm14.228 3h-24l2-6h2.104l-1.33 4h18.45l-1.297-4h2.073l2 6zm-5-10h-14v-7h14v7z"/></symbol>
+    <symbol id="database" fill-rule="evenodd" clip-rule="evenodd"><path transform="scale(.5)" d="M12.258.001l.256.004.255.005.253.008.251.01.249.012.247.015.246.016.242.019.241.02.239.023.236.024.233.027.231.028.229.031.225.032.223.034.22.036.217.038.214.04.211.041.208.043.205.045.201.046.198.048.194.05.191.051.187.053.183.054.18.056.175.057.172.059.168.06.163.061.16.063.155.064.15.066.074.033.073.033.071.034.07.034.069.035.068.035.067.035.066.035.064.036.064.036.062.036.06.036.06.037.058.037.058.037.055.038.055.038.053.038.052.038.051.039.05.039.048.039.047.039.045.04.044.04.043.04.041.04.04.041.039.041.037.041.036.041.034.041.033.042.032.042.03.042.029.042.027.042.026.043.024.043.023.043.021.043.02.043.018.044.017.043.015.044.013.044.012.044.011.045.009.044.007.045.006.045.004.045.002.045.001.045v17l-.001.045-.002.045-.004.045-.006.045-.007.045-.009.044-.011.045-.012.044-.013.044-.015.044-.017.043-.018.044-.02.043-.021.043-.023.043-.024.043-.026.043-.027.042-.029.042-.03.042-.032.042-.033.042-.034.041-.036.041-.037.041-.039.041-.04.041-.041.04-.043.04-.044.04-.045.04-.047.039-.048.039-.05.039-.051.039-.052.038-.053.038-.055.038-.055.038-.058.037-.058.037-.06.037-.06.036-.062.036-.064.036-.064.036-.066.035-.067.035-.068.035-.069.035-.07.034-.071.034-.073.033-.074.033-.15.066-.155.064-.16.063-.163.061-.168.06-.172.059-.175.057-.18.056-.183.054-.187.053-.191.051-.194.05-.198.048-.201.046-.205.045-.208.043-.211.041-.214.04-.217.038-.22.036-.223.034-.225.032-.229.031-.231.028-.233.027-.236.024-.239.023-.241.02-.242.019-.246.016-.247.015-.249.012-.251.01-.253.008-.255.005-.256.004-.258.001-.258-.001-.256-.004-.255-.005-.253-.008-.251-.01-.249-.012-.247-.015-.245-.016-.243-.019-.241-.02-.238-.023-.236-.024-.234-.027-.231-.028-.228-.031-.226-.032-.223-.034-.22-.036-.217-.038-.214-.04-.211-.041-.208-.043-.204-.045-.201-.046-.198-.048-.195-.05-.19-.051-.187-.053-.184-.054-.179-.056-.176-.057-.172-.059-.167-.06-.164-.061-.159-.063-.155-.064-.151-.066-.074-.033-.072-.033-.072-.034-.07-.034-.069-.035-.068-.035-.067-.035-.066-.035-.064-.036-.063-.036-.062-.036-.061-.036-.06-.037-.058-.037-.057-.037-.056-.038-.055-.038-.053-.038-.052-.038-.051-.039-.049-.039-.049-.039-.046-.039-.046-.04-.044-.04-.043-.04-.041-.04-.04-.041-.039-.041-.037-.041-.036-.041-.034-.041-.033-.042-.032-.042-.03-.042-.029-.042-.027-.042-.026-.043-.024-.043-.023-.043-.021-.043-.02-.043-.018-.044-.017-.043-.015-.044-.013-.044-.012-.044-.011-.045-.009-.044-.007-.045-.006-.045-.004-.045-.002-.045-.001-.045v-17l.001-.045.002-.045.004-.045.006-.045.007-.045.009-.044.011-.045.012-.044.013-.044.015-.044.017-.043.018-.044.02-.043.021-.043.023-.043.024-.043.026-.043.027-.042.029-.042.03-.042.032-.042.033-.042.034-.041.036-.041.037-.041.039-.041.04-.041.041-.04.043-.04.044-.04.046-.04.046-.039.049-.039.049-.039.051-.039.052-.038.053-.038.055-.038.056-.038.057-.037.058-.037.06-.037.061-.036.062-.036.063-.036.064-.036.066-.035.067-.035.068-.035.069-.035.07-.034.072-.034.072-.033.074-.033.151-.066.155-.064.159-.063.164-.061.167-.06.172-.059.176-.057.179-.056.184-.054.187-.053.19-.051.195-.05.198-.048.201-.046.204-.045.208-.043.211-.041.214-.04.217-.038.22-.036.223-.034.226-.032.228-.031.231-.028.234-.027.236-.024.238-.023.241-.02.243-.019.245-.016.247-.015.249-.012.251-.01.253-.008.255-.005.256-.004.258-.001.258.001z"/></symbol>
+    <symbol id="clock" width="24" height="24"><path transform="scale(.5)" d="M12 2c5.514 0 10 4.486 10 10s-4.486 10-10 10-10-4.486-10-10 4.486-10 10-10zm0-2c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm5.848 12.459c.202.038.202.333.001.372-1.907.361-6.045 1.111-6.547 1.111-.719 0-1.301-.582-1.301-1.301 0-.512.77-5.447 1.125-7.445.034-.192.312-.181.343.014l.985 6.238 5.394 1.011z"/></symbol>
     <marker id="c4-arrow" refX="9" refY="5" markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="12" orient="auto">
-    <path d="M 0 0 L 10 5 L 0 10 z" fill="#666666"/>
+    <path d="M 0 0 L 10 5 L 0 10 z"/>
 </marker>
     <marker id="c4-arrow-reverse" refX="1" refY="5" markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="12" orient="auto">
-    <path d="M 10 0 L 0 5 L 10 10 z" fill="#666666"/>
+    <path d="M 10 0 L 0 5 L 10 10 z"/>
+</marker>
+    <marker id="c4-crosshead" markerWidth="15" markerHeight="8" orient="auto" refX="16" refY="4">
+    <path fill="black" stroke="#000000" stroke-width="1px" d="M 9,2 V 6 L16,4 Z" style="stroke-dasharray: 0, 0;"/>
+    <path fill="none" stroke="#000000" stroke-width="1px" d="M 0,1 L 6,7 M 6,1 L 0,7" style="stroke-dasharray: 0, 0;"/>
+</marker>
+    <marker id="c4-filled-head" refX="18" refY="7" markerWidth="20" markerHeight="28" orient="auto">
+    <path d="M 18,7 L9,13 L14,7 L9,1 Z"/>
 </marker>
   </defs>
   <g class="root">
@@ -68,39 +78,39 @@
     <g class="nodes">
 
     </g>
-    <text x="336" y="25" class="c4-title" font-weight="bold" font-size="16" fill="#333333" text-anchor="middle">System Context diagram for Internet Banking System</text>
+    <text x="336" y="25" class="c4-title" text-anchor="middle" font-weight="bold" font-size="16" fill="#333333">System Context diagram for Internet Banking System</text>
     <g class="c4-boundary-group" id="b0">
-      <rect x="316" y="269" width="256" height="406" rx="2.5" ry="2.5" class="c4-boundary" fill="none" stroke-width="1" stroke="#444444" stroke-dasharray="7,7"/>
-      <text x="326" y="289" class="c4-boundary-label" font-weight="bold" fill="#444444" font-size="14">BankBoundary</text>
-      <text x="326" y="304" class="c4-boundary-type" fill="#444444" font-size="12">[ENTERPRISE]</text>
+      <rect x="316" y="269" width="256" height="406" rx="2.5" ry="2.5" class="c4-boundary" stroke-dasharray="7,7" fill="none" stroke="#444444" stroke-width="1"/>
+      <text x="326" y="289" class="c4-boundary-label" font-size="14" fill="#444444" font-weight="bold">BankBoundary</text>
+      <text x="326" y="304" class="c4-boundary-type" font-size="12" fill="#444444">[ENTERPRISE]</text>
     </g>
     <g class="c4-element-group" id="email">
-      <rect x="50" y="50" width="216" height="119" rx="2.5" ry="2.5" class="c4-element" stroke-width="0.5" stroke="#7a7a7a" fill="#999999"/>
-      <text x="158" y="68" class="c4-type" font-style="italic" text-anchor="middle" font-size="11" fill="#ffffff">&lt;&lt;external_system&gt;&gt;</text>
-      <text x="158" y="84" class="c4-label" fill="#ffffff" text-anchor="middle" font-size="14" font-weight="bold">E-mail System</text>
-      <text x="158" y="106" class="c4-description" fill="#ffffff" font-size="11" text-anchor="middle">External e-mail system</text>
+      <rect x="50" y="50" width="216" height="119" rx="2.5" ry="2.5" class="c4-element" stroke="#8a8a8a" fill="#999999" stroke-width="0.5"/>
+      <text x="158" y="68" class="c4-type" fill="#ffffff" font-size="11" text-anchor="middle" font-style="italic">&lt;&lt;external_system&gt;&gt;</text>
+      <text x="158" y="84" class="c4-label" font-weight="bold" fill="#ffffff" text-anchor="middle" font-size="14">E-mail System</text>
+      <text x="158" y="106" class="c4-description" text-anchor="middle" font-size="11" fill="#ffffff">External e-mail system</text>
     </g>
     <g class="c4-element-group" id="customer">
-      <rect x="336" y="319" width="216" height="167" rx="2.5" ry="2.5" class="c4-element" stroke="#073b6f" fill="#08427b" stroke-width="0.5"/>
+      <rect x="336" y="319" width="216" height="167" rx="2.5" ry="2.5" class="c4-element" fill="#08427b" stroke="#073b6f" stroke-width="0.5"/>
       <image x="420" y="353" width="48" height="48" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAACD0lEQVR4Xu2YoU4EMRCGT+4j8Ai8AhaH4QHgAUjQuFMECUgMIUgwJAgMhgQsAYUiJCiQIBBY+EITsjfTdme6V24v4c8vyGbb+ZjOtN0bNcvjQXmkH83WvYBWto6PLm6v7p7uH1/w2fXD+PBycX1Pv2l3IdDm/vn7x+dXQiAubRzoURa7gRZWd0iGRIiJbOnhnfYBQZNJjNbuyY2eJG8fkDE3bbG4ep6MHUAsgYxmE3nVs6VsBWJSGccsOlFPmLIViMzLOB7pCVO2AtHJMohH7Fh6zqitQK7m0rJvAVYgGcEpe//PLdDz65sM4pF9N7ICcXDKIB5Nv6j7tD0NoSdM2QrU9Gg0ewE1LqBhHR3BBdvj2vapnidjHxD/q6vd7Pvhr31AwcY8eXMTXAKECZZJFXuEq27aLgQK5uLMohCenGGuGewOxSjBvYBqeG6B+Nqiblggdjnc+ZXDy+FNFpFzw76O3UBAROuXh6FoiAcf5g9eTvUgzy0nWg6I8cXHRUpg5bOVBCo+KDpFajOf23GgPme7RSQ+lacIENUgJ6gg1k6HjgOlqnLqip4tEuhv0hNEMXUD0clyXE3p6pZA0S2nnvTlXwLJEZWlb7cTQH1+USgTN4VhAenm/wea1OCAOmqo6fE1WCb9WSKBah+rbUWPWAmE2Rvk0ApiB45eOyNAzU8xcTvj8KvkKEoOaIYeHNA3ZuygAvFMUO0AAAAASUVORK5CYII="/>
-      <text x="444" y="337" class="c4-type" font-size="11" font-style="italic" text-anchor="middle" fill="#ffffff">&lt;&lt;person&gt;&gt;</text>
-      <text x="444" y="409" class="c4-label" font-size="14" text-anchor="middle" font-weight="bold" fill="#ffffff">Banking Customer</text>
+      <text x="444" y="337" class="c4-type" fill="#ffffff" font-style="italic" text-anchor="middle" font-size="11">&lt;&lt;person&gt;&gt;</text>
+      <text x="444" y="409" class="c4-label" font-weight="bold" font-size="14" text-anchor="middle" fill="#ffffff">Banking Customer</text>
       <text x="444" y="431" class="c4-description" font-size="11" text-anchor="middle" fill="#ffffff">A customer of the bank</text>
     </g>
     <g class="c4-element-group" id="banking">
-      <rect x="336" y="536" width="216" height="119" rx="2.5" ry="2.5" class="c4-element" stroke="#0e5a9d" fill="#1168bd" stroke-width="0.5"/>
-      <text x="444" y="554" class="c4-type" text-anchor="middle" fill="#ffffff" font-style="italic" font-size="11">&lt;&lt;system&gt;&gt;</text>
-      <text x="444" y="570" class="c4-label" font-weight="bold" fill="#ffffff" text-anchor="middle" font-size="14">Internet Banking System</text>
-      <text x="444" y="592" class="c4-description" font-size="11" text-anchor="middle" fill="#ffffff">Allows customers to view accounts</text>
+      <rect x="336" y="536" width="216" height="119" rx="2.5" ry="2.5" class="c4-element" stroke-width="0.5" stroke="#0e5ea8" fill="#1168bd"/>
+      <text x="444" y="554" class="c4-type" text-anchor="middle" font-size="11" fill="#ffffff" font-style="italic">&lt;&lt;system&gt;&gt;</text>
+      <text x="444" y="570" class="c4-label" font-size="14" font-weight="bold" text-anchor="middle" fill="#ffffff">Internet Banking System</text>
+      <text x="444" y="592" class="c4-description" text-anchor="middle" font-size="11" fill="#ffffff">Allows customers to view accounts</text>
     </g>
     <g class="c4-relationship-group">
-      <line x1="444" y1="486" x2="444" y2="536" class="c4-relationship" stroke="#666666" stroke-width="1" marker-end="url(#c4-arrow)"/>
-      <text x="444" y="515" class="c4-rel-label" fill="#666666" text-anchor="middle" font-size="12">Uses</text>
+      <line x1="444" y1="486" x2="444" y2="536" class="c4-relationship" marker-end="url(#c4-arrow)" stroke="#444444" stroke-width="1"/>
+      <text x="444" y="515" class="c4-rel-label" text-anchor="middle" font-size="12" fill="#444444">Uses</text>
     </g>
     <g class="c4-relationship-group">
-      <path d="M408.9855967078189,536 Q354.99279835390945,352.5 193.01440329218107,169" class="c4-relationship" fill="none" marker-end="url(#c4-arrow)" stroke="#666666" stroke-width="1"/>
-      <text x="301" y="356.5" class="c4-rel-label" fill="#666666" text-anchor="middle" font-size="12">Sends e-mails</text>
-      <text x="301" y="369.5" class="c4-rel-technology" fill="#666666" text-anchor="middle" font-size="12" font-style="italic">[SMTP]</text>
+      <path d="M408.9855967078189,536 Q354.99279835390945,352.5 193.01440329218107,169" class="c4-relationship" fill="none" marker-end="url(#c4-arrow)" stroke-width="1" stroke="#444444"/>
+      <text x="301" y="356.5" class="c4-rel-label" fill="#444444" font-size="12" text-anchor="middle">Sends e-mails</text>
+      <text x="301" y="369.5" class="c4-rel-technology" fill="#444444" text-anchor="middle" font-style="italic" font-size="12">[SMTP]</text>
     </g>
   </g>
 </svg>

--- a/docs/images/c4_complex.svg
+++ b/docs/images/c4_complex.svg
@@ -48,11 +48,21 @@
 
   </style>
   <defs>
+    <symbol id="computer" width="24" height="24"><path transform="scale(.5)" d="M2 2v13h20v-13h-20zm18 11h-16v-9h16v9zm-10.228 6l.466-1h3.524l.467 1h-4.457zm14.228 3h-24l2-6h2.104l-1.33 4h18.45l-1.297-4h2.073l2 6zm-5-10h-14v-7h14v7z"/></symbol>
+    <symbol id="database" fill-rule="evenodd" clip-rule="evenodd"><path transform="scale(.5)" d="M12.258.001l.256.004.255.005.253.008.251.01.249.012.247.015.246.016.242.019.241.02.239.023.236.024.233.027.231.028.229.031.225.032.223.034.22.036.217.038.214.04.211.041.208.043.205.045.201.046.198.048.194.05.191.051.187.053.183.054.18.056.175.057.172.059.168.06.163.061.16.063.155.064.15.066.074.033.073.033.071.034.07.034.069.035.068.035.067.035.066.035.064.036.064.036.062.036.06.036.06.037.058.037.058.037.055.038.055.038.053.038.052.038.051.039.05.039.048.039.047.039.045.04.044.04.043.04.041.04.04.041.039.041.037.041.036.041.034.041.033.042.032.042.03.042.029.042.027.042.026.043.024.043.023.043.021.043.02.043.018.044.017.043.015.044.013.044.012.044.011.045.009.044.007.045.006.045.004.045.002.045.001.045v17l-.001.045-.002.045-.004.045-.006.045-.007.045-.009.044-.011.045-.012.044-.013.044-.015.044-.017.043-.018.044-.02.043-.021.043-.023.043-.024.043-.026.043-.027.042-.029.042-.03.042-.032.042-.033.042-.034.041-.036.041-.037.041-.039.041-.04.041-.041.04-.043.04-.044.04-.045.04-.047.039-.048.039-.05.039-.051.039-.052.038-.053.038-.055.038-.055.038-.058.037-.058.037-.06.037-.06.036-.062.036-.064.036-.064.036-.066.035-.067.035-.068.035-.069.035-.07.034-.071.034-.073.033-.074.033-.15.066-.155.064-.16.063-.163.061-.168.06-.172.059-.175.057-.18.056-.183.054-.187.053-.191.051-.194.05-.198.048-.201.046-.205.045-.208.043-.211.041-.214.04-.217.038-.22.036-.223.034-.225.032-.229.031-.231.028-.233.027-.236.024-.239.023-.241.02-.242.019-.246.016-.247.015-.249.012-.251.01-.253.008-.255.005-.256.004-.258.001-.258-.001-.256-.004-.255-.005-.253-.008-.251-.01-.249-.012-.247-.015-.245-.016-.243-.019-.241-.02-.238-.023-.236-.024-.234-.027-.231-.028-.228-.031-.226-.032-.223-.034-.22-.036-.217-.038-.214-.04-.211-.041-.208-.043-.204-.045-.201-.046-.198-.048-.195-.05-.19-.051-.187-.053-.184-.054-.179-.056-.176-.057-.172-.059-.167-.06-.164-.061-.159-.063-.155-.064-.151-.066-.074-.033-.072-.033-.072-.034-.07-.034-.069-.035-.068-.035-.067-.035-.066-.035-.064-.036-.063-.036-.062-.036-.061-.036-.06-.037-.058-.037-.057-.037-.056-.038-.055-.038-.053-.038-.052-.038-.051-.039-.049-.039-.049-.039-.046-.039-.046-.04-.044-.04-.043-.04-.041-.04-.04-.041-.039-.041-.037-.041-.036-.041-.034-.041-.033-.042-.032-.042-.03-.042-.029-.042-.027-.042-.026-.043-.024-.043-.023-.043-.021-.043-.02-.043-.018-.044-.017-.043-.015-.044-.013-.044-.012-.044-.011-.045-.009-.044-.007-.045-.006-.045-.004-.045-.002-.045-.001-.045v-17l.001-.045.002-.045.004-.045.006-.045.007-.045.009-.044.011-.045.012-.044.013-.044.015-.044.017-.043.018-.044.02-.043.021-.043.023-.043.024-.043.026-.043.027-.042.029-.042.03-.042.032-.042.033-.042.034-.041.036-.041.037-.041.039-.041.04-.041.041-.04.043-.04.044-.04.046-.04.046-.039.049-.039.049-.039.051-.039.052-.038.053-.038.055-.038.056-.038.057-.037.058-.037.06-.037.061-.036.062-.036.063-.036.064-.036.066-.035.067-.035.068-.035.069-.035.07-.034.072-.034.072-.033.074-.033.151-.066.155-.064.159-.063.164-.061.167-.06.172-.059.176-.057.179-.056.184-.054.187-.053.19-.051.195-.05.198-.048.201-.046.204-.045.208-.043.211-.041.214-.04.217-.038.22-.036.223-.034.226-.032.228-.031.231-.028.234-.027.236-.024.238-.023.241-.02.243-.019.245-.016.247-.015.249-.012.251-.01.253-.008.255-.005.256-.004.258-.001.258.001z"/></symbol>
+    <symbol id="clock" width="24" height="24"><path transform="scale(.5)" d="M12 2c5.514 0 10 4.486 10 10s-4.486 10-10 10-10-4.486-10-10 4.486-10 10-10zm0-2c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm5.848 12.459c.202.038.202.333.001.372-1.907.361-6.045 1.111-6.547 1.111-.719 0-1.301-.582-1.301-1.301 0-.512.77-5.447 1.125-7.445.034-.192.312-.181.343.014l.985 6.238 5.394 1.011z"/></symbol>
     <marker id="c4-arrow" refX="9" refY="5" markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="12" orient="auto">
-    <path d="M 0 0 L 10 5 L 0 10 z" fill="#666666"/>
+    <path d="M 0 0 L 10 5 L 0 10 z"/>
 </marker>
     <marker id="c4-arrow-reverse" refX="1" refY="5" markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="12" orient="auto">
-    <path d="M 10 0 L 0 5 L 10 10 z" fill="#666666"/>
+    <path d="M 10 0 L 0 5 L 10 10 z"/>
+</marker>
+    <marker id="c4-crosshead" markerWidth="15" markerHeight="8" orient="auto" refX="16" refY="4">
+    <path fill="black" stroke="#000000" stroke-width="1px" d="M 9,2 V 6 L16,4 Z" style="stroke-dasharray: 0, 0;"/>
+    <path fill="none" stroke="#000000" stroke-width="1px" d="M 0,1 L 6,7 M 6,1 L 0,7" style="stroke-dasharray: 0, 0;"/>
+</marker>
+    <marker id="c4-filled-head" refX="18" refY="7" markerWidth="20" markerHeight="28" orient="auto">
+    <path d="M 18,7 L9,13 L14,7 L9,1 Z"/>
 </marker>
   </defs>
   <g class="root">
@@ -68,77 +78,77 @@
     <g class="nodes">
 
     </g>
-    <text x="469" y="25" class="c4-title" fill="#333333" text-anchor="middle" font-size="16" font-weight="bold">Container diagram for Internet Banking System</text>
+    <text x="469" y="25" class="c4-title" text-anchor="middle" fill="#333333" font-size="16" font-weight="bold">Container diagram for Internet Banking System</text>
     <g class="c4-boundary-group" id="c1">
-      <rect x="582" y="317" width="256" height="746" rx="2.5" ry="2.5" class="c4-boundary" stroke-width="1" stroke-dasharray="7,7" fill="none" stroke="#444444"/>
+      <rect x="582" y="317" width="256" height="746" rx="2.5" ry="2.5" class="c4-boundary" fill="none" stroke="#444444" stroke-width="1" stroke-dasharray="7,7"/>
       <text x="592" y="337" class="c4-boundary-label" fill="#444444" font-weight="bold" font-size="14">Internet Banking</text>
       <text x="592" y="352" class="c4-boundary-type" fill="#444444" font-size="12">[CONTAINER]</text>
     </g>
     <g class="c4-element-group" id="email_system">
-      <rect x="50" y="50" width="216" height="119" rx="2.5" ry="2.5" class="c4-element" fill="#999999" stroke="#7a7a7a" stroke-width="0.5"/>
-      <text x="158" y="68" class="c4-type" font-size="11" font-style="italic" fill="#ffffff" text-anchor="middle">&lt;&lt;external_system&gt;&gt;</text>
-      <text x="158" y="84" class="c4-label" fill="#ffffff" text-anchor="middle" font-size="14" font-weight="bold">E-Mail System</text>
-      <text x="158" y="106" class="c4-description" text-anchor="middle" fill="#ffffff" font-size="11">The internal Microsoft Exchange system</text>
+      <rect x="50" y="50" width="216" height="119" rx="2.5" ry="2.5" class="c4-element" fill="#999999" stroke-width="0.5" stroke="#8a8a8a"/>
+      <text x="158" y="68" class="c4-type" font-style="italic" text-anchor="middle" fill="#ffffff" font-size="11">&lt;&lt;external_system&gt;&gt;</text>
+      <text x="158" y="84" class="c4-label" font-size="14" font-weight="bold" fill="#ffffff" text-anchor="middle">E-Mail System</text>
+      <text x="158" y="106" class="c4-description" font-size="11" fill="#ffffff" text-anchor="middle">The internal Microsoft Exchange system</text>
     </g>
     <g class="c4-element-group" id="customer">
-      <rect x="316" y="50" width="216" height="167" rx="2.5" ry="2.5" class="c4-element" stroke-width="0.5" fill="#08427b" stroke="#073b6f"/>
+      <rect x="316" y="50" width="216" height="167" rx="2.5" ry="2.5" class="c4-element" fill="#08427b" stroke-width="0.5" stroke="#073b6f"/>
       <image x="400" y="84" width="48" height="48" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAIAAADYYG7QAAACD0lEQVR4Xu2YoU4EMRCGT+4j8Ai8AhaH4QHgAUjQuFMECUgMIUgwJAgMhgQsAYUiJCiQIBBY+EITsjfTdme6V24v4c8vyGbb+ZjOtN0bNcvjQXmkH83WvYBWto6PLm6v7p7uH1/w2fXD+PBycX1Pv2l3IdDm/vn7x+dXQiAubRzoURa7gRZWd0iGRIiJbOnhnfYBQZNJjNbuyY2eJG8fkDE3bbG4ep6MHUAsgYxmE3nVs6VsBWJSGccsOlFPmLIViMzLOB7pCVO2AtHJMohH7Fh6zqitQK7m0rJvAVYgGcEpe//PLdDz65sM4pF9N7ICcXDKIB5Nv6j7tD0NoSdM2QrU9Gg0ewE1LqBhHR3BBdvj2vapnidjHxD/q6vd7Pvhr31AwcY8eXMTXAKECZZJFXuEq27aLgQK5uLMohCenGGuGewOxSjBvYBqeG6B+Nqiblggdjnc+ZXDy+FNFpFzw76O3UBAROuXh6FoiAcf5g9eTvUgzy0nWg6I8cXHRUpg5bOVBCo+KDpFajOf23GgPme7RSQ+lacIENUgJ6gg1k6HjgOlqnLqip4tEuhv0hNEMXUD0clyXE3p6pZA0S2nnvTlXwLJEZWlb7cTQH1+USgTN4VhAenm/wea1OCAOmqo6fE1WCb9WSKBah+rbUWPWAmE2Rvk0ApiB45eOyNAzU8xcTvj8KvkKEoOaIYeHNA3ZuygAvFMUO0AAAAASUVORK5CYII="/>
-      <text x="424" y="68" class="c4-type" text-anchor="middle" fill="#ffffff" font-size="11" font-style="italic">&lt;&lt;person&gt;&gt;</text>
-      <text x="424" y="140" class="c4-label" font-size="14" font-weight="bold" fill="#ffffff" text-anchor="middle">Customer</text>
-      <text x="424" y="162" class="c4-description" text-anchor="middle" font-size="11" fill="#ffffff">A customer of the bank, with personal bank accounts</text>
+      <text x="424" y="68" class="c4-type" font-size="11" fill="#ffffff" text-anchor="middle" font-style="italic">&lt;&lt;person&gt;&gt;</text>
+      <text x="424" y="140" class="c4-label" font-weight="bold" font-size="14" fill="#ffffff" text-anchor="middle">Customer</text>
+      <text x="424" y="162" class="c4-description" fill="#ffffff" text-anchor="middle" font-size="11">A customer of the bank, with personal bank accounts</text>
     </g>
     <g class="c4-element-group" id="spa">
-      <rect x="602" y="417" width="216" height="119" rx="2.5" ry="2.5" class="c4-element" stroke="#3879b8" stroke-width="0.5" fill="#438dd5"/>
-      <text x="710" y="435" class="c4-type" font-size="11" fill="#ffffff" text-anchor="middle" font-style="italic">&lt;&lt;container&gt;&gt;</text>
-      <text x="710" y="451" class="c4-label" font-size="14" font-weight="bold" fill="#ffffff" text-anchor="middle">Single-Page App</text>
-      <text x="710" y="467" class="c4-technology" font-style="italic" fill="#ffffff" text-anchor="middle" font-size="11">[JavaScript, Angular]</text>
-      <text x="710" y="487" class="c4-description" text-anchor="middle" fill="#ffffff" font-size="11">Provides all the Internet banking functionality</text>
+      <rect x="602" y="417" width="216" height="119" rx="2.5" ry="2.5" class="c4-element" stroke-width="0.5" stroke="#3c7fc0" fill="#438dd5"/>
+      <text x="710" y="435" class="c4-type" fill="#ffffff" text-anchor="middle" font-size="11" font-style="italic">&lt;&lt;container&gt;&gt;</text>
+      <text x="710" y="451" class="c4-label" text-anchor="middle" font-weight="bold" font-size="14" fill="#ffffff">Single-Page App</text>
+      <text x="710" y="467" class="c4-technology" text-anchor="middle" fill="#ffffff" font-style="italic" font-size="11">[JavaScript, Angular]</text>
+      <text x="710" y="487" class="c4-description" fill="#ffffff" text-anchor="middle" font-size="11">Provides all the Internet banking functionality</text>
     </g>
     <g class="c4-element-group" id="api">
-      <rect x="602" y="586" width="216" height="119" rx="2.5" ry="2.5" class="c4-element" stroke-width="0.5" fill="#438dd5" stroke="#3879b8"/>
-      <text x="710" y="604" class="c4-type" fill="#ffffff" font-size="11" text-anchor="middle" font-style="italic">&lt;&lt;container&gt;&gt;</text>
-      <text x="710" y="620" class="c4-label" font-weight="bold" font-size="14" fill="#ffffff" text-anchor="middle">API Application</text>
-      <text x="710" y="636" class="c4-technology" font-size="11" font-style="italic" fill="#ffffff" text-anchor="middle">[Java, Spring MVC]</text>
-      <text x="710" y="656" class="c4-description" text-anchor="middle" font-size="11" fill="#ffffff">Provides banking functionality via JSON/HTTPS API</text>
+      <rect x="602" y="586" width="216" height="119" rx="2.5" ry="2.5" class="c4-element" fill="#438dd5" stroke-width="0.5" stroke="#3c7fc0"/>
+      <text x="710" y="604" class="c4-type" font-style="italic" fill="#ffffff" font-size="11" text-anchor="middle">&lt;&lt;container&gt;&gt;</text>
+      <text x="710" y="620" class="c4-label" text-anchor="middle" fill="#ffffff" font-weight="bold" font-size="14">API Application</text>
+      <text x="710" y="636" class="c4-technology" fill="#ffffff" text-anchor="middle" font-size="11" font-style="italic">[Java, Spring MVC]</text>
+      <text x="710" y="656" class="c4-description" font-size="11" text-anchor="middle" fill="#ffffff">Provides banking functionality via JSON/HTTPS API</text>
     </g>
     <g class="c4-element-group" id="db">
-      <path d="M602,755c0,-10 108,-10 108,-10c0,0 108,0 108,10l0,119c0,10 -108,-10 -108,-10c0,0 -108,0 -108,-10l0,-119" class="c4-db" stroke="#3879b8" stroke-width="0.5" fill="#438dd5"/>
-      <path d="M602,755c0,10 108,10 108,10c0,0 108,0 108,-10" class="c4-db-top" stroke-width="0.5" stroke="#3879b8" fill="none"/>
-      <text x="710" y="773" class="c4-type" font-style="italic" fill="#ffffff" text-anchor="middle" font-size="11">&lt;&lt;container_db&gt;&gt;</text>
-      <text x="710" y="789" class="c4-label" text-anchor="middle" fill="#ffffff" font-size="14" font-weight="bold">Database</text>
-      <text x="710" y="805" class="c4-technology" font-style="italic" fill="#ffffff" text-anchor="middle" font-size="11">[Oracle]</text>
+      <path d="M602,755c0,-10 108,-10 108,-10c0,0 108,0 108,10l0,119c0,10 -108,-10 -108,-10c0,0 -108,0 -108,-10l0,-119" class="c4-db" stroke="#3c7fc0" fill="#438dd5" stroke-width="0.5"/>
+      <path d="M602,755c0,10 108,10 108,10c0,0 108,0 108,-10" class="c4-db-top" fill="none" stroke-width="0.5" stroke="#3c7fc0"/>
+      <text x="710" y="773" class="c4-type" font-size="11" fill="#ffffff" text-anchor="middle" font-style="italic">&lt;&lt;container_db&gt;&gt;</text>
+      <text x="710" y="789" class="c4-label" text-anchor="middle" font-size="14" fill="#ffffff" font-weight="bold">Database</text>
+      <text x="710" y="805" class="c4-technology" text-anchor="middle" fill="#ffffff" font-size="11" font-style="italic">[Oracle]</text>
       <text x="710" y="825" class="c4-description" fill="#ffffff" text-anchor="middle" font-size="11">Stores user data, accounts, transactions</text>
     </g>
     <g class="c4-element-group" id="queue">
-      <path d="M602,924l216,0c5,0 5,59.5 5,59.5c0,0 0,59.5 -5,59.5l-216,0c-5,0 -5,-59.5 -5,-59.5c0,0 0,-59.5 5,-59.5" class="c4-queue" stroke-width="0.5" fill="#438dd5" stroke="#3879b8"/>
-      <path d="M818,924c-5,0 -5,59.5 -5,59.5c0,59.5 5,59.5 5,59.5" class="c4-queue-right" fill="none" stroke="#3879b8" stroke-width="0.5"/>
-      <text x="710" y="942" class="c4-type" font-style="italic" fill="#ffffff" text-anchor="middle" font-size="11">&lt;&lt;container_queue&gt;&gt;</text>
-      <text x="710" y="958" class="c4-label" font-weight="bold" fill="#ffffff" text-anchor="middle" font-size="14">Message Broker</text>
-      <text x="710" y="974" class="c4-technology" text-anchor="middle" font-style="italic" font-size="11" fill="#ffffff">[RabbitMQ]</text>
-      <text x="710" y="994" class="c4-description" text-anchor="middle" fill="#ffffff" font-size="11">Handles async messaging</text>
+      <path d="M602,924l216,0c5,0 5,59.5 5,59.5c0,0 0,59.5 -5,59.5l-216,0c-5,0 -5,-59.5 -5,-59.5c0,0 0,-59.5 5,-59.5" class="c4-queue" fill="#438dd5" stroke="#3c7fc0" stroke-width="0.5"/>
+      <path d="M818,924c-5,0 -5,59.5 -5,59.5c0,59.5 5,59.5 5,59.5" class="c4-queue-right" fill="none" stroke="#3c7fc0" stroke-width="0.5"/>
+      <text x="710" y="942" class="c4-type" text-anchor="middle" font-style="italic" fill="#ffffff" font-size="11">&lt;&lt;container_queue&gt;&gt;</text>
+      <text x="710" y="958" class="c4-label" fill="#ffffff" text-anchor="middle" font-weight="bold" font-size="14">Message Broker</text>
+      <text x="710" y="974" class="c4-technology" text-anchor="middle" font-size="11" font-style="italic" fill="#ffffff">[RabbitMQ]</text>
+      <text x="710" y="994" class="c4-description" fill="#ffffff" font-size="11" text-anchor="middle">Handles async messaging</text>
     </g>
     <g class="c4-relationship-group">
-      <line x1="493.62390670553935" y1="217" x2="660.3877551020408" y2="417" class="c4-relationship" stroke-width="1" stroke="#666666" marker-end="url(#c4-arrow)"/>
-      <text x="577.0058309037901" y="321" class="c4-rel-label" font-size="12" text-anchor="middle" fill="#666666">Uses</text>
-      <text x="577.0058309037901" y="334" class="c4-rel-technology" fill="#666666" text-anchor="middle" font-size="12" font-style="italic">[HTTPS]</text>
+      <line x1="493.62390670553935" y1="217" x2="660.3877551020408" y2="417" class="c4-relationship" marker-end="url(#c4-arrow)" stroke-width="1" stroke="#444444"/>
+      <text x="577.0058309037901" y="321" class="c4-rel-label" fill="#444444" text-anchor="middle" font-size="12">Uses</text>
+      <text x="577.0058309037901" y="334" class="c4-rel-technology" font-style="italic" text-anchor="middle" fill="#444444" font-size="12">[HTTPS]</text>
     </g>
     <g class="c4-relationship-group">
-      <path d="M710,536 Q710,561 710,586" class="c4-relationship" stroke="#666666" stroke-width="1" marker-end="url(#c4-arrow)" fill="none"/>
-      <text x="710" y="565" class="c4-rel-label" text-anchor="middle" fill="#666666" font-size="12">Makes API calls to</text>
-      <text x="710" y="578" class="c4-rel-technology" fill="#666666" font-style="italic" text-anchor="middle" font-size="12">[JSON/HTTPS]</text>
+      <path d="M710,536 Q710,561 710,586" class="c4-relationship" fill="none" stroke="#444444" marker-end="url(#c4-arrow)" stroke-width="1"/>
+      <text x="710" y="565" class="c4-rel-label" text-anchor="middle" font-size="12" fill="#444444">Makes API calls to</text>
+      <text x="710" y="578" class="c4-rel-technology" fill="#444444" text-anchor="middle" font-size="12" font-style="italic">[JSON/HTTPS]</text>
     </g>
     <g class="c4-relationship-group">
-      <path d="M710,705 Q710,730 710,755" class="c4-relationship" stroke="#666666" stroke-width="1" marker-end="url(#c4-arrow)" fill="none"/>
-      <text x="710" y="734" class="c4-rel-label" text-anchor="middle" fill="#666666" font-size="12">Reads from and writes to</text>
-      <text x="710" y="747" class="c4-rel-technology" font-size="12" text-anchor="middle" fill="#666666" font-style="italic">[JDBC]</text>
+      <path d="M710,705 Q710,730 710,755" class="c4-relationship" stroke-width="1" stroke="#444444" marker-end="url(#c4-arrow)" fill="none"/>
+      <text x="710" y="734" class="c4-rel-label" text-anchor="middle" fill="#444444" font-size="12">Reads from and writes to</text>
+      <text x="710" y="747" class="c4-rel-technology" text-anchor="middle" fill="#444444" font-style="italic" font-size="12">[JDBC]</text>
     </g>
     <g class="c4-relationship-group">
-      <path d="M710,705 Q710,814.5 710,924" class="c4-relationship" fill="none" stroke="#666666" stroke-width="1" marker-end="url(#c4-arrow)"/>
-      <text x="710" y="818.5" class="c4-rel-label" text-anchor="middle" fill="#666666" font-size="12">Sends messages to</text>
+      <path d="M710,705 Q710,814.5 710,924" class="c4-relationship" marker-end="url(#c4-arrow)" fill="none" stroke="#444444" stroke-width="1"/>
+      <text x="710" y="818.5" class="c4-rel-label" fill="#444444" text-anchor="middle" font-size="12">Sends messages to</text>
     </g>
     <g class="c4-relationship-group">
-      <path d="M266,119.24436090225564 Q278.5,121.5 316,123.75563909774436" class="c4-relationship" stroke-width="1" fill="none" marker-end="url(#c4-arrow)" stroke="#666666"/>
-      <text x="291" y="125.5" class="c4-rel-label" fill="#666666" font-size="12" text-anchor="middle">Sends e-mails to</text>
+      <path d="M266,119.24436090225564 Q278.5,121.5 316,123.75563909774436" class="c4-relationship" marker-end="url(#c4-arrow)" fill="none" stroke-width="1" stroke="#444444"/>
+      <text x="291" y="125.5" class="c4-rel-label" font-size="12" fill="#444444" text-anchor="middle">Sends e-mails to</text>
     </g>
   </g>
 </svg>

--- a/src/render/c4.rs
+++ b/src/render/c4.rs
@@ -31,7 +31,7 @@ const COLOR_COMPONENT_EXT: &str = "#cccccc";
 const COLOR_BOUNDARY: &str = "#444444";
 const COLOR_TEXT_LIGHT: &str = "#ffffff";
 const COLOR_TEXT_DARK: &str = "#333333";
-const COLOR_REL: &str = "#666666";
+const COLOR_REL: &str = "#444444";
 
 /// Render a C4 diagram to SVG
 pub fn render_c4(db: &C4Db, config: &RenderConfig) -> Result<String> {
@@ -852,17 +852,17 @@ fn element_colors(shape_type: &C4ShapeType) -> (&'static str, &'static str, &'st
         C4ShapeType::Person => (COLOR_PERSON, "#073b6f", COLOR_TEXT_LIGHT),
         C4ShapeType::PersonExt => (COLOR_PERSON_EXT, "#4e5b63", COLOR_TEXT_LIGHT),
         C4ShapeType::System | C4ShapeType::SystemDb | C4ShapeType::SystemQueue => {
-            (COLOR_SYSTEM, "#0e5a9d", COLOR_TEXT_LIGHT)
+            (COLOR_SYSTEM, "#0e5ea8", COLOR_TEXT_LIGHT)
         }
         C4ShapeType::SystemExt | C4ShapeType::SystemDbExt | C4ShapeType::SystemQueueExt => {
-            (COLOR_SYSTEM_EXT, "#7a7a7a", COLOR_TEXT_LIGHT)
+            (COLOR_SYSTEM_EXT, "#8a8a8a", COLOR_TEXT_LIGHT)
         }
         C4ShapeType::Container | C4ShapeType::ContainerDb | C4ShapeType::ContainerQueue => {
-            (COLOR_CONTAINER, "#3879b8", COLOR_TEXT_LIGHT)
+            (COLOR_CONTAINER, "#3c7fc0", COLOR_TEXT_LIGHT)
         }
         C4ShapeType::ContainerExt
         | C4ShapeType::ContainerDbExt
-        | C4ShapeType::ContainerQueueExt => (COLOR_CONTAINER_EXT, "#7a7a7a", COLOR_TEXT_LIGHT),
+        | C4ShapeType::ContainerQueueExt => (COLOR_CONTAINER_EXT, "#8a8a8a", COLOR_TEXT_LIGHT),
         C4ShapeType::Component | C4ShapeType::ComponentDb | C4ShapeType::ComponentQueue => {
             (COLOR_COMPONENT, "#6fa8dc", COLOR_TEXT_DARK)
         }
@@ -904,20 +904,45 @@ fn wrap_text(text: &str, max_chars: usize) -> Vec<String> {
     lines
 }
 
-/// Create arrow markers for relationships
+/// Create arrow markers and symbol definitions for C4 diagrams (matching mermaid.js)
 fn create_c4_markers() -> Vec<SvgElement> {
     vec![
-        // Forward arrow (arrowhead)
+        // Symbol definitions (matching mermaid.js C4 icons)
+        SvgElement::Raw {
+            content: r##"<symbol id="computer" width="24" height="24"><path transform="scale(.5)" d="M2 2v13h20v-13h-20zm18 11h-16v-9h16v9zm-10.228 6l.466-1h3.524l.467 1h-4.457zm14.228 3h-24l2-6h2.104l-1.33 4h18.45l-1.297-4h2.073l2 6zm-5-10h-14v-7h14v7z"/></symbol>"##.to_string(),
+        },
+        SvgElement::Raw {
+            content: r##"<symbol id="database" fill-rule="evenodd" clip-rule="evenodd"><path transform="scale(.5)" d="M12.258.001l.256.004.255.005.253.008.251.01.249.012.247.015.246.016.242.019.241.02.239.023.236.024.233.027.231.028.229.031.225.032.223.034.22.036.217.038.214.04.211.041.208.043.205.045.201.046.198.048.194.05.191.051.187.053.183.054.18.056.175.057.172.059.168.06.163.061.16.063.155.064.15.066.074.033.073.033.071.034.07.034.069.035.068.035.067.035.066.035.064.036.064.036.062.036.06.036.06.037.058.037.058.037.055.038.055.038.053.038.052.038.051.039.05.039.048.039.047.039.045.04.044.04.043.04.041.04.04.041.039.041.037.041.036.041.034.041.033.042.032.042.03.042.029.042.027.042.026.043.024.043.023.043.021.043.02.043.018.044.017.043.015.044.013.044.012.044.011.045.009.044.007.045.006.045.004.045.002.045.001.045v17l-.001.045-.002.045-.004.045-.006.045-.007.045-.009.044-.011.045-.012.044-.013.044-.015.044-.017.043-.018.044-.02.043-.021.043-.023.043-.024.043-.026.043-.027.042-.029.042-.03.042-.032.042-.033.042-.034.041-.036.041-.037.041-.039.041-.04.041-.041.04-.043.04-.044.04-.045.04-.047.039-.048.039-.05.039-.051.039-.052.038-.053.038-.055.038-.055.038-.058.037-.058.037-.06.037-.06.036-.062.036-.064.036-.064.036-.066.035-.067.035-.068.035-.069.035-.07.034-.071.034-.073.033-.074.033-.15.066-.155.064-.16.063-.163.061-.168.06-.172.059-.175.057-.18.056-.183.054-.187.053-.191.051-.194.05-.198.048-.201.046-.205.045-.208.043-.211.041-.214.04-.217.038-.22.036-.223.034-.225.032-.229.031-.231.028-.233.027-.236.024-.239.023-.241.02-.242.019-.246.016-.247.015-.249.012-.251.01-.253.008-.255.005-.256.004-.258.001-.258-.001-.256-.004-.255-.005-.253-.008-.251-.01-.249-.012-.247-.015-.245-.016-.243-.019-.241-.02-.238-.023-.236-.024-.234-.027-.231-.028-.228-.031-.226-.032-.223-.034-.22-.036-.217-.038-.214-.04-.211-.041-.208-.043-.204-.045-.201-.046-.198-.048-.195-.05-.19-.051-.187-.053-.184-.054-.179-.056-.176-.057-.172-.059-.167-.06-.164-.061-.159-.063-.155-.064-.151-.066-.074-.033-.072-.033-.072-.034-.07-.034-.069-.035-.068-.035-.067-.035-.066-.035-.064-.036-.063-.036-.062-.036-.061-.036-.06-.037-.058-.037-.057-.037-.056-.038-.055-.038-.053-.038-.052-.038-.051-.039-.049-.039-.049-.039-.046-.039-.046-.04-.044-.04-.043-.04-.041-.04-.04-.041-.039-.041-.037-.041-.036-.041-.034-.041-.033-.042-.032-.042-.03-.042-.029-.042-.027-.042-.026-.043-.024-.043-.023-.043-.021-.043-.02-.043-.018-.044-.017-.043-.015-.044-.013-.044-.012-.044-.011-.045-.009-.044-.007-.045-.006-.045-.004-.045-.002-.045-.001-.045v-17l.001-.045.002-.045.004-.045.006-.045.007-.045.009-.044.011-.045.012-.044.013-.044.015-.044.017-.043.018-.044.02-.043.021-.043.023-.043.024-.043.026-.043.027-.042.029-.042.03-.042.032-.042.033-.042.034-.041.036-.041.037-.041.039-.041.04-.041.041-.04.043-.04.044-.04.046-.04.046-.039.049-.039.049-.039.051-.039.052-.038.053-.038.055-.038.056-.038.057-.037.058-.037.06-.037.061-.036.062-.036.063-.036.064-.036.066-.035.067-.035.068-.035.069-.035.07-.034.072-.034.072-.033.074-.033.151-.066.155-.064.159-.063.164-.061.167-.06.172-.059.176-.057.179-.056.184-.054.187-.053.19-.051.195-.05.198-.048.201-.046.204-.045.208-.043.211-.041.214-.04.217-.038.22-.036.223-.034.226-.032.228-.031.231-.028.234-.027.236-.024.238-.023.241-.02.243-.019.245-.016.247-.015.249-.012.251-.01.253-.008.255-.005.256-.004.258-.001.258.001z"/></symbol>"##.to_string(),
+        },
+        SvgElement::Raw {
+            content: r##"<symbol id="clock" width="24" height="24"><path transform="scale(.5)" d="M12 2c5.514 0 10 4.486 10 10s-4.486 10-10 10-10-4.486-10-10 4.486-10 10-10zm0-2c-6.627 0-12 5.373-12 12s5.373 12 12 12 12-5.373 12-12-5.373-12-12-12zm5.848 12.459c.202.038.202.333.001.372-1.907.361-6.045 1.111-6.547 1.111-.719 0-1.301-.582-1.301-1.301 0-.512.77-5.447 1.125-7.445.034-.192.312-.181.343.014l.985 6.238 5.394 1.011z"/></symbol>"##.to_string(),
+        },
+        // Forward arrow (arrowhead) - matching mermaid.js
         SvgElement::Raw {
             content: r##"<marker id="c4-arrow" refX="9" refY="5" markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="12" orient="auto">
-    <path d="M 0 0 L 10 5 L 0 10 z" fill="#666666"/>
+    <path d="M 0 0 L 10 5 L 0 10 z"/>
 </marker>"##
                 .to_string(),
         },
         // Reverse arrow (arrowend) for BiRel
         SvgElement::Raw {
             content: r##"<marker id="c4-arrow-reverse" refX="1" refY="5" markerUnits="userSpaceOnUse" markerWidth="12" markerHeight="12" orient="auto">
-    <path d="M 10 0 L 0 5 L 10 10 z" fill="#666666"/>
+    <path d="M 10 0 L 0 5 L 10 10 z"/>
+</marker>"##
+                .to_string(),
+        },
+        // Crosshead marker (matching mermaid.js)
+        SvgElement::Raw {
+            content: r##"<marker id="c4-crosshead" markerWidth="15" markerHeight="8" orient="auto" refX="16" refY="4">
+    <path fill="black" stroke="#000000" stroke-width="1px" d="M 9,2 V 6 L16,4 Z" style="stroke-dasharray: 0, 0;"/>
+    <path fill="none" stroke="#000000" stroke-width="1px" d="M 0,1 L 6,7 M 6,1 L 0,7" style="stroke-dasharray: 0, 0;"/>
+</marker>"##
+                .to_string(),
+        },
+        // Filled-head marker (matching mermaid.js)
+        SvgElement::Raw {
+            content: r##"<marker id="c4-filled-head" refX="18" refY="7" markerWidth="20" markerHeight="28" orient="auto">
+    <path d="M 18,7 L9,13 L14,7 L9,1 Z"/>
 </marker>"##
                 .to_string(),
         },

--- a/tests/c4_rendering.rs
+++ b/tests/c4_rendering.rs
@@ -722,4 +722,92 @@ Rel_Left(a, d, "Left")"#;
         let svg = render_c4_svg(input).expect("Failed to render directional relationships");
         assert!(svg.contains("<svg"), "Should produce valid SVG");
     }
+
+    #[test]
+    fn render_relationship_stroke_color_matches_reference() {
+        // mermaid.js uses #444444 for relationship stroke color (svgDraw.js default)
+        let input = r#"C4Context
+Person(a, "Alice", "A person")
+System(b, "System B", "A system")
+Rel(a, b, "Uses")"#;
+
+        let svg = render_c4_svg(input).expect("Failed to render");
+        assert!(
+            svg.contains(r##"stroke="#444444""##),
+            "Relationship stroke should be #444444 to match mermaid.js reference"
+        );
+        assert!(
+            !svg.contains(r##"stroke="#666666""##),
+            "Relationship stroke should NOT be #666666"
+        );
+    }
+
+    #[test]
+    fn render_marker_fill_color_matches_reference() {
+        // mermaid.js arrowhead markers use #444444 fill
+        let input = r#"C4Context
+Person(a, "Alice", "A person")
+System(b, "System B", "A system")
+Rel(a, b, "Uses")"#;
+
+        let svg = render_c4_svg(input).expect("Failed to render");
+        assert!(
+            svg.contains(r##"fill="#444444""##),
+            "Arrow marker fill should be #444444 to match mermaid.js reference"
+        );
+    }
+}
+
+mod symbol_tests {
+    use super::*;
+
+    #[test]
+    fn render_c4_includes_symbol_defs() {
+        // mermaid.js C4 includes symbol definitions for computer, database, clock icons
+        let input = r#"C4Context
+Person(a, "Alice", "A person")
+System(b, "System B", "A system")
+Rel(a, b, "Uses")"#;
+
+        let svg = render_c4_svg(input).expect("Failed to render");
+        assert!(
+            svg.contains(r##"<symbol id="computer""##),
+            "Should include computer symbol definition"
+        );
+        assert!(
+            svg.contains(r##"<symbol id="database""##),
+            "Should include database symbol definition"
+        );
+        assert!(
+            svg.contains(r##"<symbol id="clock""##),
+            "Should include clock symbol definition"
+        );
+    }
+
+    #[test]
+    fn render_c4_includes_all_marker_types() {
+        // mermaid.js has 4 marker types: arrowhead, arrowend, crosshead, filled-head
+        let input = r#"C4Context
+Person(a, "Alice", "A person")
+System(b, "System B", "A system")
+Rel(a, b, "Uses")"#;
+
+        let svg = render_c4_svg(input).expect("Failed to render");
+        assert!(
+            svg.contains(r##"id="c4-arrow""##),
+            "Should include forward arrow marker"
+        );
+        assert!(
+            svg.contains(r##"id="c4-arrow-reverse""##),
+            "Should include reverse arrow marker"
+        );
+        assert!(
+            svg.contains(r##"id="c4-crosshead""##),
+            "Should include crosshead marker"
+        );
+        assert!(
+            svg.contains(r##"id="c4-filled-head""##),
+            "Should include filled-head marker"
+        );
+    }
 }

--- a/tests/c4_rendering.rs
+++ b/tests/c4_rendering.rs
@@ -743,17 +743,28 @@ Rel(a, b, "Uses")"#;
     }
 
     #[test]
-    fn render_marker_fill_color_matches_reference() {
-        // mermaid.js arrowhead markers use #444444 fill
+    fn render_relationship_label_fill_matches_reference() {
+        // Relationship labels use #444444 fill (COLOR_REL), matching mermaid.js
         let input = r#"C4Context
 Person(a, "Alice", "A person")
 System(b, "System B", "A system")
-Rel(a, b, "Uses")"#;
+Rel(a, b, "Uses", "HTTP")"#;
 
         let svg = render_c4_svg(input).expect("Failed to render");
+        // Relationship label text should use #444444 fill
         assert!(
             svg.contains(r##"fill="#444444""##),
-            "Arrow marker fill should be #444444 to match mermaid.js reference"
+            "Relationship label fill should be #444444 to match mermaid.js reference"
+        );
+        // Arrow marker paths should NOT have explicit fill (inherit black per mermaid.js)
+        let marker_section = svg
+            .split(r#"<marker id="c4-arrow""#)
+            .nth(1)
+            .and_then(|s| s.split("</marker>").next())
+            .unwrap_or("");
+        assert!(
+            !marker_section.contains("fill=\"#"),
+            "Arrow marker path should not have explicit fill color — inherits black per mermaid.js"
         );
     }
 }


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Fixed relationship/edge stroke color from `#666666` to `#444444` to match mermaid.js svgDraw.js default
- Updated container stroke (`#3c7fc0`), system-ext stroke (`#8a8a8a`) to match reference SVGs
- Added SVG symbol definitions (computer, database, clock icons) that mermaid.js includes in C4 defs
- Added crosshead and filled-head marker types to match reference's 4 marker set
- Removed explicit `fill="#444444"` from arrow marker paths (reference inherits fill from context)
- Eval color match improved from 60% to 70%; path count warnings eliminated

## Test plan
- [x] All 30 C4 rendering tests pass (including 4 new tests)
- [x] `cargo fmt` and `cargo clippy` clean
- [x] Eval confirms color improvement and structural match
- [x] Updated docs/images SVGs

🤖 Generated with [Claude Code](https://claude.ai/code)