### PR TITLE
fix(eval): fix Issue struct literals and duplicate match arms in ascii_checks

### DIFF
--- a/src/eval/ascii_checks.rs
+++ b/src/eval/ascii_checks.rs
@@ -1431,30 +1431,27 @@ pub fn check_ascii_text_output(output: &str, diagram_type: &str) -> Vec<Issue> {
 
     // Check output is non-empty
     if output.trim().is_empty() {
-        issues.push(Issue {
-            check: format!("ascii_{}_output", diagram_type),
-            message: "ASCII output is empty".to_string(),
-            level: super::Level::Error,
-        });
+        issues.push(Issue::error(
+            format!("ascii_{}_output", diagram_type),
+            "ASCII output is empty",
+        ));
         return issues;
     }
 
     // Check output has reasonable length (not just a placeholder)
     if output.trim().lines().count() < 2 {
-        issues.push(Issue {
-            check: format!("ascii_{}_content", diagram_type),
-            message: "ASCII output has fewer than 2 lines".to_string(),
-            level: super::Level::Warning,
-        });
+        issues.push(Issue::warning(
+            format!("ascii_{}_content", diagram_type),
+            "ASCII output has fewer than 2 lines",
+        ));
     }
 
     // Check for "empty" placeholder (acceptable for empty diagrams, but flagged)
     if output.contains("(empty") {
-        issues.push(Issue {
-            check: format!("ascii_{}_empty", diagram_type),
-            message: "ASCII output contains empty placeholder".to_string(),
-            level: super::Level::Warning,
-        });
+        issues.push(Issue::warning(
+            format!("ascii_{}_empty", diagram_type),
+            "ASCII output contains empty placeholder",
+        ));
     }
 
     issues
@@ -1503,11 +1500,9 @@ pub fn calculate_ascii_text_similarity(output: &str) -> f64 {
                 | '◉'
                 | '★'
                 | '§'
-                | '◆'
                 | '▶'
                 | '▼'
                 | '◀'
-                | '▲'
                 | '→'
         )
     });


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Converted 3 raw `Issue { ... }` struct literals to use `Issue::error()`/`Issue::warning()` constructors, which properly supply the `expected` and `actual` fields added in recent PRs
- Removed duplicate `'◆'` and `'▲'` match arms in `calculate_ascii_text_similarity` that were introduced during the tui → ascii rename merge

These were merge artifacts from PR #160 (remaining diagram types) and PR #161 (rename tui → ascii). The function `check_ascii_text_output` is currently unused dead code, so the missing fields didn't cause a compile error yet — but would break as soon as the function gets called.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --features all-formats -- -D warnings` — no warnings
- [x] `cargo test --features all-formats` — all 40 tests + 4 doc-tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)