### PR TITLE
feat(tui): add TUI rendering for mindmap diagrams with eval

### DIFF
--- a/src/bin/selkie.rs
+++ b/src/bin/selkie.rs
@@ -771,6 +771,7 @@ fn run_eval_tui(args: EvalArgs) -> Result<(), Box<dyn std::error::Error>> {
         "er",
         "architecture",
         "requirement",
+        "mindmap",
         "pie",
         "gantt",
     ];
@@ -935,6 +936,53 @@ fn run_eval_tui(args: EvalArgs) -> Result<(), Box<dyn std::error::Error>> {
 
             let issues = tui_checks::check_tui_gantt_structure(&tui_output, &mut db_clone);
             let similarity = tui_checks::calculate_tui_gantt_similarity(&tui_output, &mut db_clone);
+            total_similarity += similarity;
+
+            let error_count = issues
+                .iter()
+                .filter(|i| i.level == eval::Level::Error)
+                .count();
+            let warning_count = issues
+                .iter()
+                .filter(|i| i.level == eval::Level::Warning)
+                .count();
+            total_issues += issues.len();
+            total_errors += error_count;
+
+            if args.verbose && !issues.is_empty() {
+                eprintln!();
+                eprintln!(
+                    "  {} ({} errors, {} warnings, similarity: {:.1}%):",
+                    input.name,
+                    error_count,
+                    warning_count,
+                    similarity * 100.0
+                );
+                for issue in &issues {
+                    let level = match issue.level {
+                        eval::Level::Error => "ERROR",
+                        eval::Level::Warning => "WARN",
+                        eval::Level::Info => "INFO",
+                    };
+                    eprintln!("    [{}] {}: {}", level, issue.check, issue.message);
+                }
+            }
+            continue;
+        }
+
+        // Mindmap doesn't use LayoutGraph — handle with dedicated eval path
+        if let selkie::diagrams::Diagram::Mindmap(ref db) = parsed {
+            let tui_output = match tui_render::mindmap::render_mindmap_tui(db) {
+                Ok(output) => output,
+                Err(e) => {
+                    eprintln!(" RENDER ERROR: {}", e);
+                    total_errors += 1;
+                    continue;
+                }
+            };
+
+            let issues = tui_checks::check_tui_mindmap_structure(&tui_output, db);
+            let similarity = tui_checks::calculate_tui_mindmap_similarity(&tui_output, db);
             total_similarity += similarity;
 
             let error_count = issues
@@ -1342,6 +1390,11 @@ fn render_tui(diagram: &selkie::diagrams::Diagram) -> Result<String, Box<dyn std
         selkie::diagrams::Diagram::Gantt(db) => {
             let mut db_clone = db.clone();
             let output = tui_render::gantt::render_gantt_tui(&mut db_clone)?;
+            Ok(output)
+        }
+        // Mindmap uses a dedicated tree renderer (no layout graph needed)
+        selkie::diagrams::Diagram::Mindmap(db) => {
+            let output = tui_render::mindmap::render_mindmap_tui(db)?;
             Ok(output)
         }
         _ => Err("TUI format not yet supported for this diagram type".into()),

--- a/src/eval/tui_checks.rs
+++ b/src/eval/tui_checks.rs
@@ -1295,6 +1295,105 @@ pub fn calculate_tui_gantt_similarity(
     score
 }
 
+// --- Mindmap-specific TUI evaluation ---
+
+/// Check TUI mindmap output against the MindmapDb ground truth.
+///
+/// Since mindmaps don't use LayoutGraph, we compare directly against MindmapDb:
+/// - All node labels must appear in the output
+/// - Tree structure connectors (├── └── │) should be present
+pub fn check_tui_mindmap_structure(
+    output: &str,
+    db: &crate::diagrams::mindmap::MindmapDb,
+) -> Vec<Issue> {
+    let mut issues = Vec::new();
+
+    let root = match db.get_mindmap() {
+        Some(node) => node,
+        None => return issues,
+    };
+
+    // Collect all labels
+    let labels = crate::render::tui::mindmap::collect_labels(root);
+
+    // Check all labels appear
+    for label in &labels {
+        if !output.contains(label.as_str()) {
+            issues.push(Issue::error(
+                "tui_mindmap_missing_label",
+                format!("TUI mindmap output missing node label: '{}'", label),
+            ));
+        }
+    }
+
+    // Check tree connectors are present (if there are children)
+    let has_children = !root.children.is_empty();
+    if has_children {
+        let has_connectors = output.contains("├──") || output.contains("└──");
+        if !has_connectors {
+            issues.push(Issue::warning(
+                "tui_mindmap_no_connectors",
+                "TUI mindmap output has children but no tree connectors (├──/└──)".to_string(),
+            ));
+        }
+    }
+
+    issues
+}
+
+/// Calculate a similarity score (0.0–1.0) for TUI mindmap output.
+///
+/// Factors:
+/// - Node label presence (70%)
+/// - Tree connector presence (20%)
+/// - Root node presence (10%)
+pub fn calculate_tui_mindmap_similarity(
+    output: &str,
+    db: &crate::diagrams::mindmap::MindmapDb,
+) -> f64 {
+    let root = match db.get_mindmap() {
+        Some(node) => node,
+        None => {
+            if output.contains("empty") {
+                return 1.0;
+            }
+            return 0.0;
+        }
+    };
+
+    let labels = crate::render::tui::mindmap::collect_labels(root);
+    let mut score = 0.0;
+
+    // Label presence (70%)
+    if !labels.is_empty() {
+        let found = labels
+            .iter()
+            .filter(|l| output.contains(l.as_str()))
+            .count();
+        score += 0.7 * (found as f64 / labels.len() as f64);
+    } else {
+        score += 0.7;
+    }
+
+    // Tree connectors (20%)
+    if !root.children.is_empty() {
+        if output.contains("├──") || output.contains("└──") {
+            score += 0.2;
+        }
+    } else {
+        score += 0.2;
+    }
+
+    // Root node (10%)
+    let root_text = root.descr.replace("<br/>", " ").replace("<br>", " ");
+    let root_text = root_text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if output.contains(&root_text) {
+        score += 0.1;
+    }
+
+    score
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/render/tui/mindmap.rs
+++ b/src/render/tui/mindmap.rs
@@ -1,0 +1,272 @@
+//! TUI renderer for mindmap diagrams.
+//!
+//! Renders mindmaps as indented tree structures with branch connectors,
+//! similar to the `tree` command output. Node shapes are indicated by
+//! bracket style matching the mermaid syntax.
+
+use crate::diagrams::mindmap::{MindmapDb, MindmapNode, NodeType};
+use crate::error::Result;
+
+/// Render a mindmap as an indented tree in character art.
+pub fn render_mindmap_tui(db: &MindmapDb) -> Result<String> {
+    let root = match db.get_mindmap() {
+        Some(node) => node,
+        None => return Ok("(empty mindmap)\n".to_string()),
+    };
+
+    let mut lines: Vec<String> = Vec::new();
+
+    // Render root node
+    lines.push(format_node(root));
+
+    // Render children recursively
+    render_children(&root.children, "", &mut lines);
+
+    lines.push(String::new());
+    Ok(lines.join("\n"))
+}
+
+/// Format a node label with shape indicators matching mermaid syntax.
+fn format_node(node: &MindmapNode) -> String {
+    let text = clean_text(&node.descr);
+    match node.node_type {
+        NodeType::Default => text,
+        NodeType::Rect => format!("[{}]", text),
+        NodeType::RoundedRect => format!("({})", text),
+        NodeType::Circle => format!("(({}))", text),
+        NodeType::Cloud => format!("){}(", text),
+        NodeType::Bang => format!(")){}((", text),
+        NodeType::Hexagon => format!("{{{{{}}}}}", text),
+    }
+}
+
+/// Clean HTML line breaks and normalize whitespace.
+fn clean_text(raw: &str) -> String {
+    let cleaned = raw.replace("<br/>", " ").replace("<br>", " ");
+    cleaned.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Recursively render children with tree branch connectors.
+fn render_children(children: &[MindmapNode], prefix: &str, lines: &mut Vec<String>) {
+    for (i, child) in children.iter().enumerate() {
+        let is_last = i == children.len() - 1;
+        let connector = if is_last { "└── " } else { "├── " };
+        let child_prefix = if is_last { "    " } else { "│   " };
+
+        lines.push(format!("{}{}{}", prefix, connector, format_node(child)));
+
+        // Recurse into grandchildren
+        let new_prefix = format!("{}{}", prefix, child_prefix);
+        render_children(&child.children, &new_prefix, lines);
+    }
+}
+
+/// Collect all node labels from the mindmap tree (for eval).
+pub fn collect_labels(node: &MindmapNode) -> Vec<String> {
+    let mut labels = vec![clean_text(&node.descr)];
+    for child in &node.children {
+        labels.extend(collect_labels(child));
+    }
+    labels
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_mindmap(input: &str) -> MindmapDb {
+        let diagram = crate::parse(input).unwrap();
+        match diagram {
+            crate::diagrams::Diagram::Mindmap(db) => db,
+            _ => panic!("Expected mindmap diagram"),
+        }
+    }
+
+    #[test]
+    fn empty_mindmap() {
+        let db = MindmapDb::new();
+        let output = render_mindmap_tui(&db).unwrap();
+        assert!(
+            output.contains("empty mindmap"),
+            "Should indicate empty\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn root_only() {
+        let db = make_mindmap("mindmap\n  root((Main Topic))");
+        let output = render_mindmap_tui(&db).unwrap();
+        assert!(
+            output.contains("((Main Topic))"),
+            "Root should show circle shape\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn simple_tree_structure() {
+        let db = make_mindmap("mindmap\n  root\n    Child1\n    Child2");
+        let output = render_mindmap_tui(&db).unwrap();
+        assert!(output.contains("root"), "Should contain root");
+        assert!(
+            output.contains("Child1"),
+            "Should contain Child1\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Child2"),
+            "Should contain Child2\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn tree_connectors_present() {
+        let db = make_mindmap("mindmap\n  root\n    Child1\n    Child2");
+        let output = render_mindmap_tui(&db).unwrap();
+        assert!(
+            output.contains("├──"),
+            "Should have branch connector\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("└──"),
+            "Should have last-child connector\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn nested_children() {
+        let db = make_mindmap(
+            "mindmap\n  root\n    Parent\n      GrandChild1\n      GrandChild2\n    Sibling",
+        );
+        let output = render_mindmap_tui(&db).unwrap();
+        assert!(
+            output.contains("GrandChild1"),
+            "Should contain nested child\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("│"),
+            "Should have vertical connector for nested\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn node_shapes_rendered() {
+        let db = make_mindmap(
+            "mindmap\n  root((Circle))\n    [Rectangle]\n    (Rounded)\n    )Cloud(\n    ))Bang((",
+        );
+        let output = render_mindmap_tui(&db).unwrap();
+        assert!(
+            output.contains("((Circle))"),
+            "Circle shape\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("[Rectangle]"),
+            "Rect shape\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("(Rounded)"),
+            "Rounded shape\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains(")Cloud("),
+            "Cloud shape\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("))Bang(("),
+            "Bang shape\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn gallery_mindmap_renders() {
+        let input = std::fs::read_to_string("docs/sources/mindmap.mmd").unwrap();
+        let db = make_mindmap(&input);
+        let output = render_mindmap_tui(&db).unwrap();
+        assert!(
+            output.contains("mindmap"),
+            "Should contain root label\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Origins"),
+            "Should contain Origins\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Research"),
+            "Should contain Research\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Tools"),
+            "Should contain Tools\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Mermaid"),
+            "Should contain Mermaid\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn gallery_mindmap_complex_renders() {
+        let input = std::fs::read_to_string("docs/sources/mindmap_complex.mmd").unwrap();
+        let db = make_mindmap(&input);
+        let output = render_mindmap_tui(&db).unwrap();
+        assert!(
+            output.contains("mindmap"),
+            "Should contain root\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Creative techniques"),
+            "Should contain deep nested node\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains(")I am a cloud("),
+            "Should show cloud shape\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("))I am a bang(("),
+            "Should show bang shape\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn collect_labels_gets_all() {
+        let db = make_mindmap("mindmap\n  root\n    A\n      B\n    C");
+        let root = db.get_mindmap().unwrap();
+        let labels = collect_labels(root);
+        assert!(labels.contains(&"root".to_string()));
+        assert!(labels.contains(&"A".to_string()));
+        assert!(labels.contains(&"B".to_string()));
+        assert!(labels.contains(&"C".to_string()));
+    }
+
+    #[test]
+    fn last_child_uses_corner_connector() {
+        let db = make_mindmap("mindmap\n  root\n    OnlyChild");
+        let output = render_mindmap_tui(&db).unwrap();
+        // Single child should use └── (last-child connector)
+        assert!(
+            output.contains("└── OnlyChild"),
+            "Only child should use └──\nOutput:\n{}",
+            output
+        );
+    }
+}

--- a/src/render/tui/mod.rs
+++ b/src/render/tui/mod.rs
@@ -8,6 +8,7 @@
 pub mod canvas;
 pub mod edges;
 pub mod gantt;
+pub mod mindmap;
 pub mod pie;
 pub mod scale;
 pub mod sequence;


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Renders mindmaps as indented tree structures with Unix tree-style connectors (├── └── │)
- Node shapes indicated by bracket style matching mermaid syntax: `((circle))`, `[rect]`, `(rounded)`, `)cloud(`, `))bang((`
- Recursive rendering with proper last-child vs middle-child connector distinction
- Mindmap-specific eval checks (label presence, tree connectors, root node)
- 100% similarity across all 2 gallery samples

Sample output:
```
((mindmap))
├── Origins
│   ├── Long history
│   └── Popularisation
│       └── British popular psychology author Tony Buzan
├── Research
│   ├── On effectiveness and features
│   └── On Automatic creation
│       └── Uses
│           ├── Creative techniques
│           ├── Strategic planning
│           └── Argument mapping
└── Tools
    ├── Pen and paper
    └── Mermaid
        ├── )I am a cloud(
        └── ))I am a bang((
```

## Test plan
- [x] 10 unit tests for mindmap TUI renderer
- [x] Full test suite passes (1646+ tests)
- [x] `cargo clippy --features all-formats -- -D warnings` clean
- [x] TUI eval: 100% similarity, 0 errors across 2 mindmap samples

🤖 Generated with [Claude Code](https://claude.com/claude-code)