### PR TITLE
fix: render radar ASCII as spider chart instead of bar chart [Midtown #150]

### DIFF
--- a/docs/images/radar.svg
+++ b/docs/images/radar.svg
@@ -196,28 +196,28 @@ marker path {
 
     </g>
     <g transform="translate(350, 350)">
-      <polygon points="0.00000000000000367394039744206,-60 57.06339097770921,-18.541019662496844 35.26711513754839,48.54101966249685 -35.26711513754838,48.54101966249685 -57.06339097770922,-18.541019662496836" class="radarGraticule" fill-opacity="0.3" stroke-width="1" stroke="#DEDEDE" fill="#DEDEDE"/>
-      <polygon points="0.00000000000000734788079488412,-120 114.12678195541842,-37.08203932499369 70.53423027509677,97.0820393249937 -70.53423027509676,97.0820393249937 -114.12678195541844,-37.08203932499367" class="radarGraticule" fill="#DEDEDE" stroke="#DEDEDE" fill-opacity="0.3" stroke-width="1"/>
-      <polygon points="0.000000000000011021821192326179,-180 171.19017293312763,-55.62305898749053 105.80134541264516,145.62305898749054 -105.80134541264515,145.62305898749054 -171.19017293312766,-55.62305898749051" class="radarGraticule" fill-opacity="0.3" stroke-width="1" fill="#DEDEDE" stroke="#DEDEDE"/>
-      <polygon points="0.00000000000001469576158976824,-240 228.25356391083685,-74.16407864998737 141.06846055019355,194.1640786499874 -141.06846055019352,194.1640786499874 -228.25356391083687,-74.16407864998735" class="radarGraticule" fill="#DEDEDE" fill-opacity="0.3" stroke="#DEDEDE" stroke-width="1"/>
-      <polygon points="0.000000000000018369701987210297,-300 285.31695488854604,-92.70509831248422 176.33557568774194,242.70509831248424 -176.3355756877419,242.70509831248424 -285.3169548885461,-92.70509831248418" class="radarGraticule" fill="#DEDEDE" fill-opacity="0.3" stroke-width="1" stroke="#DEDEDE"/>
+      <polygon points="0.00000000000000367394039744206,-60 57.06339097770921,-18.541019662496844 35.26711513754839,48.54101966249685 -35.26711513754838,48.54101966249685 -57.06339097770922,-18.541019662496836" class="radarGraticule" stroke="#DEDEDE" stroke-width="1" fill="#DEDEDE" fill-opacity="0.3"/>
+      <polygon points="0.00000000000000734788079488412,-120 114.12678195541842,-37.08203932499369 70.53423027509677,97.0820393249937 -70.53423027509676,97.0820393249937 -114.12678195541844,-37.08203932499367" class="radarGraticule" fill="#DEDEDE" stroke-width="1" fill-opacity="0.3" stroke="#DEDEDE"/>
+      <polygon points="0.000000000000011021821192326179,-180 171.19017293312763,-55.62305898749053 105.80134541264516,145.62305898749054 -105.80134541264515,145.62305898749054 -171.19017293312766,-55.62305898749051" class="radarGraticule" stroke-width="1" fill="#DEDEDE" fill-opacity="0.3" stroke="#DEDEDE"/>
+      <polygon points="0.00000000000001469576158976824,-240 228.25356391083685,-74.16407864998737 141.06846055019355,194.1640786499874 -141.06846055019352,194.1640786499874 -228.25356391083687,-74.16407864998735" class="radarGraticule" fill="#DEDEDE" stroke-width="1" stroke="#DEDEDE" fill-opacity="0.3"/>
+      <polygon points="0.000000000000018369701987210297,-300 285.31695488854604,-92.70509831248422 176.33557568774194,242.70509831248424 -176.3355756877419,242.70509831248424 -285.3169548885461,-92.70509831248418" class="radarGraticule" fill-opacity="0.3" fill="#DEDEDE" stroke="#DEDEDE" stroke-width="1"/>
       <line x1="0" y1="0" x2="0.000000000000018369701987210297" y2="-300" class="radarAxisLine" stroke-width="1" stroke="#333333"/>
-      <text x="0.000000000000019288187086570814" y="-315" class="radarAxisLabel" text-anchor="middle" fill="#333333" dominant-baseline="middle" font-size="12">Coding</text>
-      <line x1="0" y1="0" x2="285.31695488854604" y2="-92.70509831248422" class="radarAxisLine" stroke="#333333" stroke-width="1"/>
-      <text x="299.58280263297337" y="-97.34035322810843" class="radarAxisLabel" text-anchor="middle" fill="#333333" font-size="12" dominant-baseline="middle">Testing</text>
-      <line x1="0" y1="0" x2="176.33557568774194" y2="242.70509831248424" class="radarAxisLine" stroke="#333333" stroke-width="1"/>
-      <text x="185.15235447212905" y="254.84035322810846" class="radarAxisLabel" font-size="12" dominant-baseline="middle" text-anchor="middle" fill="#333333">Design</text>
-      <line x1="0" y1="0" x2="-176.3355756877419" y2="242.70509831248424" class="radarAxisLine" stroke="#333333" stroke-width="1"/>
-      <text x="-185.152354472129" y="254.84035322810846" class="radarAxisLabel" dominant-baseline="middle" text-anchor="middle" fill="#333333" font-size="12">Code Review</text>
+      <line x1="0" y1="0" x2="285.31695488854604" y2="-92.70509831248422" class="radarAxisLine" stroke-width="1" stroke="#333333"/>
+      <line x1="0" y1="0" x2="176.33557568774194" y2="242.70509831248424" class="radarAxisLine" stroke-width="1" stroke="#333333"/>
+      <line x1="0" y1="0" x2="-176.3355756877419" y2="242.70509831248424" class="radarAxisLine" stroke-width="1" stroke="#333333"/>
       <line x1="0" y1="0" x2="-285.3169548885461" y2="-92.70509831248418" class="radarAxisLine" stroke="#333333" stroke-width="1"/>
-      <text x="-299.5828026329734" y="-97.3403532281084" class="radarAxisLabel" text-anchor="middle" font-size="12" dominant-baseline="middle" fill="#333333">Documentation</text>
       <polygon points="0.00000000000001469576158976824,-240 171.19017293312763,-55.62305898749053 105.80134541264516,145.62305898749054 -141.06846055019352,194.1640786499874 -114.12678195541844,-37.08203932499367" class="radarCurve-0" fill="#8686FF" stroke="#8686FF"/>
-      <polygon points="0.000000000000011021821192326179,-180 228.25356391083685,-74.16407864998737 141.06846055019355,194.1640786499874 -105.80134541264515,145.62305898749054 -285.3169548885461,-92.70509831248418" class="radarCurve-1" fill="#FFFF78" stroke="#FFFF78"/>
+      <polygon points="0.000000000000011021821192326179,-180 228.25356391083685,-74.16407864998737 141.06846055019355,194.1640786499874 -105.80134541264515,145.62305898749054 -285.3169548885461,-92.70509831248418" class="radarCurve-1" stroke="#FFFF78" fill="#FFFF78"/>
       <rect x="262.5" y="-262.5" width="12" height="12" class="radarLegendBox-0" fill="#8686FF"/>
-      <text x="278.5" y="-262.5" class="radarLegendText" font-size="12" dominant-baseline="hanging">Team Alpha</text>
       <rect x="262.5" y="-242.5" width="12" height="12" class="radarLegendBox-1" fill="#FFFF78"/>
+      <text x="0.000000000000019288187086570814" y="-315" class="radarAxisLabel" dominant-baseline="middle" text-anchor="middle" fill="#333333" font-size="12">Coding</text>
+      <text x="299.58280263297337" y="-97.34035322810843" class="radarAxisLabel" text-anchor="middle" font-size="12" fill="#333333" dominant-baseline="middle">Testing</text>
+      <text x="185.15235447212905" y="254.84035322810846" class="radarAxisLabel" dominant-baseline="middle" fill="#333333" text-anchor="middle" font-size="12">Design</text>
+      <text x="-185.152354472129" y="254.84035322810846" class="radarAxisLabel" font-size="12" fill="#333333" text-anchor="middle" dominant-baseline="middle">Code Review</text>
+      <text x="-299.5828026329734" y="-97.3403532281084" class="radarAxisLabel" fill="#333333" dominant-baseline="middle" font-size="12" text-anchor="middle">Documentation</text>
+      <text x="278.5" y="-262.5" class="radarLegendText" dominant-baseline="hanging" font-size="12">Team Alpha</text>
       <text x="278.5" y="-242.5" class="radarLegendText" dominant-baseline="hanging" font-size="12">Team Beta</text>
-      <text x="0" y="-350" class="radarTitle" font-size="16" text-anchor="middle" font-weight="bold" dominant-baseline="hanging" fill="#333333">Skills Assessment</text>
+      <text x="0" y="-350" class="radarTitle" dominant-baseline="hanging" font-size="16" text-anchor="middle" font-weight="bold" fill="#333333">Skills Assessment</text>
     </g>
   </g>
 </svg>

--- a/docs/images/radar_complex.svg
+++ b/docs/images/radar_complex.svg
@@ -196,36 +196,36 @@ marker path {
 
     </g>
     <g transform="translate(350, 350)">
-      <circle cx="0" cy="0" r="60" class="radarGraticule" stroke="#DEDEDE" stroke-width="1" fill-opacity="0.3" fill="#DEDEDE"/>
-      <circle cx="0" cy="0" r="120" class="radarGraticule" fill="#DEDEDE" stroke="#DEDEDE" fill-opacity="0.3" stroke-width="1"/>
-      <circle cx="0" cy="0" r="180" class="radarGraticule" stroke="#DEDEDE" stroke-width="1" fill="#DEDEDE" fill-opacity="0.3"/>
-      <circle cx="0" cy="0" r="240" class="radarGraticule" fill-opacity="0.3" stroke-width="1" fill="#DEDEDE" stroke="#DEDEDE"/>
-      <circle cx="0" cy="0" r="300" class="radarGraticule" fill-opacity="0.3" fill="#DEDEDE" stroke="#DEDEDE" stroke-width="1"/>
+      <circle cx="0" cy="0" r="60" class="radarGraticule" stroke="#DEDEDE" stroke-width="1" fill="#DEDEDE" fill-opacity="0.3"/>
+      <circle cx="0" cy="0" r="120" class="radarGraticule" stroke="#DEDEDE" stroke-width="1" fill="#DEDEDE" fill-opacity="0.3"/>
+      <circle cx="0" cy="0" r="180" class="radarGraticule" stroke="#DEDEDE" fill-opacity="0.3" fill="#DEDEDE" stroke-width="1"/>
+      <circle cx="0" cy="0" r="240" class="radarGraticule" fill-opacity="0.3" fill="#DEDEDE" stroke="#DEDEDE" stroke-width="1"/>
+      <circle cx="0" cy="0" r="300" class="radarGraticule" fill-opacity="0.3" fill="#DEDEDE" stroke-width="1" stroke="#DEDEDE"/>
       <line x1="0" y1="0" x2="0.000000000000018369701987210297" y2="-300" class="radarAxisLine" stroke-width="1" stroke="#333333"/>
-      <text x="0.000000000000019288187086570814" y="-315" class="radarAxisLabel" text-anchor="middle" font-size="12" dominant-baseline="middle" fill="#333333">Performance</text>
-      <line x1="0" y1="0" x2="259.8076211353316" y2="-150" class="radarAxisLine" stroke-width="1" stroke="#333333"/>
-      <text x="272.7980021920982" y="-157.5" class="radarAxisLabel" font-size="12" dominant-baseline="middle" text-anchor="middle" fill="#333333">Ecosystem</text>
+      <line x1="0" y1="0" x2="259.8076211353316" y2="-150" class="radarAxisLine" stroke="#333333" stroke-width="1"/>
       <line x1="0" y1="0" x2="259.8076211353316" y2="149.99999999999994" class="radarAxisLine" stroke="#333333" stroke-width="1"/>
-      <text x="272.7980021920982" y="157.49999999999994" class="radarAxisLabel" dominant-baseline="middle" font-size="12" fill="#333333" text-anchor="middle">Safety</text>
-      <line x1="0" y1="0" x2="0.000000000000018369701987210297" y2="300" class="radarAxisLine" stroke-width="1" stroke="#333333"/>
-      <text x="0.000000000000019288187086570814" y="315" class="radarAxisLabel" fill="#333333" text-anchor="middle" dominant-baseline="middle" font-size="12">Learning Curve</text>
-      <line x1="0" y1="0" x2="-259.80762113533154" y2="150.0000000000001" class="radarAxisLine" stroke="#333333" stroke-width="1"/>
-      <text x="-272.7980021920981" y="157.5000000000001" class="radarAxisLabel" dominant-baseline="middle" fill="#333333" font-size="12" text-anchor="middle">Tooling</text>
+      <line x1="0" y1="0" x2="0.000000000000018369701987210297" y2="300" class="radarAxisLine" stroke="#333333" stroke-width="1"/>
+      <line x1="0" y1="0" x2="-259.80762113533154" y2="150.0000000000001" class="radarAxisLine" stroke-width="1" stroke="#333333"/>
       <line x1="0" y1="0" x2="-259.8076211353316" y2="-150.00000000000003" class="radarAxisLine" stroke="#333333" stroke-width="1"/>
-      <text x="-272.7980021920982" y="-157.50000000000003" class="radarAxisLabel" font-size="12" dominant-baseline="middle" fill="#333333" text-anchor="middle">Community</text>
       <path d="M0.000000000000018369701987210297,-300 C69.42059636736062,-300 164.45822417866486,-195.14999999999998 207.84609690826525,-120 C251.23396963786564,-44.85000000000001 294.5179193190119,109.91999999999993 259.8076211353316,149.99999999999994 C225.0973229516513,190.07999999999996 86.77574545920078,119.99999999999997 0.00000000000000734788079488412,120 C-86.77574545920075,120.00000000000003 -225.09732295165125,190.08000000000013 -259.80762113533154,150.0000000000001 C-294.51791931901187,109.9200000000001 -251.2339696378656,-44.85000000000001 -207.84609690826525,-120.00000000000003 C-164.4582241786649,-195.15000000000003 -69.42059636736059,-300 0.000000000000018369701987210297,-300 Z" class="radarCurve-0" stroke="#8686FF" fill="#8686FF"/>
       <path d="M0.00000000000000734788079488412,-120 C86.77574545920078,-120 233.77489749757137,-185.07 259.8076211353316,-150 C285.84034477309183,-114.93 199.27244541079935,14.849999999999966 155.88457268119896,89.99999999999997 C112.49669995159857,165.14999999999998 60.74302182144054,294.99 0.000000000000018369701987210297,300 C-60.7430218214405,305.01 -164.45822417866484,195.1500000000001 -207.84609690826522,120.00000000000009 C-251.2339696378656,44.85000000000008 -294.51791931901187,-109.92000000000002 -259.8076211353316,-150.00000000000003 C-225.0973229516513,-190.08000000000004 -86.77574545920075,-120 0.00000000000000734788079488412,-120 Z" class="radarCurve-1" stroke="#FFFF78" fill="#FFFF78"/>
       <path d="M0.00000000000001469576158976824,-240 C69.42059636736062,-240 173.13579872458496,-180.12 207.84609690826525,-120 C242.55639509194555,-59.88 242.55639509194557,59.87999999999995 207.84609690826528,119.99999999999996 C173.135798724585,180.11999999999995 78.09817091328068,234.98999999999998 0.00000000000001469576158976824,240 C-78.09817091328065,245.01000000000002 -225.09732295165125,210.12000000000012 -259.80762113533154,150.0000000000001 C-294.51791931901187,89.88000000000011 -251.2339696378656,-54.870000000000005 -207.84609690826525,-120.00000000000003 C-164.4582241786649,-185.13000000000005 -69.42059636736059,-240 0.00000000000001469576158976824,-240 Z" class="radarCurve-2" fill="#9FFF9F" stroke="#9FFF9F"/>
-      <path d="M0.000000000000018369701987210297,-300 C78.0981709132807,-305.01 242.45247204349144,-210.12 259.8076211353316,-150 C277.16277022717173,-89.88 147.31092118373303,24.92999999999998 103.92304845413264,59.99999999999998 C60.53517572453226,95.06999999999998 43.38787272960039,54.98999999999999 0.00000000000000367394039744206,60 C-43.387872729600375,65.01000000000002 -121.17427449751864,120.06000000000006 -155.88457268119893,90.00000000000006 C-190.59487086487923,59.940000000000055 -233.87882054602548,-54.87000000000002 -207.84609690826525,-120.00000000000003 C-181.81337327050502,-185.13000000000005 -78.09817091328067,-294.99 0.000000000000018369701987210297,-300 Z" class="radarCurve-3" fill="#C986FF" stroke="#C986FF"/>
+      <path d="M0.000000000000018369701987210297,-300 C78.0981709132807,-305.01 242.45247204349144,-210.12 259.8076211353316,-150 C277.16277022717173,-89.88 147.31092118373303,24.92999999999998 103.92304845413264,59.99999999999998 C60.53517572453226,95.06999999999998 43.38787272960039,54.98999999999999 0.00000000000000367394039744206,60 C-43.387872729600375,65.01000000000002 -121.17427449751864,120.06000000000006 -155.88457268119893,90.00000000000006 C-190.59487086487923,59.940000000000055 -233.87882054602548,-54.87000000000002 -207.84609690826525,-120.00000000000003 C-181.81337327050502,-185.13000000000005 -78.09817091328067,-294.99 0.000000000000018369701987210297,-300 Z" class="radarCurve-3" stroke="#C986FF" fill="#C986FF"/>
       <rect x="262.5" y="-262.5" width="12" height="12" class="radarLegendBox-0" fill="#8686FF"/>
-      <text x="278.5" y="-262.5" class="radarLegendText" dominant-baseline="hanging" font-size="12">Rust</text>
       <rect x="262.5" y="-242.5" width="12" height="12" class="radarLegendBox-1" fill="#FFFF78"/>
-      <text x="278.5" y="-242.5" class="radarLegendText" dominant-baseline="hanging" font-size="12">Python</text>
       <rect x="262.5" y="-222.5" width="12" height="12" class="radarLegendBox-2" fill="#9FFF9F"/>
-      <text x="278.5" y="-222.5" class="radarLegendText" font-size="12" dominant-baseline="hanging">Go</text>
       <rect x="262.5" y="-202.5" width="12" height="12" class="radarLegendBox-3" fill="#C986FF"/>
-      <text x="278.5" y="-202.5" class="radarLegendText" dominant-baseline="hanging" font-size="12">C++</text>
-      <text x="0" y="-350" class="radarTitle" fill="#333333" font-size="16" dominant-baseline="hanging" font-weight="bold" text-anchor="middle">Programming Language Comparison</text>
+      <text x="0.000000000000019288187086570814" y="-315" class="radarAxisLabel" text-anchor="middle" font-size="12" dominant-baseline="middle" fill="#333333">Performance</text>
+      <text x="272.7980021920982" y="-157.5" class="radarAxisLabel" text-anchor="middle" dominant-baseline="middle" font-size="12" fill="#333333">Ecosystem</text>
+      <text x="272.7980021920982" y="157.49999999999994" class="radarAxisLabel" text-anchor="middle" font-size="12" fill="#333333" dominant-baseline="middle">Safety</text>
+      <text x="0.000000000000019288187086570814" y="315" class="radarAxisLabel" text-anchor="middle" dominant-baseline="middle" fill="#333333" font-size="12">Learning Curve</text>
+      <text x="-272.7980021920981" y="157.5000000000001" class="radarAxisLabel" fill="#333333" dominant-baseline="middle" font-size="12" text-anchor="middle">Tooling</text>
+      <text x="-272.7980021920982" y="-157.50000000000003" class="radarAxisLabel" text-anchor="middle" fill="#333333" font-size="12" dominant-baseline="middle">Community</text>
+      <text x="278.5" y="-262.5" class="radarLegendText" font-size="12" dominant-baseline="hanging">Rust</text>
+      <text x="278.5" y="-242.5" class="radarLegendText" font-size="12" dominant-baseline="hanging">Python</text>
+      <text x="278.5" y="-222.5" class="radarLegendText" dominant-baseline="hanging" font-size="12">Go</text>
+      <text x="278.5" y="-202.5" class="radarLegendText" font-size="12" dominant-baseline="hanging">C++</text>
+      <text x="0" y="-350" class="radarTitle" font-weight="bold" fill="#333333" dominant-baseline="hanging" text-anchor="middle" font-size="16">Programming Language Comparison</text>
     </g>
   </g>
 </svg>

--- a/src/eval/ascii_checks.rs
+++ b/src/eval/ascii_checks.rs
@@ -1513,6 +1513,7 @@ pub fn calculate_ascii_text_similarity(output: &str) -> f64 {
                 | '★'
                 | '§'
                 | '▶'
+                | '◈'
                 | '▼'
                 | '◀'
                 | '→'
@@ -1864,5 +1865,27 @@ mod tests {
             score_diamond,
             score_plain
         );
+    }
+
+    #[test]
+    fn structural_chars_include_all_curve_markers() {
+        // All CURVE_MARKERS from radar.rs must be recognized as structural characters.
+        // Regression: ◈ (U+25C8) was missing, causing lower eval scores for 8+ curve radars.
+        // Use each marker as the ONLY structural char to verify it's individually recognized.
+        let markers = ['●', '◆', '■', '▲', '★', '◉', '▶', '◈'];
+        let plain_text = "hello\nworld\nfoo";
+        let score_plain = calculate_ascii_text_similarity(plain_text);
+        for marker in markers {
+            let input = format!("  {marker}\nLabel\n  {marker}");
+            let score = calculate_ascii_text_similarity(&input);
+            assert!(
+                score > score_plain,
+                "Marker '{}' (U+{:04X}) should be recognized as structural, got score {} vs plain {}",
+                marker,
+                marker as u32,
+                score,
+                score_plain,
+            );
+        }
     }
 }

--- a/src/render/ascii/radar.rs
+++ b/src/render/ascii/radar.rs
@@ -1,16 +1,30 @@
 //! ASCII renderer for radar/spider chart diagrams.
 //!
-//! Since radial charts don't render well in character art, radar charts
-//! are displayed as a comparison table with bar indicators for each axis value.
+//! Renders radar charts as a true radial shape using braille characters
+//! for the chart body (graticule, axes, curves), with text labels placed
+//! around the perimeter and a legend below.
 
-use crate::diagrams::radar::RadarDb;
+use std::f64::consts::PI;
+
+use crate::diagrams::radar::{Graticule, RadarDb};
 use crate::error::Result;
 
-const BAR_WIDTH: usize = 20;
-const FULL_BLOCK: char = '█';
-const EMPTY_BLOCK: char = '░';
+use super::canvas::BrailleCanvas;
 
-/// Render a radar chart as character art.
+/// Chart radius in character cell columns.
+const CHART_CELL_RADIUS: usize = 12;
+
+/// How far outside the chart perimeter to place axis labels
+/// (as a fraction of the radius in cell coordinates).
+const LABEL_FACTOR: f64 = 1.15;
+
+/// Number of line segments used to approximate a circle.
+const CIRCLE_SEGMENTS: usize = 64;
+
+/// Markers to visually differentiate curves in monochrome output.
+const CURVE_MARKERS: &[char] = &['●', '◆', '■', '▲', '★', '◉', '▶', '◈'];
+
+/// Render a radar chart as character art with a radial layout.
 pub fn render_radar_ascii(db: &RadarDb) -> Result<String> {
     let axes = db.get_axes();
     let curves = db.get_curves();
@@ -24,6 +38,170 @@ pub fn render_radar_ascii(db: &RadarDb) -> Result<String> {
         return Ok("(empty radar chart)\n".to_string());
     }
 
+    let n = axes.len();
+    let max_val = options.max.unwrap_or_else(|| {
+        curves
+            .iter()
+            .flat_map(|c| c.entries.iter().copied())
+            .fold(0.0f64, f64::max)
+    });
+    let min_val = options.min;
+
+    // Compute axis angles: start from top (-π/2), go clockwise.
+    let angles: Vec<f64> = (0..n)
+        .map(|i| -PI / 2.0 + (i as f64) * 2.0 * PI / (n as f64))
+        .collect();
+
+    // ── Braille canvas ──────────────────────────────────────
+    // Terminal characters are ~2× taller than wide. Braille encodes 2×4
+    // dots per cell, making braille "pixels" physically square. To render
+    // a circular chart we use cell_rows ≈ cell_cols/2.
+    let chart_cols = 2 * CHART_CELL_RADIUS + 1;
+    let chart_rows = CHART_CELL_RADIUS + 1;
+    let mut canvas = BrailleCanvas::new(chart_cols, chart_rows);
+
+    let px_cx = canvas.pixel_width() as f64 / 2.0;
+    let px_cy = canvas.pixel_height() as f64 / 2.0;
+    let px_r = (CHART_CELL_RADIUS * 2) as f64;
+
+    // Draw graticule (concentric rings)
+    for t in 1..=options.ticks {
+        let frac = t as f64 / options.ticks as f64;
+        let ring_r = px_r * frac;
+        match options.graticule {
+            Graticule::Circle => draw_circle(&mut canvas, px_cx, px_cy, ring_r),
+            Graticule::Polygon => draw_polygon(&mut canvas, px_cx, px_cy, ring_r, &angles),
+        }
+    }
+
+    // Draw axis spokes (from center to perimeter)
+    for angle in &angles {
+        let ex = px_cx + px_r * angle.cos();
+        let ey = px_cy + px_r * angle.sin();
+        canvas.draw_line(px_cx as isize, px_cy as isize, ex as isize, ey as isize);
+    }
+
+    // Compute curve data points in pixel coordinates
+    let curve_points: Vec<Vec<(f64, f64)>> = curves
+        .iter()
+        .map(|curve| {
+            (0..n)
+                .map(|i| {
+                    let val = curve.entries.get(i).copied().unwrap_or(0.0);
+                    let frac = relative_radius(val, min_val, max_val);
+                    let x = px_cx + px_r * frac * angles[i].cos();
+                    let y = px_cy + px_r * frac * angles[i].sin();
+                    (x, y)
+                })
+                .collect()
+        })
+        .collect();
+
+    // Draw curve polygons on braille canvas
+    for points in &curve_points {
+        let len = points.len();
+        for j in 0..len {
+            let k = (j + 1) % len;
+            canvas.draw_line(
+                points[j].0 as isize,
+                points[j].1 as isize,
+                points[k].0 as isize,
+                points[k].1 as isize,
+            );
+        }
+    }
+
+    // ── Compose text buffer ─────────────────────────────────
+    let braille_grid = canvas.to_char_grid();
+
+    let axis_labels: Vec<&str> = axes
+        .iter()
+        .map(|a| {
+            if !a.label.is_empty() {
+                a.label.as_str()
+            } else {
+                a.name.as_str()
+            }
+        })
+        .collect();
+
+    let max_label_len = axis_labels
+        .iter()
+        .map(|l| l.chars().count())
+        .max()
+        .unwrap_or(0);
+
+    // Buffer margins (enough room for labels on all sides)
+    let margin_x = max_label_len + 3;
+    let margin_top: usize = 2;
+    let margin_bottom: usize = 2;
+
+    let buf_cols = margin_x + chart_cols + margin_x;
+    let buf_rows = margin_top + chart_rows + margin_bottom;
+
+    let mut buf: Vec<Vec<char>> = vec![vec![' '; buf_cols]; buf_rows];
+
+    // Place braille grid in center of buffer
+    for (row, braille_row) in braille_grid.iter().enumerate() {
+        for (col, &ch) in braille_row.iter().enumerate() {
+            let br = margin_top + row;
+            let bc = margin_x + col;
+            if br < buf_rows && bc < buf_cols {
+                buf[br][bc] = ch;
+            }
+        }
+    }
+
+    // Place axis labels around the perimeter
+    let center_buf_col = margin_x + chart_cols / 2;
+    let center_buf_row = margin_top + chart_rows / 2;
+
+    // Radii in buffer cell coordinates
+    let cell_r_x = CHART_CELL_RADIUS as f64;
+    let cell_r_y = CHART_CELL_RADIUS as f64 / 2.0;
+
+    for (i, label) in axis_labels.iter().enumerate() {
+        let theta = angles[i];
+        let lx = center_buf_col as f64 + LABEL_FACTOR * cell_r_x * theta.cos();
+        let ly = center_buf_row as f64 + LABEL_FACTOR * cell_r_y * theta.sin();
+
+        let label_len = label.chars().count();
+        let cos_t = theta.cos();
+
+        let start_col: isize = if cos_t > 0.3 {
+            // Right half: left-align starting just after the position
+            lx.round() as isize + 1
+        } else if cos_t < -0.3 {
+            // Left half: right-align ending just before the position
+            lx.round() as isize - label_len as isize
+        } else {
+            // Top/bottom: center
+            lx.round() as isize - (label_len as isize) / 2
+        };
+
+        let row = ly.round().max(0.0) as usize;
+
+        for (j, ch) in label.chars().enumerate() {
+            let col = start_col + j as isize;
+            if col >= 0 && (col as usize) < buf_cols && row < buf_rows {
+                buf[row][col as usize] = ch;
+            }
+        }
+    }
+
+    // Place curve data point markers in the text buffer
+    for (ci, points) in curve_points.iter().enumerate() {
+        let marker = CURVE_MARKERS[ci % CURVE_MARKERS.len()];
+        for &(px, py) in points {
+            let col = margin_x + (px.round() as usize / 2);
+            let row = margin_top + (py.round() as usize / 4);
+            if row < buf_rows && col < buf_cols {
+                buf[row][col] = marker;
+            }
+        }
+    }
+
+    // ── Build output ────────────────────────────────────────
     let mut lines: Vec<String> = Vec::new();
 
     // Title
@@ -31,86 +209,73 @@ pub fn render_radar_ascii(db: &RadarDb) -> Result<String> {
     if !title.is_empty() {
         lines.push(title.to_string());
         lines.push("─".repeat(title.chars().count().max(40)));
+        lines.push(String::new());
     }
 
-    // max is Option<f64>; fall back to max value found in data
-    let max_val = options.max.unwrap_or_else(|| {
-        curves
-            .iter()
-            .flat_map(|c| c.entries.iter().copied())
-            .fold(0.0f64, f64::max)
-    });
+    // Chart
+    for row in &buf {
+        let line: String = row.iter().collect();
+        lines.push(line.trim_end().to_string());
+    }
 
-    // Find max axis label width
-    let max_axis_len = axes
-        .iter()
-        .map(|a| {
-            let label = if !a.label.is_empty() {
-                &a.label
-            } else {
-                &a.name
-            };
-            label.chars().count()
-        })
-        .max()
-        .unwrap_or(5);
-
-    // Render each curve
-    for curve in curves {
-        let label = if !curve.label.is_empty() {
-            &curve.label
-        } else {
-            &curve.name
-        };
+    // Legend
+    if options.show_legend && !curves.is_empty() {
         lines.push(String::new());
-        lines.push(format!("  ◆ {}", label));
-        lines.push(format!("  {}", "─".repeat(label.chars().count() + 2)));
-
-        for (i, axis) in axes.iter().enumerate() {
-            let axis_label = if !axis.label.is_empty() {
-                &axis.label
-            } else {
-                &axis.name
-            };
-
-            let value = curve.entries.get(i).copied().unwrap_or(0.0);
-            let pct = if max_val > 0.0 {
-                (value / max_val).min(1.0)
-            } else {
-                0.0
-            };
-
-            let filled = (pct * BAR_WIDTH as f64).round() as usize;
-            let empty = BAR_WIDTH.saturating_sub(filled);
-            let bar: String = std::iter::repeat_n(FULL_BLOCK, filled)
-                .chain(std::iter::repeat_n(EMPTY_BLOCK, empty))
-                .collect();
-
-            let value_str = if value.fract() == 0.0 {
-                format!("{}", value as i64)
-            } else {
-                format!("{:.1}", value)
-            };
-
-            let max_str = if max_val.fract() == 0.0 {
-                format!("{}", max_val as i64)
-            } else {
-                format!("{:.1}", max_val)
-            };
-
-            lines.push(format!(
-                "    {:width$} │{} {}/{}",
-                axis_label,
-                bar,
-                value_str,
-                max_str,
-                width = max_axis_len,
-            ));
-        }
+        let legend_parts: Vec<String> = curves
+            .iter()
+            .enumerate()
+            .map(|(i, c)| {
+                let marker = CURVE_MARKERS[i % CURVE_MARKERS.len()];
+                let label = if !c.label.is_empty() {
+                    &c.label
+                } else {
+                    &c.name
+                };
+                format!("{} {}", marker, label)
+            })
+            .collect();
+        lines.push(format!("  Legend: {}", legend_parts.join("  ")));
     }
 
     lines.push(String::new());
     Ok(lines.join("\n"))
+}
+
+/// Calculate relative radius (0.0 to 1.0) for a value within min/max range.
+fn relative_radius(value: f64, min_value: f64, max_value: f64) -> f64 {
+    let clipped = value.clamp(min_value, max_value);
+    if (max_value - min_value).abs() < f64::EPSILON {
+        return 1.0;
+    }
+    (clipped - min_value) / (max_value - min_value)
+}
+
+/// Draw a circle approximated by line segments on the braille canvas.
+fn draw_circle(canvas: &mut BrailleCanvas, cx: f64, cy: f64, r: f64) {
+    for i in 0..CIRCLE_SEGMENTS {
+        let t0 = 2.0 * PI * i as f64 / CIRCLE_SEGMENTS as f64;
+        let t1 = 2.0 * PI * (i + 1) as f64 / CIRCLE_SEGMENTS as f64;
+        canvas.draw_line(
+            (cx + r * t0.cos()) as isize,
+            (cy + r * t0.sin()) as isize,
+            (cx + r * t1.cos()) as isize,
+            (cy + r * t1.sin()) as isize,
+        );
+    }
+}
+
+/// Draw a polygon connecting axis positions at a given radius.
+fn draw_polygon(canvas: &mut BrailleCanvas, cx: f64, cy: f64, r: f64, angles: &[f64]) {
+    let n = angles.len();
+    for i in 0..n {
+        let j = (i + 1) % n;
+        canvas.draw_line(
+            (cx + r * angles[i].cos()) as isize,
+            (cy + r * angles[i].sin()) as isize,
+            (cx + r * angles[j].cos()) as isize,
+            (cy + r * angles[j].sin()) as isize,
+        );
+    }
 }
 
 #[cfg(test)]
@@ -125,6 +290,39 @@ mod tests {
     }
 
     #[test]
+    fn renders_radial_shape_not_bars() {
+        let input = std::fs::read_to_string("docs/sources/radar.mmd").unwrap();
+        let diagram = crate::parse(&input).unwrap();
+        let db = match diagram {
+            crate::diagrams::Diagram::Radar(db) => db,
+            _ => panic!("Expected radar"),
+        };
+        let output = render_radar_ascii(&db).unwrap();
+
+        // Should use braille characters for radar shape (radial layout)
+        let has_braille = output
+            .chars()
+            .any(|c| ('\u{2800}'..='\u{28FF}').contains(&c));
+        assert!(
+            has_braille,
+            "Radar chart should use braille characters for radial shape\nOutput:\n{}",
+            output
+        );
+
+        // Should NOT render as a bar chart
+        assert!(
+            !output.contains('█'),
+            "Should not render as bar chart\nOutput:\n{}",
+            output
+        );
+        assert!(
+            !output.contains('░'),
+            "Should not render as bar chart\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
     fn gallery_radar_renders() {
         let input = std::fs::read_to_string("docs/sources/radar.mmd").unwrap();
         let diagram = crate::parse(&input).unwrap();
@@ -136,10 +334,13 @@ mod tests {
         assert!(output.contains("Skills Assessment"), "Output:\n{}", output);
         assert!(output.contains("Coding"), "Output:\n{}", output);
         assert!(output.contains("Testing"), "Output:\n{}", output);
+        assert!(output.contains("Design"), "Output:\n{}", output);
+        assert!(output.contains("Code Review"), "Output:\n{}", output);
+        assert!(output.contains("Documentation"), "Output:\n{}", output);
     }
 
     #[test]
-    fn curves_appear() {
+    fn curves_appear_in_legend() {
         let input = std::fs::read_to_string("docs/sources/radar.mmd").unwrap();
         let diagram = crate::parse(&input).unwrap();
         let db = match diagram {
@@ -147,12 +348,25 @@ mod tests {
             _ => panic!("Expected radar"),
         };
         let output = render_radar_ascii(&db).unwrap();
-        assert!(output.contains("Team Alpha"), "Output:\n{}", output);
-        assert!(output.contains("Team Beta"), "Output:\n{}", output);
+        assert!(
+            output.contains("Team Alpha"),
+            "Should show curve name\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Team Beta"),
+            "Should show curve name\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Legend"),
+            "Should have legend section\nOutput:\n{}",
+            output
+        );
     }
 
     #[test]
-    fn has_bar_chars() {
+    fn has_data_point_markers() {
         let input = std::fs::read_to_string("docs/sources/radar.mmd").unwrap();
         let diagram = crate::parse(&input).unwrap();
         let db = match diagram {
@@ -160,6 +374,46 @@ mod tests {
             _ => panic!("Expected radar"),
         };
         let output = render_radar_ascii(&db).unwrap();
-        assert!(output.contains(FULL_BLOCK), "Output:\n{}", output);
+        assert!(
+            output.contains('●'),
+            "Should have data point markers for first curve\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains('◆'),
+            "Should have data point markers for second curve\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn complex_radar_renders() {
+        let input = std::fs::read_to_string("docs/sources/radar_complex.mmd").unwrap();
+        let diagram = crate::parse(&input).unwrap();
+        let db = match diagram {
+            crate::diagrams::Diagram::Radar(db) => db,
+            _ => panic!("Expected radar"),
+        };
+        let output = render_radar_ascii(&db).unwrap();
+        assert!(
+            output.contains("Programming Language Comparison"),
+            "Should show title\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Performance"),
+            "Should have axis label\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Rust"),
+            "Should show curve\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Python"),
+            "Should show curve\nOutput:\n{}",
+            output
+        );
     }
 }


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- Replaced horizontal bar chart rendering with a true radial spider/radar chart using braille characters
- Chart draws concentric graticule rings (circle or polygon depending on config), axis spokes from center, and curve polygons connecting data points
- Axis labels placed around the chart perimeter, legend below with distinct markers (●, ◆, ■, ▲) per curve
- Uses existing `BrailleCanvas` with Bresenham line drawing for sub-cell resolution; aspect ratio corrected so charts render circular in terminal

## Test plan
- [x] TDD: wrote `renders_radial_shape_not_bars` test first, confirmed failure with old bar-chart implementation
- [x] All 6 radar ASCII unit tests pass (empty, radial shape, gallery, legend, markers, complex)
- [x] Full test suite passes (`cargo test --features all-formats`)
- [x] `cargo fmt` and `cargo clippy --features all-formats -- -D warnings` pass clean
- [x] Visual verification of both `radar.mmd` and `radar_complex.mmd` output