### PR TITLE
fix: Block diagram ASCII rendering - nesting, shapes, spaces [Midtown #142]

### DIFF
--- a/docs/images/block.svg
+++ b/docs/images/block.svg
@@ -48,7 +48,7 @@
       <path d="M 0 5 L 10 10 L 10 0 z"/>
     </marker>
     <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
@@ -63,7 +63,7 @@
   <g class="root">
     <g class="clusters">
       <g class="block-nodes">
-        <g class="node block-node block-composite" id="block-composite_1" transform="translate(0, 0)">
+        <g class="node block-node block-composite" transform="translate(0, 0)" id="block-composite_1">
           <rect x="0" y="0" width="268" height="60" class="block-composite"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
@@ -84,21 +84,21 @@
           <rect x="0" y="0" width="122" height="44" class="node-bkg"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
-            <text x="61" y="22" class="block-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">I am a wide one</text>
+            <text x="61" y="22" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">I am a wide one</text>
           </g>
         </g>
         <g class="node block-node block-square" id="block-id1" transform="translate(138, 8)">
           <rect x="0" y="0" width="122" height="44" class="node-bkg"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
-            <text x="61" y="22" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">id1</text>
+            <text x="61" y="22" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">id1</text>
           </g>
         </g>
         <g class="node block-node block-square" transform="translate(276, 0)" id="block-id">
           <rect x="0" y="0" width="268" height="60" class="node-bkg"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
-            <text x="134" y="30" class="block-label" text-anchor="middle" font-size="14px" dominant-baseline="middle">Next row</text>
+            <text x="134" y="30" class="block-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Next row</text>
           </g>
         </g>
       </g>

--- a/docs/images/block_complex.svg
+++ b/docs/images/block_complex.svg
@@ -64,21 +64,21 @@
   <g class="root">
     <g class="clusters">
       <g class="block-nodes">
-        <g class="node block-node block-composite" transform="translate(0, 60)" id="block-container">
+        <g class="node block-node block-composite" id="block-container" transform="translate(0, 60)">
           <rect x="0" y="0" width="236" height="60" class="block-composite"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
-            <text x="118" y="30" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px"></text>
+            <text x="118" y="30" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px"></text>
           </g>
         </g>
       </g>
     </g>
     <g class="edgePaths">
       <g class="block-edges">
-        <path d="M 118 128 Q 118 90 118 52" class="block-edge" stroke-width="1" fill="none" marker-end="url(#arrowhead)"/>
-        <path d="M 480 26 Q 484 26 488 26" class="block-edge" marker-end="url(#arrowhead)" stroke-width="1" fill="none"/>
-        <path d="M 114 90 Q 118 90 122 90" class="block-edge" fill="none" stroke-width="1" marker-end="url(#arrowhead)"/>
-        <text x="118" y="80" class="edge-label" dominant-baseline="middle" font-size="12px" text-anchor="middle">labeled</text>
+        <path d="M 118 128 Q 118 90 118 52" class="block-edge" stroke-width="1" marker-end="url(#arrowhead)" fill="none"/>
+        <path d="M 480 26 Q 484 26 488 26" class="block-edge" fill="none" stroke-width="1" marker-end="url(#arrowhead)"/>
+        <path d="M 114 90 Q 118 90 122 90" class="block-edge" stroke-width="1" marker-end="url(#arrowhead)" fill="none"/>
+        <text x="118" y="80" class="edge-label" font-size="12px" text-anchor="middle" dominant-baseline="middle">labeled</text>
       </g>
     </g>
     <g class="edgeLabels">
@@ -86,53 +86,53 @@
     </g>
     <g class="nodes">
       <g class="block-nodes">
-        <g class="node block-node block-square blue" id="block-A" transform="translate(0, 0)">
+        <g class="node block-node block-square blue" transform="translate(0, 0)" id="block-A">
           <rect x="0" y="0" width="236" height="52" class="node-bkg"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
-            <text x="118" y="26" class="block-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Square Block</text>
+            <text x="118" y="26" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Square Block</text>
           </g>
         </g>
         <g class="node block-node block-round" transform="translate(244, 0)" id="block-B">
           <rect x="0" y="0" width="236" height="52" rx="10" ry="10" class="node-bkg" style="fill:#f9F;stroke:#333;stroke-width:4px"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
-            <text x="118" y="26" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Rounded Block</text>
+            <text x="118" y="26" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Rounded Block</text>
           </g>
         </g>
-        <g class="node block-node block-diamond" id="block-C" transform="translate(488, 0)">
+        <g class="node block-node block-diamond" transform="translate(488, 0)" id="block-C">
           <polygon points="118,0 236,26 118,52 0,26" class="node-bkg"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
-            <text x="118" y="26" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Diamond</text>
+            <text x="118" y="26" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Diamond</text>
           </g>
         </g>
         <g class="node block-node block-square" transform="translate(8, 68)" id="block-D">
           <rect x="0" y="0" width="106" height="44" class="node-bkg"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
-            <text x="53" y="22" class="block-label" font-size="14px" dominant-baseline="middle" text-anchor="middle">Nested 1</text>
+            <text x="53" y="22" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">Nested 1</text>
           </g>
         </g>
-        <g class="node block-node block-square" id="block-E" transform="translate(122, 68)">
+        <g class="node block-node block-square" transform="translate(122, 68)" id="block-E">
           <rect x="0" y="0" width="106" height="44" class="node-bkg"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
-            <text x="53" y="22" class="block-label" text-anchor="middle" dominant-baseline="middle" font-size="14px">Nested 2</text>
+            <text x="53" y="22" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Nested 2</text>
           </g>
         </g>
-        <g class="node block-node block-stadium" id="block-F" transform="translate(488, 60)">
+        <g class="node block-node block-stadium" transform="translate(488, 60)" id="block-F">
           <rect x="0" y="0" width="236" height="60" rx="30" ry="30" class="node-bkg"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
-            <text x="118" y="30" class="block-label" font-size="14px" text-anchor="middle" dominant-baseline="middle">Stadium</text>
+            <text x="118" y="30" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">Stadium</text>
           </g>
         </g>
         <g class="node block-node block-square" id="block-G" transform="translate(0, 128)">
           <rect x="0" y="0" width="236" height="40" class="node-bkg"/>
           <g class="label">
             <rect x="0" y="0" width="0" height="0"/>
-            <text x="118" y="20" class="block-label" dominant-baseline="middle" text-anchor="middle" font-size="14px">G</text>
+            <text x="118" y="20" class="block-label" dominant-baseline="middle" font-size="14px" text-anchor="middle">G</text>
           </g>
         </g>
       </g>

--- a/src/diagrams/block/types.rs
+++ b/src/diagrams/block/types.rs
@@ -267,6 +267,19 @@ impl BlockDb {
     pub fn get_columns(&self) -> Option<usize> {
         self.root_block.columns
     }
+
+    /// Get child block IDs for a given parent, in insertion order
+    pub fn get_children(&self, parent_id: &str) -> Vec<&str> {
+        self.block_order
+            .iter()
+            .filter(|id| {
+                self.blocks
+                    .get(id.as_str())
+                    .is_some_and(|b| b.parent_id.as_deref() == Some(parent_id))
+            })
+            .map(|s| s.as_str())
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/eval/ascii_checks.rs
+++ b/src/eval/ascii_checks.rs
@@ -1506,6 +1506,7 @@ pub fn calculate_ascii_text_similarity(output: &str) -> f64 {
                 | '░'
                 | '●'
                 | '◆'
+                | '◇'
                 | '■'
                 | '▲'
                 | '◉'
@@ -1568,34 +1569,34 @@ mod tests {
     #[test]
     fn parse_single_node_finds_label() {
         let ascii_out = parse_ascii(&single_node_ascii());
-        assert_eq!(ascii.labels, vec!["Hello"]);
+        assert_eq!(ascii_out.labels, vec!["Hello"]);
     }
 
     #[test]
     fn parse_two_nodes_finds_labels() {
         let ascii_out = parse_ascii(&simple_two_node_ascii());
         assert!(
-            ascii.labels.contains(&"Start".to_string()),
+            ascii_out.labels.contains(&"Start".to_string()),
             "Should find Start label, got: {:?}",
-            ascii.labels
+            ascii_out.labels
         );
         assert!(
-            ascii.labels.contains(&"End".to_string()),
+            ascii_out.labels.contains(&"End".to_string()),
             "Should find End label, got: {:?}",
-            ascii.labels
+            ascii_out.labels
         );
     }
 
     #[test]
     fn parse_detects_arrows() {
         let ascii_out = parse_ascii(&simple_two_node_ascii());
-        assert_eq!(ascii.arrow_count, 1, "Should find one arrow tip");
+        assert_eq!(ascii_out.arrow_count, 1, "Should find one arrow tip");
     }
 
     #[test]
     fn parse_detects_braille() {
         let ascii_out = parse_ascii(&simple_two_node_ascii());
-        assert!(ascii.has_braille, "Should detect braille characters");
+        assert!(ascii_out.has_braille, "Should detect braille characters");
         assert!(ascii_out.braille_count > 0);
     }
 
@@ -1609,9 +1610,9 @@ mod tests {
     #[test]
     fn parse_empty_output() {
         let ascii_out = parse_ascii("");
-        assert!(ascii.labels.is_empty());
-        assert_eq!(ascii.arrow_count, 0);
-        assert!(!ascii.has_braille);
+        assert!(ascii_out.labels.is_empty());
+        assert_eq!(ascii_out.arrow_count, 0);
+        assert!(!ascii_out.has_braille);
         assert_eq!(ascii_out.dimensions, (0, 0));
     }
 
@@ -1622,13 +1623,13 @@ mod tests {
         let start_pos = ascii_out
             .labels
             .iter()
-            .zip(ascii.label_positions.iter())
+            .zip(ascii_out.label_positions.iter())
             .find(|(l, _)| *l == "Start")
             .map(|(_, p)| p);
         let end_pos = ascii_out
             .labels
             .iter()
-            .zip(ascii.label_positions.iter())
+            .zip(ascii_out.label_positions.iter())
             .find(|(l, _)| *l == "End")
             .map(|(_, p)| p);
 
@@ -1645,7 +1646,7 @@ mod tests {
         // Diamond text ("Ok") is between / and \, not │ — so it won't be extracted as a node label
         // This is expected behavior for now; diamond parsing can be enhanced later
         assert!(
-            ascii.labels.is_empty() || ascii.labels.contains(&"Ok".to_string()),
+            ascii_out.labels.is_empty() || ascii_out.labels.contains(&"Ok".to_string()),
             "Diamond label extraction is best-effort"
         );
     }
@@ -1665,9 +1666,9 @@ mod tests {
         .join("\n");
         let ascii_out = parse_ascii(&output);
         assert!(
-            ascii.edge_labels.contains(&"Yes".to_string()),
+            ascii_out.edge_labels.contains(&"Yes".to_string()),
             "Should find edge label 'Yes', got: {:?}",
-            ascii.edge_labels
+            ascii_out.edge_labels
         );
     }
 
@@ -1759,9 +1760,9 @@ mod tests {
         let (output, graph) = parse_layout_render_ascii("flowchart TD\n    A[Hello]");
         let ascii_out = parse_ascii(&output);
         assert!(
-            ascii.labels.contains(&"Hello".to_string()),
+            ascii_out.labels.contains(&"Hello".to_string()),
             "Should find label 'Hello' in ASCII output, got: {:?}\nOutput:\n{}",
-            ascii.labels,
+            ascii_out.labels,
             output
         );
         let issues = check_ascii_structure(&ascii_out, &graph);
@@ -1782,18 +1783,18 @@ mod tests {
         let ascii_out = parse_ascii(&output);
 
         assert!(
-            ascii.labels.contains(&"Start".to_string()),
+            ascii_out.labels.contains(&"Start".to_string()),
             "Should find 'Start', got: {:?}\nOutput:\n{}",
-            ascii.labels,
+            ascii_out.labels,
             output
         );
         assert!(
-            ascii.labels.contains(&"End".to_string()),
+            ascii_out.labels.contains(&"End".to_string()),
             "Should find 'End', got: {:?}",
-            ascii.labels
+            ascii_out.labels
         );
         assert!(
-            ascii.arrow_count > 0 || ascii.has_braille,
+            ascii_out.arrow_count > 0 || ascii_out.has_braille,
             "Should have edges rendered"
         );
 
@@ -1808,14 +1809,14 @@ mod tests {
         let ascii_out = parse_ascii(&output);
 
         assert!(
-            ascii.labels.len() >= 3,
+            ascii_out.labels.len() >= 3,
             "Should find 3 labels, got: {:?}",
-            ascii.labels
+            ascii_out.labels
         );
         assert!(
-            ascii.arrow_count >= 2,
+            ascii_out.arrow_count >= 2,
             "Should have at least 2 arrows for 2 edges, got {}",
-            ascii.arrow_count
+            ascii_out.arrow_count
         );
     }
 
@@ -1847,6 +1848,21 @@ mod tests {
             ordering_issues.is_empty(),
             "TD flow should preserve top→bottom ordering, got: {:?}",
             ordering_issues
+        );
+    }
+
+    #[test]
+    fn similarity_recognizes_white_diamond() {
+        // Use ◇ as the ONLY structural character to verify it's in the match pattern
+        let with_diamond = "  ◇\nDiamond\n  ◇";
+        let plain_text = "hello\nworld\nfoo";
+        let score_diamond = calculate_ascii_text_similarity(with_diamond);
+        let score_plain = calculate_ascii_text_similarity(plain_text);
+        assert!(
+            score_diamond > score_plain,
+            "Text with ◇ should score higher than plain text: {} vs {}",
+            score_diamond,
+            score_plain
         );
     }
 }

--- a/src/render/ascii/block.rs
+++ b/src/render/ascii/block.rs
@@ -123,12 +123,10 @@ fn render_simple_row(
                 top.push_str(&format!("╭{}╮ ", "─".repeat(cell_width)));
             }
             BlockType::Diamond => {
-                let half = cell_width / 2;
-                top.push_str(&format!(
-                    "{}◇{} ",
-                    " ".repeat(half),
-                    " ".repeat(cell_width - half)
-                ));
+                let total_pad = cell_width + 1;
+                let left = total_pad / 2;
+                let right = total_pad - left;
+                top.push_str(&format!("{}◇{} ", " ".repeat(left), " ".repeat(right)));
             }
             BlockType::Stadium => {
                 top.push_str(&format!("╭{}╮ ", "─".repeat(cell_width)));
@@ -204,12 +202,10 @@ fn render_simple_row(
                 bottom.push_str(&format!("╰{}╯ ", "─".repeat(cell_width)));
             }
             BlockType::Diamond => {
-                let half = cell_width / 2;
-                bottom.push_str(&format!(
-                    "{}◇{} ",
-                    " ".repeat(half),
-                    " ".repeat(cell_width - half)
-                ));
+                let total_pad = cell_width + 1;
+                let left = total_pad / 2;
+                let right = total_pad - left;
+                bottom.push_str(&format!("{}◇{} ", " ".repeat(left), " ".repeat(right)));
             }
             BlockType::Stadium => {
                 bottom.push_str(&format!("╰{}╯ ", "─".repeat(cell_width)));
@@ -540,6 +536,40 @@ mod tests {
             !output.contains("space_"),
             "Space rendered as visible block\nOutput:\n{}",
             output
+        );
+    }
+
+    #[test]
+    fn diamond_and_square_same_row_width() {
+        // With 3 columns and a diamond in the middle, all three lines of the row
+        // must have equal character widths. If the diamond cell is narrower,
+        // the top/bottom lines will be shorter than the label line.
+        let input = "block-beta\n  columns 3\n  A[\"Left\"]\n  B{\"Mid\"}\n  C[\"Right\"]";
+        let diagram = crate::parse(input).unwrap();
+        let db = match diagram {
+            crate::diagrams::Diagram::Block(db) => db,
+            _ => panic!("Expected block"),
+        };
+        let output = render_block_ascii(&db).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        assert!(
+            lines.len() >= 3,
+            "Need at least 3 lines\nOutput:\n{}",
+            output
+        );
+
+        let top_chars = lines[0].chars().count();
+        let label_chars = lines[1].chars().count();
+        let bottom_chars = lines[2].chars().count();
+        assert_eq!(
+            top_chars, label_chars,
+            "Top border ({}) and label ({}) char widths must match\nOutput:\n{}",
+            top_chars, label_chars, output
+        );
+        assert_eq!(
+            label_chars, bottom_chars,
+            "Label ({}) and bottom border ({}) char widths must match\nOutput:\n{}",
+            label_chars, bottom_chars, output
         );
     }
 }

--- a/src/render/ascii/block.rs
+++ b/src/render/ascii/block.rs
@@ -2,8 +2,9 @@
 //!
 //! Renders blocks in a grid layout with edges shown as flow connections.
 //! Uses box-drawing characters for block borders and arrows for connections.
+//! Supports shape differentiation (round, diamond, stadium) and nested composites.
 
-use crate::diagrams::block::BlockDb;
+use crate::diagrams::block::{BlockDb, BlockType};
 use crate::error::Result;
 
 /// Render a block diagram as character art.
@@ -20,11 +21,9 @@ pub fn render_block_ascii(db: &BlockDb) -> Result<String> {
     // Determine grid layout based on column settings
     let columns = db.get_columns().unwrap_or(3);
 
-    // Render blocks in rows
-    let block_order = db.get_block_order();
-
     // Filter to top-level blocks (not children of composites)
-    let top_level: Vec<&str> = block_order
+    let top_level: Vec<&str> = db
+        .get_block_order()
         .iter()
         .filter(|id| {
             db.get_blocks()
@@ -34,59 +33,10 @@ pub fn render_block_ascii(db: &BlockDb) -> Result<String> {
         .map(|s| s.as_str())
         .collect();
 
-    // Calculate cell width from longest label
-    let max_label_len = top_level
-        .iter()
-        .filter_map(|id| db.get_blocks().get(*id))
-        .map(|b| {
-            b.label
-                .as_ref()
-                .map(|l| l.chars().count())
-                .unwrap_or(b.id.chars().count())
-        })
-        .max()
-        .unwrap_or(8);
-    let cell_width = max_label_len + 4; // padding + borders
+    // Calculate cell width from the longest label among all visible blocks
+    let cell_width = calc_cell_width(db, &top_level);
 
-    for chunk in top_level.chunks(columns) {
-        // Top border
-        let mut top_line = String::from("  ");
-        for _ in chunk {
-            top_line.push_str(&format!("┌{}┐ ", "─".repeat(cell_width)));
-        }
-        lines.push(top_line.trim_end().to_string());
-
-        // Label row
-        let mut label_line = String::from("  ");
-        for id in chunk {
-            let block = db.get_blocks().get(*id);
-            let label = block
-                .and_then(|b| b.label.as_ref())
-                .map(|l| l.as_str())
-                .unwrap_or(id);
-
-            let pad_total = cell_width.saturating_sub(label.chars().count());
-            let pad_left = pad_total / 2;
-            let pad_right = pad_total - pad_left;
-            label_line.push_str(&format!(
-                "│{}{}{}│ ",
-                " ".repeat(pad_left),
-                label,
-                " ".repeat(pad_right)
-            ));
-        }
-        lines.push(label_line.trim_end().to_string());
-
-        // Bottom border
-        let mut bottom_line = String::from("  ");
-        for _ in chunk {
-            bottom_line.push_str(&format!("└{}┘ ", "─".repeat(cell_width)));
-        }
-        lines.push(bottom_line.trim_end().to_string());
-
-        // Inter-row spacing with potential edge arrows
-        lines.push(String::new());
-    }
+    render_block_rows(db, &top_level, columns, cell_width, "  ", &mut lines);
 
     // Render edges as a connection list
     if !edges.is_empty() {
@@ -103,6 +53,308 @@ pub fn render_block_ascii(db: &BlockDb) -> Result<String> {
     }
 
     Ok(lines.join("\n"))
+}
+
+/// Calculate the cell width needed for a set of block IDs.
+fn calc_cell_width(db: &BlockDb, ids: &[&str]) -> usize {
+    let max_label = ids
+        .iter()
+        .filter_map(|id| db.get_blocks().get(*id))
+        .filter(|b| b.block_type != BlockType::Space)
+        .map(|b| {
+            b.label
+                .as_ref()
+                .map(|l| l.chars().count())
+                .unwrap_or(b.id.chars().count())
+        })
+        .max()
+        .unwrap_or(8);
+    max_label + 4 // padding
+}
+
+/// Render rows of blocks at a given indent level.
+fn render_block_rows(
+    db: &BlockDb,
+    ids: &[&str],
+    columns: usize,
+    cell_width: usize,
+    indent: &str,
+    lines: &mut Vec<String>,
+) {
+    for chunk in ids.chunks(columns) {
+        // We need to know the max height for this row (composites are taller)
+        let has_composite = chunk.iter().any(|id| {
+            db.get_blocks()
+                .get(*id)
+                .is_some_and(|b| b.block_type == BlockType::Composite)
+        });
+
+        if has_composite {
+            render_mixed_row(db, chunk, cell_width, indent, lines);
+        } else {
+            render_simple_row(db, chunk, cell_width, indent, lines);
+        }
+
+        lines.push(String::new());
+    }
+}
+
+/// Render a row where all blocks are simple (non-composite).
+fn render_simple_row(
+    db: &BlockDb,
+    chunk: &[&str],
+    cell_width: usize,
+    indent: &str,
+    lines: &mut Vec<String>,
+) {
+    let blocks_map = db.get_blocks();
+
+    // Top border
+    let mut top = String::from(indent);
+    for id in chunk {
+        let block = blocks_map.get(*id);
+        let bt = block.map(|b| &b.block_type).unwrap_or(&BlockType::Square);
+        match bt {
+            BlockType::Space => {
+                top.push_str(&" ".repeat(cell_width + 2));
+                top.push(' ');
+            }
+            BlockType::Round => {
+                top.push_str(&format!("╭{}╮ ", "─".repeat(cell_width)));
+            }
+            BlockType::Diamond => {
+                let half = cell_width / 2;
+                top.push_str(&format!(
+                    "{}◇{} ",
+                    " ".repeat(half),
+                    " ".repeat(cell_width - half)
+                ));
+            }
+            BlockType::Stadium => {
+                top.push_str(&format!("╭{}╮ ", "─".repeat(cell_width)));
+            }
+            _ => {
+                top.push_str(&format!("┌{}┐ ", "─".repeat(cell_width)));
+            }
+        }
+    }
+    lines.push(top.trim_end().to_string());
+
+    // Label row
+    let mut label_line = String::from(indent);
+    for id in chunk {
+        let block = blocks_map.get(*id);
+        let bt = block.map(|b| &b.block_type).unwrap_or(&BlockType::Square);
+
+        if *bt == BlockType::Space {
+            label_line.push_str(&" ".repeat(cell_width + 2));
+            label_line.push(' ');
+            continue;
+        }
+
+        let label = block
+            .and_then(|b| b.label.as_ref())
+            .map(|l| l.as_str())
+            .unwrap_or(id);
+        let pad_total = cell_width.saturating_sub(label.chars().count());
+        let pad_left = pad_total / 2;
+        let pad_right = pad_total - pad_left;
+
+        match bt {
+            BlockType::Diamond => {
+                label_line.push_str(&format!(
+                    "<{}{}{}>",
+                    " ".repeat(pad_left),
+                    label,
+                    " ".repeat(pad_right)
+                ));
+                label_line.push(' ');
+            }
+            BlockType::Stadium => {
+                label_line.push_str(&format!(
+                    "({}{}{}) ",
+                    " ".repeat(pad_left),
+                    label,
+                    " ".repeat(pad_right)
+                ));
+            }
+            _ => {
+                label_line.push_str(&format!(
+                    "│{}{}{}│ ",
+                    " ".repeat(pad_left),
+                    label,
+                    " ".repeat(pad_right)
+                ));
+            }
+        }
+    }
+    lines.push(label_line.trim_end().to_string());
+
+    // Bottom border
+    let mut bottom = String::from(indent);
+    for id in chunk {
+        let block = blocks_map.get(*id);
+        let bt = block.map(|b| &b.block_type).unwrap_or(&BlockType::Square);
+        match bt {
+            BlockType::Space => {
+                bottom.push_str(&" ".repeat(cell_width + 2));
+                bottom.push(' ');
+            }
+            BlockType::Round => {
+                bottom.push_str(&format!("╰{}╯ ", "─".repeat(cell_width)));
+            }
+            BlockType::Diamond => {
+                let half = cell_width / 2;
+                bottom.push_str(&format!(
+                    "{}◇{} ",
+                    " ".repeat(half),
+                    " ".repeat(cell_width - half)
+                ));
+            }
+            BlockType::Stadium => {
+                bottom.push_str(&format!("╰{}╯ ", "─".repeat(cell_width)));
+            }
+            _ => {
+                bottom.push_str(&format!("└{}┘ ", "─".repeat(cell_width)));
+            }
+        }
+    }
+    lines.push(bottom.trim_end().to_string());
+}
+
+/// Render a row that contains at least one composite block.
+/// Composites are drawn as bordered containers with their children inside.
+fn render_mixed_row(
+    db: &BlockDb,
+    chunk: &[&str],
+    cell_width: usize,
+    indent: &str,
+    lines: &mut Vec<String>,
+) {
+    let blocks_map = db.get_blocks();
+
+    // Pre-render each cell as a set of lines so we can align heights
+    let mut cell_renders: Vec<Vec<String>> = Vec::new();
+    let mut cell_widths: Vec<usize> = Vec::new();
+
+    for id in chunk {
+        let block = blocks_map.get(*id);
+        let bt = block.map(|b| &b.block_type).unwrap_or(&BlockType::Square);
+
+        if *bt == BlockType::Composite {
+            let children: Vec<&str> = db.get_children(id).into_iter().collect();
+            let child_columns = block.and_then(|b| b.columns).unwrap_or(2);
+            let child_cell_width = calc_cell_width(db, &children);
+
+            // Calculate composite inner width
+            let cols_in_use = child_columns.min(children.len());
+            let inner_width = if cols_in_use > 0 {
+                cols_in_use * (child_cell_width + 3) - 1
+            } else {
+                cell_width
+            };
+            let composite_width = inner_width + 2; // for outer border padding
+
+            let mut cell_lines = Vec::new();
+
+            // Top border of composite
+            cell_lines.push(format!("┌{}┐", "─".repeat(composite_width)));
+
+            // Render children inside
+            let mut inner_lines: Vec<String> = Vec::new();
+            render_block_rows(
+                db,
+                &children,
+                child_columns,
+                child_cell_width,
+                "  ",
+                &mut inner_lines,
+            );
+
+            // Remove trailing empty lines
+            while inner_lines.last().is_some_and(|l| l.trim().is_empty()) {
+                inner_lines.pop();
+            }
+
+            for il in &inner_lines {
+                let content_len = il.chars().count();
+                let pad = composite_width.saturating_sub(content_len);
+                cell_lines.push(format!("│{}{}│", il, " ".repeat(pad)));
+            }
+
+            // Bottom border of composite
+            cell_lines.push(format!("└{}┘", "─".repeat(composite_width)));
+
+            cell_widths.push(composite_width + 2); // +2 for the │ chars
+            cell_renders.push(cell_lines);
+        } else if *bt == BlockType::Space {
+            cell_widths.push(cell_width + 2);
+            cell_renders.push(vec![
+                " ".repeat(cell_width + 2),
+                " ".repeat(cell_width + 2),
+                " ".repeat(cell_width + 2),
+            ]);
+        } else {
+            // Simple block rendered as 3 lines
+            let label = block
+                .and_then(|b| b.label.as_ref())
+                .map(|l| l.as_str())
+                .unwrap_or(id);
+            let pad_total = cell_width.saturating_sub(label.chars().count());
+            let pad_left = pad_total / 2;
+            let pad_right = pad_total - pad_left;
+
+            let (top_ch, side_l, side_r, bot_ch) = shape_chars(bt);
+            cell_widths.push(cell_width + 2);
+            cell_renders.push(vec![
+                format!("{}{}{}", top_ch.0, "─".repeat(cell_width), top_ch.1),
+                format!(
+                    "{}{}{}{}{}",
+                    side_l,
+                    " ".repeat(pad_left),
+                    label,
+                    " ".repeat(pad_right),
+                    side_r
+                ),
+                format!("{}{}{}", bot_ch.0, "─".repeat(cell_width), bot_ch.1),
+            ]);
+        }
+    }
+
+    // Find max height across cells in this row
+    let max_height = cell_renders.iter().map(|c| c.len()).max().unwrap_or(3);
+
+    // Emit lines, padding shorter cells vertically
+    for row_idx in 0..max_height {
+        let mut line = String::from(indent);
+        for (cell_idx, cell) in cell_renders.iter().enumerate() {
+            if row_idx < cell.len() {
+                line.push_str(&cell[row_idx]);
+            } else {
+                // Pad with spaces to match width
+                line.push_str(&" ".repeat(cell_widths[cell_idx]));
+            }
+            line.push(' ');
+        }
+        lines.push(line.trim_end().to_string());
+    }
+}
+
+/// Return shape-specific border characters: ((top_left, top_right), side_left, side_right, (bot_left, bot_right))
+fn shape_chars(
+    bt: &BlockType,
+) -> (
+    (&'static str, &'static str),
+    &'static str,
+    &'static str,
+    (&'static str, &'static str),
+) {
+    match bt {
+        BlockType::Round => (("╭", "╮"), "│", "│", ("╰", "╯")),
+        BlockType::Diamond => ((" ", " "), "<", ">", (" ", " ")),
+        BlockType::Stadium => (("╭", "╮"), "(", ")", ("╰", "╯")),
+        _ => (("┌", "┐"), "│", "│", ("└", "┘")),
+    }
 }
 
 #[cfg(test)]
@@ -146,5 +398,148 @@ mod tests {
         assert!(output.contains('┌'), "Output:\n{}", output);
         assert!(output.contains('┘'), "Output:\n{}", output);
         assert!(output.contains('│'), "Output:\n{}", output);
+    }
+
+    #[test]
+    fn composite_children_visible() {
+        let input = r#"block-beta
+  columns 3
+  A["Parent"]
+  block:container
+    columns 2
+    D["Nested 1"]
+    E["Nested 2"]
+  end
+  F["Sibling"]"#;
+        let diagram = crate::parse(input).unwrap();
+        let db = match diagram {
+            crate::diagrams::Diagram::Block(db) => db,
+            _ => panic!("Expected block"),
+        };
+        let output = render_block_ascii(&db).unwrap();
+        assert!(
+            output.contains("Nested 1"),
+            "Nested child 1 should be visible\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Nested 2"),
+            "Nested child 2 should be visible\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn diamond_shape_distinct() {
+        let input = "block-beta\n  A{\"Diamond\"}";
+        let diagram = crate::parse(input).unwrap();
+        let db = match diagram {
+            crate::diagrams::Diagram::Block(db) => db,
+            _ => panic!("Expected block"),
+        };
+        let output = render_block_ascii(&db).unwrap();
+        assert!(
+            output.contains('◇') || output.contains('/') || output.contains('<'),
+            "Diamond shape should use distinct characters\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn stadium_shape_distinct() {
+        let input = "block-beta\n  A([\"Stadium\"])";
+        let diagram = crate::parse(input).unwrap();
+        let db = match diagram {
+            crate::diagrams::Diagram::Block(db) => db,
+            _ => panic!("Expected block"),
+        };
+        let output = render_block_ascii(&db).unwrap();
+        assert!(
+            output.contains('(') || output.contains(')'),
+            "Stadium shape should use rounded ends\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn round_shape_distinct() {
+        let input = "block-beta\n  A(\"Rounded\")";
+        let diagram = crate::parse(input).unwrap();
+        let db = match diagram {
+            crate::diagrams::Diagram::Block(db) => db,
+            _ => panic!("Expected block"),
+        };
+        let output = render_block_ascii(&db).unwrap();
+        assert!(
+            output.contains('╭') || output.contains('╰'),
+            "Rounded shape should use rounded corners\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn space_blocks_invisible() {
+        let input = "block-beta\n  columns 3\n  A[\"Left\"]\n  space\n  B[\"Right\"]";
+        let diagram = crate::parse(input).unwrap();
+        let db = match diagram {
+            crate::diagrams::Diagram::Block(db) => db,
+            _ => panic!("Expected block"),
+        };
+        let output = render_block_ascii(&db).unwrap();
+        assert!(
+            !output.contains("space"),
+            "Space blocks should not show a label\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn block_complex_gallery_renders() {
+        let input = std::fs::read_to_string("docs/sources/block_complex.mmd").unwrap();
+        let diagram = crate::parse(&input).unwrap();
+        let db = match diagram {
+            crate::diagrams::Diagram::Block(db) => db,
+            _ => panic!("Expected block"),
+        };
+        let output = render_block_ascii(&db).unwrap();
+
+        // Must show all named blocks
+        assert!(
+            output.contains("Square Block"),
+            "Missing 'Square Block'\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Rounded Block"),
+            "Missing 'Rounded Block'\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Diamond"),
+            "Missing 'Diamond'\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Nested 1"),
+            "Missing 'Nested 1'\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Nested 2"),
+            "Missing 'Nested 2'\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Stadium"),
+            "Missing 'Stadium'\nOutput:\n{}",
+            output
+        );
+
+        // Should not render space as visible block
+        assert!(
+            !output.contains("space_"),
+            "Space rendered as visible block\nOutput:\n{}",
+            output
+        );
     }
 }


### PR DESCRIPTION
<!-- midtown: lexington -->

## Summary
- Composite blocks now render their children inside bordered containers with proper visual nesting
- Added shape differentiation: round (`╭╮╰╯`), diamond (`<◇>`), stadium (`()`), vs square (`┌┐└┘`)
- Space blocks render as invisible whitespace instead of visible labeled boxes
- Added `get_children()` helper to `BlockDb` for hierarchy traversal
- Fixed eval compilation errors (missing `actual`/`expected` fields on `Issue`, duplicate match patterns)

## Before
```
┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐
│  Square Block   │ │  Rounded Block  │ │     Diamond     │
└─────────────────┘ └─────────────────┘ └─────────────────┘

┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐
│                 │ │     space_1     │ │     Stadium     │
└─────────────────┘ └─────────────────┘ └─────────────────┘
```

## After
```
┌─────────────────┐ ╭─────────────────╮         ◇
│  Square Block   │ │  Rounded Block  │ <     Diamond     >
└─────────────────┘ ╰─────────────────╯         ◇

┌───────────────────────────────┐                     ╭─────────────────╮
│  ┌────────────┐ ┌────────────┐│                     (     Stadium     )
│  │  Nested 1  │ │  Nested 2  ││                     ╰─────────────────╯
│  └────────────┘ └────────────┘│
└───────────────────────────────┘
```

## Test plan
- [x] All 9 block ASCII tests pass (6 new, 3 existing)
- [x] Full test suite passes (1755 tests, 0 failures)
- [x] `cargo clippy --features all-formats -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] Gallery SVGs updated