### PR TITLE
fix(eval): add missing Issue fields and remove duplicate match arms

### DIFF
--- a/src/bin/selkie.rs
+++ b/src/bin/selkie.rs
@@ -801,7 +801,7 @@ fn run_eval_ascii(args: EvalArgs) -> Result<(), Box<dyn std::error::Error>> {
                     ascii_supported_types.contains(&dt.as_str())
                 } else {
                     let detected = detect_diagram_type(&i.text);
-                    detected.map_or(false, |t| ascii_supported_types.contains(&t))
+                    detected.is_some_and(|t| ascii_supported_types.contains(&t))
                 }
             }
         })

--- a/src/eval/ascii_checks.rs
+++ b/src/eval/ascii_checks.rs
@@ -1435,6 +1435,8 @@ pub fn check_ascii_text_output(output: &str, diagram_type: &str) -> Vec<Issue> {
             check: format!("ascii_{}_output", diagram_type),
             message: "ASCII output is empty".to_string(),
             level: super::Level::Error,
+            expected: None,
+            actual: None,
         });
         return issues;
     }
@@ -1445,6 +1447,8 @@ pub fn check_ascii_text_output(output: &str, diagram_type: &str) -> Vec<Issue> {
             check: format!("ascii_{}_content", diagram_type),
             message: "ASCII output has fewer than 2 lines".to_string(),
             level: super::Level::Warning,
+            expected: None,
+            actual: None,
         });
     }
 
@@ -1454,6 +1458,8 @@ pub fn check_ascii_text_output(output: &str, diagram_type: &str) -> Vec<Issue> {
             check: format!("ascii_{}_empty", diagram_type),
             message: "ASCII output contains empty placeholder".to_string(),
             level: super::Level::Warning,
+            expected: None,
+            actual: None,
         });
     }
 
@@ -1503,11 +1509,9 @@ pub fn calculate_ascii_text_similarity(output: &str) -> f64 {
                 | '◉'
                 | '★'
                 | '§'
-                | '◆'
                 | '▶'
                 | '▼'
                 | '◀'
-                | '▲'
                 | '→'
         )
     });


### PR DESCRIPTION
<!-- midtown: columbus -->

## Summary
- Added missing `expected` and `actual` fields to 3 `Issue` struct literals in `ascii_checks.rs` (fixes compile errors after the struct gained new fields)
- Removed duplicate `'◆'` and `'▲'` match arms in `calculate_ascii_text_similarity`
- Fixed clippy lint: `map_or(false, ...)` → `is_some_and(...)` in `selkie.rs`

## Context
These compile errors were blocking the deploy-playground workflow on main.

## Test plan
- [x] Fixes compile errors introduced by recent refactor
- [x] No behavioral changes — struct fields set to `None`, duplicate arms removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)