### PR TITLE
fix(ascii): Render pie charts as circular ASCII art [Midtown #143]

### DIFF
--- a/docs/images/example_pie_netflix.svg
+++ b/docs/images/example_pie_netflix.svg
@@ -128,7 +128,7 @@ marker path {
       <circle cx="0" cy="0" r="186" class="pieOuterCircle"/>
       <path d="M0.000,-185.000A185,185,0,1,1,-108.740,-149.668L0,0Z" class="pieCircle" fill="#ececff"/>
       <path d="M-108.740,-149.668A185,185,0,0,1,-0.000,-185.000L0,0Z" class="pieCircle" fill="#ffffde"/>
-      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(42.876,131.959)">90%</text>
+      <text x="0" y="0" class="slice" transform="translate(42.876,131.959)" style="text-anchor: middle;">90%</text>
       <text x="0" y="0" class="slice" transform="translate(-42.876,-131.959)" style="text-anchor: middle;">10%</text>
       <text x="0" y="-200" class="pieTitleText">NETFLIX</text>
       <g class="legend" transform="translate(216,-22)">

--- a/docs/images/example_pie_netflix.svg
+++ b/docs/images/example_pie_netflix.svg
@@ -128,7 +128,7 @@ marker path {
       <circle cx="0" cy="0" r="186" class="pieOuterCircle"/>
       <path d="M0.000,-185.000A185,185,0,1,1,-108.740,-149.668L0,0Z" class="pieCircle" fill="#ececff"/>
       <path d="M-108.740,-149.668A185,185,0,0,1,-0.000,-185.000L0,0Z" class="pieCircle" fill="#ffffde"/>
-      <text x="0" y="0" class="slice" transform="translate(42.876,131.959)" style="text-anchor: middle;">90%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(42.876,131.959)">90%</text>
       <text x="0" y="0" class="slice" transform="translate(-42.876,-131.959)" style="text-anchor: middle;">10%</text>
       <text x="0" y="-200" class="pieTitleText">NETFLIX</text>
       <g class="legend" transform="translate(216,-22)">

--- a/docs/images/pie.svg
+++ b/docs/images/pie.svg
@@ -133,7 +133,7 @@ marker path {
       <text x="0" y="0" class="slice" transform="translate(131.959,-42.876)" style="text-anchor: middle;">40%</text>
       <text x="0" y="0" class="slice" transform="translate(-21.705,137.042)" style="text-anchor: middle;">25%</text>
       <text x="0" y="0" class="slice" transform="translate(-138.750,0.000)" style="text-anchor: middle;">20%</text>
-      <text x="0" y="0" class="slice" transform="translate(-62.991,-123.627)" style="text-anchor: middle;">15%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-62.991,-123.627)">15%</text>
       <text x="0" y="-200" class="pieTitleText">Project Distribution</text>
       <g class="legend" transform="translate(216,-44)">
         <rect x="0" y="0" width="18" height="18" style="fill: rgb(236, 236, 255); stroke: rgb(236, 236, 255);"/>

--- a/docs/images/pie.svg
+++ b/docs/images/pie.svg
@@ -131,9 +131,9 @@ marker path {
       <path d="M-149.668,108.740A185,185,0,0,1,-149.668,-108.740L0,0Z" class="pieCircle" fill="hsl(80, 100%, 56.2745098039%)"/>
       <path d="M-149.668,-108.740A185,185,0,0,1,-0.000,-185.000L0,0Z" class="pieCircle" fill="hsl(240, 100%, 86.2745098039%)"/>
       <text x="0" y="0" class="slice" transform="translate(131.959,-42.876)" style="text-anchor: middle;">40%</text>
-      <text x="0" y="0" class="slice" transform="translate(-21.705,137.042)" style="text-anchor: middle;">25%</text>
-      <text x="0" y="0" class="slice" transform="translate(-138.750,0.000)" style="text-anchor: middle;">20%</text>
-      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-62.991,-123.627)">15%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-21.705,137.042)">25%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-138.750,0.000)">20%</text>
+      <text x="0" y="0" class="slice" transform="translate(-62.991,-123.627)" style="text-anchor: middle;">15%</text>
       <text x="0" y="-200" class="pieTitleText">Project Distribution</text>
       <g class="legend" transform="translate(216,-44)">
         <rect x="0" y="0" width="18" height="18" style="fill: rgb(236, 236, 255); stroke: rgb(236, 236, 255);"/>

--- a/docs/images/pie_complex.svg
+++ b/docs/images/pie_complex.svg
@@ -134,14 +134,14 @@ marker path {
       <path d="M-117.923,-142.545A185,185,0,0,1,-68.103,-172.009L0,0Z" class="pieCircle" fill="hsl(80, 100%, 76.2745098039%)"/>
       <path d="M-68.103,-172.009A185,185,0,0,1,-23.187,-183.541L0,0Z" class="pieCircle" fill="hsl(300, 100%, 76.2745098039%)"/>
       <path d="M-23.187,-183.541A185,185,0,0,1,-0.000,-185.000L0,0Z" class="pieCircle" fill="hsl(180, 100%, 56.2745098039%)"/>
-      <text x="0" y="0" class="slice" transform="translate(123.627,-62.991)" style="text-anchor: middle;">35%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(123.627,-62.991)">35%</text>
       <text x="0" y="0" class="slice" transform="translate(34.506,134.391)" style="text-anchor: middle;">22%</text>
       <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-117.150,74.346)">18%</text>
       <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-134.391,-34.506)">8%</text>
-      <text x="0" y="0" class="slice" transform="translate(-106.909,-88.443)" style="text-anchor: middle;">6%</text>
-      <text x="0" y="0" class="slice" transform="translate(-70.629,-119.428)" style="text-anchor: middle;">5%</text>
-      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-34.506,-134.391)">4%</text>
-      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-8.712,-138.476)">2%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-106.909,-88.443)">6%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-70.629,-119.428)">5%</text>
+      <text x="0" y="0" class="slice" transform="translate(-34.506,-134.391)" style="text-anchor: middle;">4%</text>
+      <text x="0" y="0" class="slice" transform="translate(-8.712,-138.476)" style="text-anchor: middle;">2%</text>
       <text x="0" y="-200" class="pieTitleText">Cloud Infrastructure Costs</text>
       <g class="legend" transform="translate(216,-88)">
         <rect x="0" y="0" width="18" height="18" style="fill: rgb(236, 236, 255); stroke: rgb(236, 236, 255);"/>

--- a/docs/images/pie_complex.svg
+++ b/docs/images/pie_complex.svg
@@ -136,11 +136,11 @@ marker path {
       <path d="M-23.187,-183.541A185,185,0,0,1,-0.000,-185.000L0,0Z" class="pieCircle" fill="hsl(180, 100%, 56.2745098039%)"/>
       <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(123.627,-62.991)">35%</text>
       <text x="0" y="0" class="slice" transform="translate(34.506,134.391)" style="text-anchor: middle;">22%</text>
-      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-117.150,74.346)">18%</text>
-      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-134.391,-34.506)">8%</text>
-      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-106.909,-88.443)">6%</text>
+      <text x="0" y="0" class="slice" transform="translate(-117.150,74.346)" style="text-anchor: middle;">18%</text>
+      <text x="0" y="0" class="slice" transform="translate(-134.391,-34.506)" style="text-anchor: middle;">8%</text>
+      <text x="0" y="0" class="slice" transform="translate(-106.909,-88.443)" style="text-anchor: middle;">6%</text>
       <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-70.629,-119.428)">5%</text>
-      <text x="0" y="0" class="slice" transform="translate(-34.506,-134.391)" style="text-anchor: middle;">4%</text>
+      <text x="0" y="0" class="slice" style="text-anchor: middle;" transform="translate(-34.506,-134.391)">4%</text>
       <text x="0" y="0" class="slice" transform="translate(-8.712,-138.476)" style="text-anchor: middle;">2%</text>
       <text x="0" y="-200" class="pieTitleText">Cloud Infrastructure Costs</text>
       <g class="legend" transform="translate(216,-88)">

--- a/src/eval/ascii_checks.rs
+++ b/src/eval/ascii_checks.rs
@@ -707,12 +707,14 @@ pub fn check_ascii_pie_structure(output: &str, db: &crate::diagrams::pie::PieDb)
         }
     }
 
-    // Check bar characters are present (at least one █ or ▌)
-    let has_bars = output.contains('█') || output.contains('▌');
-    if !has_bars {
+    // Check that at least one pie slice fill character is present.
+    // The circular renderer uses these distinct characters for slices.
+    const SLICE_CHARS: &[char] = &['█', '▓', '▒', '░', '◆', '●', '■', '▲'];
+    let has_slices = SLICE_CHARS.iter().any(|&ch| output.contains(ch));
+    if !has_slices {
         issues.push(Issue::error(
-            "ascii_pie_no_bars",
-            "ASCII pie output has no bar characters (█/▌)".to_string(),
+            "ascii_pie_no_slices",
+            "ASCII pie output has no slice fill characters (█▓▒░◆●■▲)".to_string(),
         ));
     }
 

--- a/src/render/ascii/pie.rs
+++ b/src/render/ascii/pie.rs
@@ -1,27 +1,27 @@
 //! ASCII renderer for pie charts.
 //!
-//! Since circular shapes don't render well in character art, pie charts are
-//! displayed as horizontal bar charts with proportional widths, percentages,
-//! and section labels. This preserves the key information while being readable
-//! in any terminal.
+//! Renders pie charts as circular ASCII art using Unicode block characters
+//! to fill pie slices, with a legend showing labels and percentages.
+//! Uses polar coordinate math (same as the SVG renderer) to determine
+//! slice boundaries.
+
+use std::f64::consts::PI;
 
 use crate::diagrams::pie::PieDb;
 use crate::error::Result;
 
-/// Maximum width for the bar portion of the chart.
-const BAR_WIDTH: usize = 40;
+/// Radius of the pie circle in character cells.
+const PIE_RADIUS: usize = 8;
 
-/// Block characters for filled bars.
-const FULL_BLOCK: char = '█';
-const HALF_BLOCK: char = '▌';
+/// Fill characters for different slices — visually distinct density patterns.
+const SLICE_CHARS: &[char] = &['█', '▓', '▒', '░', '◆', '●', '■', '▲'];
 
-/// Render a pie chart as a horizontal bar chart in character art.
+/// Render a pie chart as a circular ASCII pie with legend.
 pub fn render_pie_ascii(db: &PieDb) -> Result<String> {
     let sections = db.get_sections();
     let show_data = db.get_show_data();
 
     if sections.is_empty() {
-        // Empty chart — just show title if present
         if let Some(title) = db.get_diagram_title() {
             return Ok(format!("{}\n\n(empty pie chart)\n", title));
         }
@@ -41,10 +41,62 @@ pub fn render_pie_ascii(db: &PieDb) -> Result<String> {
     // Title
     if let Some(title) = db.get_diagram_title() {
         lines.push(title.to_string());
-        lines.push("─".repeat(title.chars().count().max(BAR_WIDTH)));
     }
 
-    // Calculate percentages and find longest label for alignment
+    // Build slice angle ranges: each slice spans [start_angle, end_angle)
+    // Start at -π/2 (12 o'clock), sweep clockwise like the SVG renderer.
+    let mut slices: Vec<(f64, f64, usize)> = Vec::new(); // (start, end, index)
+    let mut angle = -PI / 2.0;
+    for (i, (_label, value)) in sections.iter().enumerate() {
+        let sweep = (*value / total) * 2.0 * PI;
+        slices.push((angle, angle + sweep, i));
+        angle += sweep;
+    }
+
+    // Render the circle row by row.
+    // Character cells are taller than wide (~2:1), so we scale x by 2 to
+    // compensate, making the circle appear round in a monospace terminal.
+    let r = PIE_RADIUS as f64;
+    let diameter = PIE_RADIUS * 2 + 1;
+
+    for row in 0..diameter {
+        let dy = row as f64 - r; // vertical offset from center (-r..+r)
+        let mut line = String::new();
+
+        // Add left padding for centering (match legend width roughly)
+        line.push_str("  ");
+
+        for col in 0..(diameter * 2) {
+            let dx = (col as f64 - r * 2.0) / 2.0; // horizontal offset, scaled
+
+            let dist = (dx * dx + dy * dy).sqrt();
+            if dist > r + 0.5 {
+                line.push(' ');
+                continue;
+            }
+
+            // Determine which slice this pixel belongs to
+            let mut theta = dy.atan2(dx);
+            // Normalize to same range as slices (-π/2 .. 3π/2)
+            if theta < -PI / 2.0 {
+                theta += 2.0 * PI;
+            }
+
+            let slice_idx = slices
+                .iter()
+                .find(|(start, end, _)| theta >= *start && theta < *end)
+                .map(|(_, _, idx)| *idx)
+                .unwrap_or(slices.last().map(|(_, _, idx)| *idx).unwrap_or(0));
+
+            let ch = SLICE_CHARS[slice_idx % SLICE_CHARS.len()];
+            line.push(ch);
+        }
+
+        lines.push(line.trim_end().to_string());
+    }
+
+    // Legend
+    lines.push(String::new());
     let entries: Vec<(&str, f64, f64)> = sections
         .iter()
         .map(|(label, value)| {
@@ -53,54 +105,19 @@ pub fn render_pie_ascii(db: &PieDb) -> Result<String> {
         })
         .collect();
 
-    let max_label_len = entries
-        .iter()
-        .map(|(label, value, _)| {
-            if show_data {
-                format_label_with_data(label, *value).chars().count()
-            } else {
-                label.chars().count()
-            }
-        })
-        .max()
-        .unwrap_or(0);
-
-    // Render each section as a bar
-    for (label, value, pct) in &entries {
+    for (i, (label, value, pct)) in entries.iter().enumerate() {
+        let marker = SLICE_CHARS[i % SLICE_CHARS.len()];
         let display_label = if show_data {
             format_label_with_data(label, *value)
         } else {
             label.to_string()
         };
-
-        // Pad label to align bars
-        let padded_label = format!("{:width$}", display_label, width = max_label_len);
-
-        // Calculate bar width proportional to percentage
-        let bar_cells = (*pct / 100.0) * BAR_WIDTH as f64;
-        let full_cells = bar_cells.floor() as usize;
-        let has_half = (bar_cells - full_cells as f64) >= 0.5;
-
-        let mut bar = String::new();
-        for _ in 0..full_cells {
-            bar.push(FULL_BLOCK);
-        }
-        if has_half {
-            bar.push(HALF_BLOCK);
-        }
-
-        // Ensure at least one block for non-zero values
-        if bar.is_empty() && *pct > 0.0 {
-            bar.push(HALF_BLOCK);
-        }
-
-        let pct_str = format!("{:.1}%", pct);
-        lines.push(format!("  {} │{} {}", padded_label, bar, pct_str));
+        lines.push(format!("  {} {}: {:.1}%", marker, display_label, pct));
     }
 
-    // Add a total line
-    lines.push(String::new());
+    // Total line for showData
     if show_data {
+        lines.push(String::new());
         let total_str = if total.fract() == 0.0 {
             format!("{}", total as i64)
         } else {
@@ -187,36 +204,23 @@ mod tests {
     }
 
     #[test]
-    fn bars_are_proportional() {
+    fn slices_are_proportional_in_circle() {
         let db = make_pie(None, &[("Big", 75.0), ("Small", 25.0)], false);
         let output = render_pie_ascii(&db).unwrap();
-        let lines: Vec<&str> = output.lines().collect();
-        // Find the bar lines (contain █)
-        let bar_lines: Vec<&str> = lines
-            .iter()
-            .filter(|l| l.contains(FULL_BLOCK) || l.contains(HALF_BLOCK))
-            .copied()
-            .collect();
-        assert_eq!(
-            bar_lines.len(),
-            2,
-            "Should have 2 bar lines\nOutput:\n{}",
-            output
-        );
 
-        // Count block chars in each bar
-        let count_blocks = |line: &str| -> usize {
-            line.chars()
-                .filter(|&c| c == FULL_BLOCK || c == HALF_BLOCK)
-                .count()
-        };
-        let big_blocks = count_blocks(bar_lines[0]);
-        let small_blocks = count_blocks(bar_lines[1]);
+        // Count fill characters for each slice in the circle body
+        let big_char = SLICE_CHARS[0];
+        let small_char = SLICE_CHARS[1];
+
+        let big_count: usize = output.chars().filter(|&c| c == big_char).count();
+        let small_count: usize = output.chars().filter(|&c| c == small_char).count();
+
         assert!(
-            big_blocks > small_blocks,
-            "Big section ({}) should have more blocks than Small ({})",
-            big_blocks,
-            small_blocks
+            big_count > small_count,
+            "Big slice ({} chars) should have more fill than Small ({} chars)\nOutput:\n{}",
+            big_count,
+            small_count,
+            output
         );
     }
 
@@ -257,18 +261,17 @@ mod tests {
     }
 
     #[test]
-    fn labels_are_aligned() {
+    fn legend_contains_all_labels() {
         let db = make_pie(None, &[("Short", 10.0), ("Much Longer Label", 10.0)], false);
         let output = render_pie_ascii(&db).unwrap();
-        let lines: Vec<&str> = output.lines().collect();
-        let bar_lines: Vec<&str> = lines.iter().filter(|l| l.contains('│')).copied().collect();
-        assert_eq!(bar_lines.len(), 2);
-        // The │ separator should be at the same column position
-        let pipe_pos = |line: &str| line.find('│').unwrap();
-        assert_eq!(
-            pipe_pos(bar_lines[0]),
-            pipe_pos(bar_lines[1]),
-            "Bars should be aligned\nOutput:\n{}",
+        assert!(
+            output.contains("Short"),
+            "Legend should contain Short\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Much Longer Label"),
+            "Legend should contain Much Longer Label\nOutput:\n{}",
             output
         );
     }
@@ -327,16 +330,59 @@ mod tests {
     }
 
     #[test]
-    fn nonzero_section_gets_at_least_one_block() {
-        // A very small section should still show at least one block character
+    fn small_section_appears_in_legend() {
+        // Even a very small section should appear in the legend
         let db = make_pie(None, &[("Huge", 99.0), ("Tiny", 1.0)], false);
         let output = render_pie_ascii(&db).unwrap();
-        let tiny_line = output.lines().find(|l| l.contains("Tiny")).unwrap();
-        let has_block = tiny_line.contains(FULL_BLOCK) || tiny_line.contains(HALF_BLOCK);
         assert!(
-            has_block,
-            "Even 1% should show at least one block\nLine: {}",
-            tiny_line
+            output.contains("Tiny"),
+            "Small section should appear in legend\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("1.0%"),
+            "Small section should show percentage\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn renders_as_circular_pie_not_bar_chart() {
+        // The pie chart should render as a circular shape, not as horizontal bars.
+        let db = make_pie(
+            Some("Test Chart"),
+            &[("A", 60.0), ("B", 30.0), ("C", 10.0)],
+            false,
+        );
+        let output = render_pie_ascii(&db).unwrap();
+
+        // A bar chart has lines matching "label │████ XX.X%" pattern.
+        // A circular pie chart should NOT have this pattern.
+        let bar_chart_lines = output.lines().filter(|l| l.contains('│')).count();
+        assert_eq!(
+            bar_chart_lines, 0,
+            "Pie chart should render as a circle, not as bars with │ separators\nOutput:\n{}",
+            output
+        );
+
+        // The output should still contain all labels and percentages in the legend
+        assert!(output.contains("A"), "Missing label A\nOutput:\n{}", output);
+        assert!(output.contains("B"), "Missing label B\nOutput:\n{}", output);
+        assert!(output.contains("C"), "Missing label C\nOutput:\n{}", output);
+        assert!(
+            output.contains("60.0%"),
+            "Missing percentage 60.0%\nOutput:\n{}",
+            output
+        );
+
+        // The output should have many rows (circle body + legend), not just
+        // one row per section like a bar chart.
+        let non_empty_lines: Vec<&str> = output.lines().filter(|l| !l.trim().is_empty()).collect();
+        assert!(
+            non_empty_lines.len() > 10,
+            "Circular pie should have many lines (got {}), not just a few bar lines\nOutput:\n{}",
+            non_empty_lines.len(),
+            output
         );
     }
 }

--- a/src/render/ascii/pie.rs
+++ b/src/render/ascii/pie.rs
@@ -347,6 +347,38 @@ mod tests {
     }
 
     #[test]
+    fn many_slices_uses_all_slice_chars() {
+        // >8 sections forces all SLICE_CHARS to appear (wrapping around)
+        let db = make_pie(
+            Some("Many Slices"),
+            &[
+                ("A", 15.0),
+                ("B", 12.0),
+                ("C", 10.0),
+                ("D", 10.0),
+                ("E", 10.0),
+                ("F", 10.0),
+                ("G", 10.0),
+                ("H", 10.0),
+                ("I", 8.0),
+                ("J", 5.0),
+            ],
+            false,
+        );
+        let output = render_pie_ascii(&db).unwrap();
+
+        // Every one of the 8 distinct slice characters should appear
+        for &ch in SLICE_CHARS {
+            assert!(
+                output.contains(ch),
+                "Output should contain slice char '{}'\nOutput:\n{}",
+                ch,
+                output
+            );
+        }
+    }
+
+    #[test]
     fn renders_as_circular_pie_not_bar_chart() {
         // The pie chart should render as a circular shape, not as horizontal bars.
         let db = make_pie(


### PR DESCRIPTION
<!-- midtown: york -->

## Summary
- Replaced horizontal bar chart rendering with circular ASCII pie chart
- Uses polar coordinate math (matching SVG renderer) to draw filled circle with distinct slice characters (`█▓▒░◆●■▲`)
- Includes legend below the circle with labels and percentages
- All 12 pie tests pass, eval 100% (5/5 diagrams)

**Before:**
```
Project Distribution
────────────────────────────────────────
  Development   │████████████████ 40.0%
  Testing       │██████████ 25.0%
  Documentation │██████ 15.0%
  Design        │████████ 20.0%
```

**After:**
```
Project Distribution
             ░░░░░██████
         ░░░░░░░░░██████████
      ░░░░░░░░░░░░█████████████
     ░░░░░░░░░░░░░██████████████
   ░░░░░░░░░░░░░░░████████████████
   ░░░░░░░░░░░░░░░████████████████
  ▒▒▒▒░░░░░░░░░░░░█████████████████
  ▒▒▒▒▒▒▒▒▒▒░░░░░░█████████████████
  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒██████████████████
  ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▓▓▓▓███████████████
  ▒▒▒▒▒▒▒▒▒▒▒▓▓▓▓▓▓▓▓██████████████
   ▒▒▒▒▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▓███████████
   ▒▒▒▒▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓██████████
     ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓██████
      ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓████
         ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
             ▓▓▓▓▓▓▓▓▓▓▓

  █ Development: 40.0%
  ▓ Testing: 25.0%
  ▒ Documentation: 15.0%
  ░ Design: 20.0%
```

## Test plan
- [x] All 12 pie ASCII tests pass (including `renders_as_circular_pie_not_bar_chart`)
- [x] Gallery tests pass for both `pie.mmd` and `pie_complex.mmd`
- [x] Eval passes 100% (5/5 pie diagrams)
- [x] Full test suite passes (1750 tests)
- [x] `cargo fmt` and `cargo clippy` clean