### PR TITLE
chore: bump version to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,7 +1015,7 @@ checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "selkie-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "atty",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "selkie-rs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "A Rust implementation of the mermaid diagramming parser and renderer"
 license = "MIT"


### PR DESCRIPTION
<!-- midtown: vernon -->

## Summary
- Bumps crate version from 0.1.0 to 0.2.0 for the first point release
- After merge, tag `v0.2.0` and create GitHub release with release notes

## Changes since 0.1.0

### Rendering Fixes
- **Architecture**: z-order and node spacing corrections
- **State**: composite sizing, edge routing, stroke-width, color palette, nested centering
- **Block**: rect count mismatch, z-order, and layout fixes
- **ER**: theme colors and layout spacing
- **Sequence**: SVG structure, fragment frames, z-order, message classes, autonumber
- **Requirement**: CSS colors and stroke-width alignment
- **Mindmap**: label extraction for `<br/>` in `<p>` tags, missing CSS
- **Sankey**: node height calculation
- **Kanban**: card width, CSS-based styling
- **Treemap**: label positioning, font size, colors, viewBox
- **XYChart**: stroke attributes, visual parity
- **Quadrant**: visual parity improvements
- **Timeline**: visual parity improvements
- **Pie**: visual parity improvements
- **SVG z-order**: shapes rendered before text globally

### Features
- **Eval**: `--use-repo-svgs` flag for CI, improved analysis
- **TUI renderer**: braille edge routing, arrow tips, node shapes
- **Refactor**: extracted `text_utils.rs` for shared utilities
- **Crate rename**: `selkie-diagrams` → `selkie-rs`

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt` clean
- [x] `cargo clippy --features all-formats -- -D warnings` clean
- [x] `cargo test --features all-formats` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)