### PR TITLE
feat(tui): add TUI rendering for pie charts with eval

### DIFF
--- a/src/bin/selkie.rs
+++ b/src/bin/selkie.rs
@@ -770,6 +770,7 @@ fn run_eval_tui(args: EvalArgs) -> Result<(), Box<dyn std::error::Error>> {
         "er",
         "architecture",
         "requirement",
+        "pie",
     ];
 
     // Filter to TUI-supported types, or a specific type if requested
@@ -822,6 +823,53 @@ fn run_eval_tui(args: EvalArgs) -> Result<(), Box<dyn std::error::Error>> {
                 continue;
             }
         };
+
+        // Pie charts don't use LayoutGraph — handle with dedicated eval path
+        if let selkie::diagrams::Diagram::Pie(ref db) = parsed {
+            let tui_output = match tui_render::pie::render_pie_tui(db) {
+                Ok(output) => output,
+                Err(e) => {
+                    eprintln!(" RENDER ERROR: {}", e);
+                    total_errors += 1;
+                    continue;
+                }
+            };
+
+            let issues = tui_checks::check_tui_pie_structure(&tui_output, db);
+            let similarity = tui_checks::calculate_tui_pie_similarity(&tui_output, db);
+            total_similarity += similarity;
+
+            let error_count = issues
+                .iter()
+                .filter(|i| i.level == eval::Level::Error)
+                .count();
+            let warning_count = issues
+                .iter()
+                .filter(|i| i.level == eval::Level::Warning)
+                .count();
+            total_issues += issues.len();
+            total_errors += error_count;
+
+            if args.verbose && !issues.is_empty() {
+                eprintln!();
+                eprintln!(
+                    "  {} ({} errors, {} warnings, similarity: {:.1}%):",
+                    input.name,
+                    error_count,
+                    warning_count,
+                    similarity * 100.0
+                );
+                for issue in &issues {
+                    let level = match issue.level {
+                        eval::Level::Error => "ERROR",
+                        eval::Level::Warning => "WARN",
+                        eval::Level::Info => "INFO",
+                    };
+                    eprintln!("    [{}] {}: {}", level, issue.check, issue.message);
+                }
+            }
+            continue;
+        }
 
         // Layout — use ToLayoutGraph trait to get a layout graph for any supported type
         let graph = match layout_diagram(&parsed, &estimator) {
@@ -1180,6 +1228,11 @@ fn render_tui(diagram: &selkie::diagrams::Diagram) -> Result<String, Box<dyn std
             let graph = db.to_layout_graph(&estimator)?;
             let graph = layout::layout(graph)?;
             Ok(tui_render::render_graph_tui(&graph)?)
+        }
+        // Pie charts use a dedicated bar-chart renderer (no layout graph needed)
+        selkie::diagrams::Diagram::Pie(db) => {
+            let output = tui_render::pie::render_pie_tui(db)?;
+            Ok(output)
         }
         _ => Err("TUI format not yet supported for this diagram type".into()),
     }

--- a/src/eval/tui_checks.rs
+++ b/src/eval/tui_checks.rs
@@ -531,6 +531,146 @@ pub fn calculate_tui_similarity(tui: &TuiStructure, graph: &LayoutGraph) -> f64 
     }
 }
 
+// --- Pie chart-specific TUI evaluation ---
+
+/// Check TUI pie chart output against the PieDb ground truth.
+///
+/// Since pie charts don't use LayoutGraph, we compare directly against PieDb:
+/// - All section labels must appear in the output
+/// - Percentage values should be present
+/// - Title should appear if set
+pub fn check_tui_pie_structure(output: &str, db: &crate::diagrams::pie::PieDb) -> Vec<Issue> {
+    let mut issues = Vec::new();
+    let sections = db.get_sections();
+    let total: f64 = sections.iter().map(|(_, v)| *v).sum();
+
+    // Check title
+    if let Some(title) = db.get_diagram_title() {
+        if !output.contains(title) {
+            issues.push(Issue::error(
+                "tui_pie_missing_title",
+                format!("TUI pie output missing title: '{}'", title),
+            ));
+        }
+    }
+
+    if total <= 0.0 || sections.is_empty() {
+        return issues;
+    }
+
+    // Check section labels
+    for (label, _) in sections {
+        if !output.contains(label.as_str()) {
+            issues.push(Issue::error(
+                "tui_pie_missing_label",
+                format!("TUI pie output missing section label: '{}'", label),
+            ));
+        }
+    }
+
+    // Check percentages appear
+    for (label, value) in sections {
+        let pct = value / total * 100.0;
+        let pct_str = format!("{:.1}%", pct);
+        if !output.contains(&pct_str) {
+            issues.push(Issue::warning(
+                "tui_pie_missing_percentage",
+                format!(
+                    "TUI pie output missing percentage for '{}': expected {}",
+                    label, pct_str
+                ),
+            ));
+        }
+    }
+
+    // Check showData values appear
+    if db.get_show_data() {
+        for (label, value) in sections {
+            let value_str = if value.fract() == 0.0 {
+                format!("[{}]", *value as i64)
+            } else {
+                format!("[{}]", value)
+            };
+            if !output.contains(&value_str) {
+                issues.push(Issue::warning(
+                    "tui_pie_missing_data_value",
+                    format!(
+                        "TUI pie output missing data value for '{}': expected {}",
+                        label, value_str
+                    ),
+                ));
+            }
+        }
+    }
+
+    // Check bar characters are present (at least one █ or ▌)
+    let has_bars = output.contains('█') || output.contains('▌');
+    if !has_bars {
+        issues.push(Issue::error(
+            "tui_pie_no_bars",
+            "TUI pie output has no bar characters (█/▌)".to_string(),
+        ));
+    }
+
+    issues
+}
+
+/// Calculate a similarity score (0.0–1.0) for TUI pie chart output.
+///
+/// Factors:
+/// - Section label presence (50%)
+/// - Percentage value presence (30%)
+/// - Title presence (10%)
+/// - Bar character presence (10%)
+pub fn calculate_tui_pie_similarity(output: &str, db: &crate::diagrams::pie::PieDb) -> f64 {
+    let sections = db.get_sections();
+    let total: f64 = sections.iter().map(|(_, v)| *v).sum();
+
+    if sections.is_empty() || total <= 0.0 {
+        // Empty chart — if output says "empty" or "no data", that's correct
+        if output.contains("empty") || output.contains("no data") {
+            return 1.0;
+        }
+        return 0.0;
+    }
+
+    let mut score = 0.0;
+
+    // Label presence (50% weight)
+    let label_count = sections
+        .iter()
+        .filter(|(label, _)| output.contains(label.as_str()))
+        .count();
+    score += 0.5 * (label_count as f64 / sections.len() as f64);
+
+    // Percentage presence (30% weight)
+    let pct_count = sections
+        .iter()
+        .filter(|(_, value)| {
+            let pct = value / total * 100.0;
+            let pct_str = format!("{:.1}%", pct);
+            output.contains(&pct_str)
+        })
+        .count();
+    score += 0.3 * (pct_count as f64 / sections.len() as f64);
+
+    // Title presence (10% weight)
+    if let Some(title) = db.get_diagram_title() {
+        if output.contains(title) {
+            score += 0.1;
+        }
+    } else {
+        score += 0.1; // No title expected, full credit
+    }
+
+    // Bar characters (10% weight)
+    if output.contains('█') || output.contains('▌') {
+        score += 0.1;
+    }
+
+    score
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/render/tui/mod.rs
+++ b/src/render/tui/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod canvas;
 pub mod edges;
+pub mod pie;
 pub mod scale;
 pub mod shapes;
 

--- a/src/render/tui/pie.rs
+++ b/src/render/tui/pie.rs
@@ -1,0 +1,342 @@
+//! TUI renderer for pie charts.
+//!
+//! Since circular shapes don't render well in character art, pie charts are
+//! displayed as horizontal bar charts with proportional widths, percentages,
+//! and section labels. This preserves the key information while being readable
+//! in any terminal.
+
+use crate::diagrams::pie::PieDb;
+use crate::error::Result;
+
+/// Maximum width for the bar portion of the chart.
+const BAR_WIDTH: usize = 40;
+
+/// Block characters for filled bars.
+const FULL_BLOCK: char = '█';
+const HALF_BLOCK: char = '▌';
+
+/// Render a pie chart as a horizontal bar chart in character art.
+pub fn render_pie_tui(db: &PieDb) -> Result<String> {
+    let sections = db.get_sections();
+    let show_data = db.get_show_data();
+
+    if sections.is_empty() {
+        // Empty chart — just show title if present
+        if let Some(title) = db.get_diagram_title() {
+            return Ok(format!("{}\n\n(empty pie chart)\n", title));
+        }
+        return Ok("(empty pie chart)\n".to_string());
+    }
+
+    let total: f64 = sections.iter().map(|(_, v)| *v).sum();
+    if total <= 0.0 {
+        if let Some(title) = db.get_diagram_title() {
+            return Ok(format!("{}\n\n(no data)\n", title));
+        }
+        return Ok("(no data)\n".to_string());
+    }
+
+    let mut lines: Vec<String> = Vec::new();
+
+    // Title
+    if let Some(title) = db.get_diagram_title() {
+        lines.push(title.to_string());
+        lines.push("─".repeat(title.chars().count().max(BAR_WIDTH)));
+    }
+
+    // Calculate percentages and find longest label for alignment
+    let entries: Vec<(&str, f64, f64)> = sections
+        .iter()
+        .map(|(label, value)| {
+            let pct = *value / total * 100.0;
+            (label.as_str(), *value, pct)
+        })
+        .collect();
+
+    let max_label_len = entries
+        .iter()
+        .map(|(label, value, _)| {
+            if show_data {
+                format_label_with_data(label, *value).chars().count()
+            } else {
+                label.chars().count()
+            }
+        })
+        .max()
+        .unwrap_or(0);
+
+    // Render each section as a bar
+    for (label, value, pct) in &entries {
+        let display_label = if show_data {
+            format_label_with_data(label, *value)
+        } else {
+            label.to_string()
+        };
+
+        // Pad label to align bars
+        let padded_label = format!("{:width$}", display_label, width = max_label_len);
+
+        // Calculate bar width proportional to percentage
+        let bar_cells = (*pct / 100.0) * BAR_WIDTH as f64;
+        let full_cells = bar_cells.floor() as usize;
+        let has_half = (bar_cells - full_cells as f64) >= 0.5;
+
+        let mut bar = String::new();
+        for _ in 0..full_cells {
+            bar.push(FULL_BLOCK);
+        }
+        if has_half {
+            bar.push(HALF_BLOCK);
+        }
+
+        // Ensure at least one block for non-zero values
+        if bar.is_empty() && *pct > 0.0 {
+            bar.push(HALF_BLOCK);
+        }
+
+        let pct_str = format!("{:.1}%", pct);
+        lines.push(format!("  {} │{} {}", padded_label, bar, pct_str));
+    }
+
+    // Add a total line
+    lines.push(String::new());
+    if show_data {
+        let total_str = if total.fract() == 0.0 {
+            format!("{}", total as i64)
+        } else {
+            format!("{:.1}", total)
+        };
+        lines.push(format!("  Total: {}", total_str));
+    }
+
+    lines.push(String::new());
+    Ok(lines.join("\n"))
+}
+
+/// Format a label with its data value (for showData mode).
+fn format_label_with_data(label: &str, value: f64) -> String {
+    let value_str = if value.fract() == 0.0 {
+        format!("{}", value as i64)
+    } else {
+        format!("{}", value)
+    };
+    format!("{} [{}]", label, value_str)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_pie(title: Option<&str>, sections: &[(&str, f64)], show_data: bool) -> PieDb {
+        let mut db = PieDb::new();
+        if let Some(t) = title {
+            db.set_diagram_title(t);
+        }
+        for (label, value) in sections {
+            db.add_section(*label, *value).unwrap();
+        }
+        db.set_show_data(show_data);
+        db
+    }
+
+    #[test]
+    fn empty_pie_chart() {
+        let db = make_pie(None, &[], false);
+        let output = render_pie_tui(&db).unwrap();
+        assert!(
+            output.contains("empty pie chart"),
+            "Empty chart should say so\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn empty_pie_chart_with_title() {
+        let db = make_pie(Some("My Chart"), &[], false);
+        let output = render_pie_tui(&db).unwrap();
+        assert!(output.contains("My Chart"), "Should show title");
+        assert!(output.contains("empty pie chart"));
+    }
+
+    #[test]
+    fn single_section_shows_100_percent() {
+        let db = make_pie(None, &[("Only", 10.0)], false);
+        let output = render_pie_tui(&db).unwrap();
+        assert!(
+            output.contains("100.0%"),
+            "Single section should be 100%\nOutput:\n{}",
+            output
+        );
+        assert!(output.contains("Only"), "Should contain label");
+    }
+
+    #[test]
+    fn two_sections_show_percentages() {
+        let db = make_pie(None, &[("A", 75.0), ("B", 25.0)], false);
+        let output = render_pie_tui(&db).unwrap();
+        assert!(
+            output.contains("75.0%"),
+            "Should show 75%\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("25.0%"),
+            "Should show 25%\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn bars_are_proportional() {
+        let db = make_pie(None, &[("Big", 75.0), ("Small", 25.0)], false);
+        let output = render_pie_tui(&db).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        // Find the bar lines (contain █)
+        let bar_lines: Vec<&str> = lines
+            .iter()
+            .filter(|l| l.contains(FULL_BLOCK) || l.contains(HALF_BLOCK))
+            .copied()
+            .collect();
+        assert_eq!(
+            bar_lines.len(),
+            2,
+            "Should have 2 bar lines\nOutput:\n{}",
+            output
+        );
+
+        // Count block chars in each bar
+        let count_blocks = |line: &str| -> usize {
+            line.chars()
+                .filter(|&c| c == FULL_BLOCK || c == HALF_BLOCK)
+                .count()
+        };
+        let big_blocks = count_blocks(bar_lines[0]);
+        let small_blocks = count_blocks(bar_lines[1]);
+        assert!(
+            big_blocks > small_blocks,
+            "Big section ({}) should have more blocks than Small ({})",
+            big_blocks,
+            small_blocks
+        );
+    }
+
+    #[test]
+    fn title_appears_in_output() {
+        let db = make_pie(
+            Some("Project Distribution"),
+            &[("Dev", 40.0), ("Test", 25.0)],
+            false,
+        );
+        let output = render_pie_tui(&db).unwrap();
+        assert!(
+            output.contains("Project Distribution"),
+            "Title should appear\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn show_data_includes_values() {
+        let db = make_pie(None, &[("Dev", 40.0), ("Test", 25.0)], true);
+        let output = render_pie_tui(&db).unwrap();
+        assert!(
+            output.contains("[40]"),
+            "Should show data value 40\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("[25]"),
+            "Should show data value 25\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Total: 65"),
+            "Should show total\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn labels_are_aligned() {
+        let db = make_pie(None, &[("Short", 10.0), ("Much Longer Label", 10.0)], false);
+        let output = render_pie_tui(&db).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        let bar_lines: Vec<&str> = lines.iter().filter(|l| l.contains('│')).copied().collect();
+        assert_eq!(bar_lines.len(), 2);
+        // The │ separator should be at the same column position
+        let pipe_pos = |line: &str| line.find('│').unwrap();
+        assert_eq!(
+            pipe_pos(bar_lines[0]),
+            pipe_pos(bar_lines[1]),
+            "Bars should be aligned\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn gallery_pie_renders() {
+        let input = std::fs::read_to_string("docs/sources/pie.mmd").unwrap();
+        let diagram = crate::parse(&input).unwrap();
+        let db = match diagram {
+            crate::diagrams::Diagram::Pie(db) => db,
+            _ => panic!("Expected pie diagram"),
+        };
+        let output = render_pie_tui(&db).unwrap();
+        assert!(
+            output.contains("Development"),
+            "Should contain Development\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Testing"),
+            "Should contain Testing\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("40.0%"),
+            "Dev should be 40%\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn gallery_pie_complex_renders() {
+        let input = std::fs::read_to_string("docs/sources/pie_complex.mmd").unwrap();
+        let diagram = crate::parse(&input).unwrap();
+        let db = match diagram {
+            crate::diagrams::Diagram::Pie(db) => db,
+            _ => panic!("Expected pie diagram"),
+        };
+        let output = render_pie_tui(&db).unwrap();
+        // Complex pie has showData and 8 slices
+        assert!(
+            output.contains("Compute"),
+            "Should contain Compute\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("[35]"),
+            "showData should show value 35\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Cloud Infrastructure Costs"),
+            "Should show title\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn nonzero_section_gets_at_least_one_block() {
+        // A very small section should still show at least one block character
+        let db = make_pie(None, &[("Huge", 99.0), ("Tiny", 1.0)], false);
+        let output = render_pie_tui(&db).unwrap();
+        let tiny_line = output.lines().find(|l| l.contains("Tiny")).unwrap();
+        let has_block = tiny_line.contains(FULL_BLOCK) || tiny_line.contains(HALF_BLOCK);
+        assert!(
+            has_block,
+            "Even 1% should show at least one block\nLine: {}",
+            tiny_line
+        );
+    }
+}


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Renders pie charts as horizontal bar charts using Unicode block characters (█/▌) — circles don't translate well to character art, so proportional bars preserve the key data relationships
- Includes aligned labels, percentage display, optional data values (showData), and title rendering
- Adds pie-specific eval checks (label presence, percentage accuracy, title, bar characters) — scored 100% similarity across all 5 gallery samples
- Adds `Diagram::Pie` branch to `render_tui()` and `run_eval_tui()` with dedicated eval path (pie charts don't use LayoutGraph)

Sample output:
```
Cloud Infrastructure Costs
────────────────────────────────────────
  Compute (EC2/GKE) [35] │██████████████ 35.0%
  Storage (S3/GCS) [18]  │███████ 18.0%
  Database (RDS) [22]    │████████▌ 22.0%
  Networking [8]         │███ 8.0%
  CDN & Edge [6]         │██ 6.0%
  Monitoring [5]         │██ 5.0%
  Security [4]           │█▌ 4.0%
  Other [2]              │▌ 2.0%

  Total: 100
```

## Test plan
- [x] 11 unit tests for pie TUI renderer (empty, single, multi, proportional bars, alignment, showData, gallery samples)
- [x] Full test suite passes (all 1641+ tests)
- [x] `cargo clippy --features all-formats -- -D warnings` clean
- [x] TUI eval: 100% similarity, 0 errors across 5 pie chart samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)