### PR TITLE
feat(tui): add TUI rendering for gantt charts with eval

### DIFF
--- a/src/bin/selkie.rs
+++ b/src/bin/selkie.rs
@@ -772,6 +772,7 @@ fn run_eval_tui(args: EvalArgs) -> Result<(), Box<dyn std::error::Error>> {
         "architecture",
         "requirement",
         "pie",
+        "gantt",
     ];
 
     // Filter to TUI-supported types, or a specific type if requested
@@ -886,6 +887,54 @@ fn run_eval_tui(args: EvalArgs) -> Result<(), Box<dyn std::error::Error>> {
             let tui_struct = tui_checks::parse_tui_sequence(&tui_output);
             let issues = tui_checks::check_tui_sequence_structure(&tui_struct, db);
             let similarity = tui_checks::calculate_tui_sequence_similarity(&tui_struct, db);
+            total_similarity += similarity;
+
+            let error_count = issues
+                .iter()
+                .filter(|i| i.level == eval::Level::Error)
+                .count();
+            let warning_count = issues
+                .iter()
+                .filter(|i| i.level == eval::Level::Warning)
+                .count();
+            total_issues += issues.len();
+            total_errors += error_count;
+
+            if args.verbose && !issues.is_empty() {
+                eprintln!();
+                eprintln!(
+                    "  {} ({} errors, {} warnings, similarity: {:.1}%):",
+                    input.name,
+                    error_count,
+                    warning_count,
+                    similarity * 100.0
+                );
+                for issue in &issues {
+                    let level = match issue.level {
+                        eval::Level::Error => "ERROR",
+                        eval::Level::Warning => "WARN",
+                        eval::Level::Info => "INFO",
+                    };
+                    eprintln!("    [{}] {}: {}", level, issue.check, issue.message);
+                }
+            }
+            continue;
+        }
+
+        // Gantt charts don't use LayoutGraph — handle with dedicated eval path
+        if let selkie::diagrams::Diagram::Gantt(ref db) = parsed {
+            let mut db_clone = db.clone();
+            let tui_output = match tui_render::gantt::render_gantt_tui(&mut db_clone) {
+                Ok(output) => output,
+                Err(e) => {
+                    eprintln!(" RENDER ERROR: {}", e);
+                    total_errors += 1;
+                    continue;
+                }
+            };
+
+            let issues = tui_checks::check_tui_gantt_structure(&tui_output, &mut db_clone);
+            let similarity = tui_checks::calculate_tui_gantt_similarity(&tui_output, &mut db_clone);
             total_similarity += similarity;
 
             let error_count = issues
@@ -1281,6 +1330,12 @@ fn render_tui(diagram: &selkie::diagrams::Diagram) -> Result<String, Box<dyn std
         // Pie charts use a dedicated bar-chart renderer (no layout graph needed)
         selkie::diagrams::Diagram::Pie(db) => {
             let output = tui_render::pie::render_pie_tui(db)?;
+            Ok(output)
+        }
+        // Gantt charts use a dedicated timeline renderer (no layout graph needed)
+        selkie::diagrams::Diagram::Gantt(db) => {
+            let mut db_clone = db.clone();
+            let output = tui_render::gantt::render_gantt_tui(&mut db_clone)?;
             Ok(output)
         }
         _ => Err("TUI format not yet supported for this diagram type".into()),

--- a/src/eval/tui_checks.rs
+++ b/src/eval/tui_checks.rs
@@ -1024,6 +1024,191 @@ pub fn calculate_tui_sequence_similarity(
     }
 }
 
+// --- Gantt chart-specific TUI evaluation ---
+
+/// Check TUI gantt chart output against the GanttDb ground truth.
+///
+/// Since gantt charts don't use LayoutGraph, we compare directly against GanttDb:
+/// - All task names must appear in the output
+/// - Section names should appear
+/// - Title should appear if set
+/// - Status indicators should be present for flagged tasks
+pub fn check_tui_gantt_structure(
+    output: &str,
+    db: &mut crate::diagrams::gantt::GanttDb,
+) -> Vec<Issue> {
+    let mut issues = Vec::new();
+    let tasks = db.get_tasks();
+
+    // Check title
+    let title = db.get_diagram_title();
+    if !title.is_empty() && !output.contains(title) {
+        issues.push(Issue::error(
+            "tui_gantt_missing_title",
+            format!("TUI gantt output missing title: '{}'", title),
+        ));
+    }
+
+    if tasks.is_empty() {
+        return issues;
+    }
+
+    // Check task names (skip vert markers)
+    for task in &tasks {
+        if task.flags.vert {
+            continue;
+        }
+        if !output.contains(&task.task) {
+            issues.push(Issue::error(
+                "tui_gantt_missing_task",
+                format!("TUI gantt output missing task: '{}'", task.task),
+            ));
+        }
+    }
+
+    // Check section names
+    for section in db.get_sections() {
+        if !output.contains(section.as_str()) {
+            issues.push(Issue::warning(
+                "tui_gantt_missing_section",
+                format!("TUI gantt output missing section: '{}'", section),
+            ));
+        }
+    }
+
+    // Check status indicators
+    let has_done = tasks.iter().any(|t| t.flags.done && !t.flags.vert);
+    let has_active = tasks.iter().any(|t| t.flags.active && !t.flags.vert);
+    let has_milestone = tasks.iter().any(|t| t.flags.milestone && !t.flags.vert);
+
+    if has_done && !output.contains('✓') && !output.contains('░') {
+        issues.push(Issue::warning(
+            "tui_gantt_no_done_indicator",
+            "TUI gantt output has done tasks but no done indicator (✓/░)".to_string(),
+        ));
+    }
+    if has_active && !output.contains('►') {
+        issues.push(Issue::warning(
+            "tui_gantt_no_active_indicator",
+            "TUI gantt output has active tasks but no active indicator (►)".to_string(),
+        ));
+    }
+    if has_milestone && !output.contains('◆') {
+        issues.push(Issue::warning(
+            "tui_gantt_no_milestone_indicator",
+            "TUI gantt output has milestones but no milestone indicator (◆)".to_string(),
+        ));
+    }
+
+    // Check bar characters are present
+    let has_bars = output.contains('█') || output.contains('░');
+    if !has_bars {
+        issues.push(Issue::error(
+            "tui_gantt_no_bars",
+            "TUI gantt output has no bar characters (█/░)".to_string(),
+        ));
+    }
+
+    issues
+}
+
+/// Calculate a similarity score (0.0–1.0) for TUI gantt chart output.
+///
+/// Factors:
+/// - Task name presence (40%)
+/// - Section name presence (20%)
+/// - Title presence (15%)
+/// - Status indicator presence (15%)
+/// - Bar character presence (10%)
+pub fn calculate_tui_gantt_similarity(
+    output: &str,
+    db: &mut crate::diagrams::gantt::GanttDb,
+) -> f64 {
+    let tasks = db.get_tasks();
+    let sections = db.get_sections();
+
+    if tasks.is_empty() {
+        if output.contains("empty") || output.contains("no data") || output.contains("no resolved")
+        {
+            return 1.0;
+        }
+        return 0.0;
+    }
+
+    let mut score = 0.0;
+
+    // Task name presence (40% weight)
+    let non_vert_tasks: Vec<_> = tasks.iter().filter(|t| !t.flags.vert).collect();
+    if !non_vert_tasks.is_empty() {
+        let found = non_vert_tasks
+            .iter()
+            .filter(|t| output.contains(&t.task))
+            .count();
+        score += 0.4 * (found as f64 / non_vert_tasks.len() as f64);
+    } else {
+        score += 0.4;
+    }
+
+    // Section name presence (20% weight)
+    if !sections.is_empty() {
+        let found = sections
+            .iter()
+            .filter(|s| output.contains(s.as_str()))
+            .count();
+        score += 0.2 * (found as f64 / sections.len() as f64);
+    } else {
+        score += 0.2;
+    }
+
+    // Title presence (15% weight)
+    let title = db.get_diagram_title();
+    if !title.is_empty() {
+        if output.contains(title) {
+            score += 0.15;
+        }
+    } else {
+        score += 0.15;
+    }
+
+    // Status indicators (15% weight)
+    let mut status_checks = 0;
+    let mut status_found = 0;
+    let has_done = non_vert_tasks.iter().any(|t| t.flags.done);
+    let has_active = non_vert_tasks.iter().any(|t| t.flags.active);
+    let has_milestone = non_vert_tasks.iter().any(|t| t.flags.milestone);
+
+    if has_done {
+        status_checks += 1;
+        if output.contains('✓') || output.contains('░') {
+            status_found += 1;
+        }
+    }
+    if has_active {
+        status_checks += 1;
+        if output.contains('►') {
+            status_found += 1;
+        }
+    }
+    if has_milestone {
+        status_checks += 1;
+        if output.contains('◆') {
+            status_found += 1;
+        }
+    }
+    if status_checks > 0 {
+        score += 0.15 * (status_found as f64 / status_checks as f64);
+    } else {
+        score += 0.15;
+    }
+
+    // Bar characters (10% weight)
+    if output.contains('█') || output.contains('░') {
+        score += 0.1;
+    }
+
+    score
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/render/tui/gantt.rs
+++ b/src/render/tui/gantt.rs
@@ -1,0 +1,465 @@
+//! TUI renderer for Gantt charts.
+//!
+//! Renders gantt charts as horizontal timeline bars in character art.
+//! Each task gets a row with its name, status indicators, and a proportional
+//! bar positioned on a time axis. Section headers act as visual separators.
+
+use chrono::NaiveDateTime;
+
+use crate::diagrams::gantt::GanttDb;
+use crate::error::Result;
+
+/// Width of the timeline bar area in characters.
+const TIMELINE_WIDTH: usize = 50;
+
+/// Block characters for task bars.
+const FULL_BLOCK: char = '█';
+const LIGHT_BLOCK: char = '░';
+
+/// Render a Gantt chart as character art.
+pub fn render_gantt_tui(db: &mut GanttDb) -> Result<String> {
+    let tasks = db.get_tasks();
+
+    if tasks.is_empty() {
+        let title = db.get_diagram_title();
+        if !title.is_empty() {
+            return Ok(format!("{}\n\n(empty gantt chart)\n", title));
+        }
+        return Ok("(empty gantt chart)\n".to_string());
+    }
+
+    // Find the overall time range
+    let mut min_time: Option<NaiveDateTime> = None;
+    let mut max_time: Option<NaiveDateTime> = None;
+
+    for task in &tasks {
+        if task.flags.vert {
+            continue; // Skip vertical markers for range calculation
+        }
+        if let Some(start) = task.start_time {
+            min_time = Some(min_time.map_or(start, |m: NaiveDateTime| m.min(start)));
+        }
+        if let Some(end) = task.end_time {
+            max_time = Some(max_time.map_or(end, |m: NaiveDateTime| m.max(end)));
+        }
+    }
+
+    let (chart_start, chart_end) = match (min_time, max_time) {
+        (Some(s), Some(e)) => {
+            if s == e {
+                // Single-point timeline — extend by 1 day
+                (s, e + chrono::Duration::days(1))
+            } else {
+                (s, e)
+            }
+        }
+        _ => {
+            return Ok("(no resolved dates)\n".to_string());
+        }
+    };
+
+    let total_duration = (chart_end - chart_start).num_seconds().max(1) as f64;
+
+    // Calculate label widths for alignment
+    let max_task_name_len = tasks
+        .iter()
+        .filter(|t| !t.flags.vert)
+        .map(|t| t.task.chars().count())
+        .max()
+        .unwrap_or(0);
+
+    // Add space for status prefix (e.g., "✓ " or "► ")
+    let label_col_width = max_task_name_len + 3;
+
+    let mut lines: Vec<String> = Vec::new();
+
+    // Title
+    let title = db.get_diagram_title();
+    if !title.is_empty() {
+        lines.push(title.to_string());
+        lines.push("─".repeat(label_col_width + 1 + TIMELINE_WIDTH));
+    }
+
+    // Date axis header
+    let start_str = chart_start.format("%Y-%m-%d").to_string();
+    let end_str = chart_end.format("%Y-%m-%d").to_string();
+    let axis_padding = TIMELINE_WIDTH.saturating_sub(start_str.len() + end_str.len());
+    lines.push(format!(
+        "{:width$} │{}{}{}",
+        "",
+        start_str,
+        " ".repeat(axis_padding),
+        end_str,
+        width = label_col_width
+    ));
+    lines.push(format!(
+        "{:width$} │{}",
+        "",
+        "─".repeat(TIMELINE_WIDTH),
+        width = label_col_width
+    ));
+
+    // Track current section for headers
+    let mut current_section = String::new();
+
+    for task in &tasks {
+        // Section header (emit even for vert-only sections)
+        if task.section != current_section && !task.section.is_empty() {
+            current_section = task.section.clone();
+            lines.push(format!("  [{}]", current_section));
+        }
+
+        // Skip vert markers in main task list (no bar rendering)
+        if task.flags.vert {
+            continue;
+        }
+
+        // Status prefix
+        let prefix = if task.flags.milestone {
+            "◆"
+        } else if task.flags.done {
+            "✓"
+        } else if task.flags.active {
+            "►"
+        } else if task.flags.critical {
+            "!"
+        } else {
+            " "
+        };
+
+        // Task name with padding
+        let label = format!("{} {:width$}", prefix, task.task, width = max_task_name_len);
+
+        // Calculate bar position
+        let (bar_start_col, bar_end_col) = match (task.start_time, task.end_time) {
+            (Some(start), Some(end)) => {
+                let start_offset = (start - chart_start).num_seconds() as f64;
+                let end_offset = (end - chart_start).num_seconds() as f64;
+                let col_start =
+                    ((start_offset / total_duration) * TIMELINE_WIDTH as f64).round() as usize;
+                let col_end =
+                    ((end_offset / total_duration) * TIMELINE_WIDTH as f64).round() as usize;
+                (
+                    col_start.min(TIMELINE_WIDTH),
+                    col_end.min(TIMELINE_WIDTH).max(col_start + 1),
+                )
+            }
+            (Some(start), None) => {
+                // No end — show a single marker
+                let start_offset = (start - chart_start).num_seconds() as f64;
+                let col =
+                    ((start_offset / total_duration) * TIMELINE_WIDTH as f64).round() as usize;
+                (
+                    col.min(TIMELINE_WIDTH.saturating_sub(1)),
+                    col.min(TIMELINE_WIDTH.saturating_sub(1)) + 1,
+                )
+            }
+            _ => (0, 1),
+        };
+
+        // Build the timeline bar
+        let mut bar = String::with_capacity(TIMELINE_WIDTH);
+        let bar_char = if task.flags.milestone {
+            '◆'
+        } else if task.flags.done {
+            LIGHT_BLOCK
+        } else {
+            FULL_BLOCK
+        };
+
+        for col in 0..TIMELINE_WIDTH {
+            if col >= bar_start_col && col < bar_end_col {
+                bar.push(bar_char);
+            } else {
+                bar.push(' ');
+            }
+        }
+
+        // Date range suffix
+        let date_suffix = match (task.start_time, task.end_time) {
+            (Some(s), Some(e)) => {
+                let days = (e - s).num_days();
+                if task.flags.milestone {
+                    s.format("%m-%d").to_string()
+                } else {
+                    format!("{}d", days)
+                }
+            }
+            _ => String::new(),
+        };
+
+        lines.push(format!("{} │{} {}", label, bar, date_suffix));
+    }
+
+    lines.push(String::new());
+    Ok(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagrams::gantt::GanttDb;
+
+    fn make_gantt(input: &str) -> GanttDb {
+        let diagram = crate::parse(input).unwrap();
+        match diagram {
+            crate::diagrams::Diagram::Gantt(db) => db,
+            _ => panic!("Expected gantt diagram"),
+        }
+    }
+
+    #[test]
+    fn empty_gantt_chart() {
+        let mut db = GanttDb::new();
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains("empty gantt chart"),
+            "Should indicate empty\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn single_task_renders() {
+        let mut db = make_gantt(
+            "gantt\n    dateFormat YYYY-MM-DD\n    section Dev\n    Task1 :a1, 2024-01-01, 5d",
+        );
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains("Task1"),
+            "Should contain task name\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains(FULL_BLOCK),
+            "Should have bar blocks\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn section_headers_appear() {
+        let mut db = make_gantt(
+            "gantt\n    dateFormat YYYY-MM-DD\n    section Planning\n    Task1 :a1, 2024-01-01, 5d\n    section Dev\n    Task2 :a2, after a1, 3d",
+        );
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains("[Planning]"),
+            "Should show Planning section\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("[Dev]"),
+            "Should show Dev section\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn title_appears() {
+        let mut db = make_gantt(
+            "gantt\n    title My Project\n    dateFormat YYYY-MM-DD\n    section Dev\n    Task1 :a1, 2024-01-01, 5d",
+        );
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains("My Project"),
+            "Should show title\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn done_task_shows_checkmark() {
+        let mut db = make_gantt(
+            "gantt\n    dateFormat YYYY-MM-DD\n    section Dev\n    Task1 :done, a1, 2024-01-01, 5d",
+        );
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains('✓'),
+            "Done task should show ✓\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains(LIGHT_BLOCK),
+            "Done task should use light block\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn active_task_shows_arrow() {
+        let mut db = make_gantt(
+            "gantt\n    dateFormat YYYY-MM-DD\n    section Dev\n    Task1 :active, a1, 2024-01-01, 5d",
+        );
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains('►'),
+            "Active task should show ►\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn critical_task_shows_bang() {
+        let mut db = make_gantt(
+            "gantt\n    dateFormat YYYY-MM-DD\n    section Dev\n    Task1 :crit, a1, 2024-01-01, 5d",
+        );
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains('!'),
+            "Critical task should show !\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn milestone_shows_diamond() {
+        let mut db = make_gantt(
+            "gantt\n    dateFormat YYYY-MM-DD\n    section Dev\n    Task1 :a1, 2024-01-01, 5d\n    Release :milestone, m1, after a1, 1d",
+        );
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains('◆'),
+            "Milestone should show ◆\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn date_axis_shows_range() {
+        let mut db = make_gantt(
+            "gantt\n    dateFormat YYYY-MM-DD\n    section Dev\n    Task1 :a1, 2024-01-01, 5d",
+        );
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains("2024-01-01"),
+            "Should show start date\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("2024-01-06"),
+            "Should show end date\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn duration_shown_in_days() {
+        let mut db = make_gantt(
+            "gantt\n    dateFormat YYYY-MM-DD\n    section Dev\n    Task1 :a1, 2024-01-01, 10d",
+        );
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains("10d"),
+            "Should show duration in days\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn gallery_gantt_renders() {
+        let input = std::fs::read_to_string("docs/sources/gantt.mmd").unwrap();
+        let mut db = make_gantt(&input);
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains("Project Timeline"),
+            "Should show title\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Requirements"),
+            "Should contain task\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("[Planning]"),
+            "Should show section\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("[Development]"),
+            "Should show section\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("[Testing]"),
+            "Should show section\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn gallery_gantt_complex_renders() {
+        let input = std::fs::read_to_string("docs/sources/gantt_complex.mmd").unwrap();
+        let mut db = make_gantt(&input);
+        let output = render_gantt_tui(&mut db).unwrap();
+        assert!(
+            output.contains("Product Launch Timeline"),
+            "Should show title\nOutput:\n{}",
+            output
+        );
+        // Check flags
+        assert!(
+            output.contains('✓'),
+            "Should have done tasks\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains('►'),
+            "Should have active task\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains('◆'),
+            "Should have milestone\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn longer_task_has_wider_bar() {
+        let mut db = make_gantt(
+            "gantt\n    dateFormat YYYY-MM-DD\n    section Dev\n    Short :a1, 2024-01-01, 2d\n    Long  :a2, 2024-01-01, 20d",
+        );
+        let output = render_gantt_tui(&mut db).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+
+        let count_blocks = |line: &str| -> usize {
+            line.chars()
+                .filter(|&c| c == FULL_BLOCK || c == LIGHT_BLOCK)
+                .count()
+        };
+
+        let short_line = lines.iter().find(|l| l.contains("Short")).unwrap();
+        let long_line = lines.iter().find(|l| l.contains("Long")).unwrap();
+        assert!(
+            count_blocks(long_line) > count_blocks(short_line),
+            "Long task should have wider bar\nShort: {}\nLong: {}",
+            short_line,
+            long_line
+        );
+    }
+
+    #[test]
+    fn bars_are_aligned() {
+        let mut db = make_gantt(
+            "gantt\n    dateFormat YYYY-MM-DD\n    section Dev\n    Short :a1, 2024-01-01, 5d\n    Much Longer Name :a2, after a1, 3d",
+        );
+        let output = render_gantt_tui(&mut db).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        let bar_lines: Vec<&str> = lines
+            .iter()
+            .filter(|l| l.contains(FULL_BLOCK))
+            .copied()
+            .collect();
+        assert_eq!(bar_lines.len(), 2, "Should have 2 bar lines");
+        // The │ separator should be at the same column
+        let pipe_pos = |line: &str| line.find('│').unwrap();
+        assert_eq!(
+            pipe_pos(bar_lines[0]),
+            pipe_pos(bar_lines[1]),
+            "Bars should be vertically aligned\nOutput:\n{}",
+            output
+        );
+    }
+}

--- a/src/render/tui/mod.rs
+++ b/src/render/tui/mod.rs
@@ -7,6 +7,7 @@
 
 pub mod canvas;
 pub mod edges;
+pub mod gantt;
 pub mod pie;
 pub mod scale;
 pub mod sequence;


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Renders gantt charts as horizontal timeline bars with proportional date-axis positioning
- Status indicators: ✓ (done), ► (active), ! (critical), ◆ (milestone) — replacing SVG color-based status
- Section headers as `[Name]` separators, date axis with start/end dates, duration suffix in days
- Done tasks use ░ light block, active/normal use █ full block, milestones use ◆ diamond
- Gantt-specific eval checks (task names, sections, title, status indicators, bar presence)
- 100% similarity across all 3 gallery samples, 0 errors

Sample output:
```
Project Timeline
─────────────────────────────────────────────────────────────────────
                   │2024-01-01                              2024-01-31
                   │──────────────────────────────────────────────────
  [Planning]
  Requirements    │████████████                                       7d
  Design          │            ████████                               5d
  [Development]
! Backend         │                    █████████████████              10d
  Frontend        │                    █████████████                  8d
  API Integration │                                     █████         3d
  [Testing]
  Unit Tests      │                                 █████             3d
  QA              │                                          ████████ 5d
```

## Test plan
- [x] 14 unit tests for gantt TUI renderer
- [x] Full test suite passes (1650+ tests)
- [x] `cargo clippy --features all-formats -- -D warnings` clean
- [x] TUI eval: 100% similarity, 0 errors across 3 gantt chart samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)