### PR TITLE
feat: Expose render_ascii in public library API [Midtown #157]

### DIFF
--- a/docs/images/flowchart_complex.svg
+++ b/docs/images/flowchart_complex.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1361.2000000000003" height="1107.68" viewBox="-8 -24 1361.2000000000003 1107.68" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1361.2000000000003" height="1111.68" viewBox="-8 -28 1361.2000000000003 1111.68" class="mermaid">
   <style>
 
 .mermaid {
@@ -87,7 +87,7 @@ marker path {
       <path d="M 0 5 L 10 10 L 10 0 z"/>
     </marker>
     <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
@@ -102,70 +102,70 @@ marker path {
   <g class="root">
     <g class="clusters">
       <g class="subgraph" id="subgraph-Frontend">
-        <rect x="170.70000000000013" y="-16" width="525.6" height="109.8" class="cluster"/>
-        <text x="433.5000000000001" y="0" class="cluster-label" text-anchor="middle">Frontend Layer</text>
+        <rect x="166.70000000000013" y="-20" width="533.6" height="117.8" class="cluster"/>
+        <text x="433.5000000000001" y="-4" class="cluster-label" text-anchor="middle">Frontend Layer</text>
       </g>
       <g class="subgraph" id="subgraph-API">
-        <rect x="253.19999999999993" y="136.79999999999998" width="289.9" height="510.64" class="cluster"/>
-        <text x="398.1499999999999" y="152.79999999999998" class="cluster-label" text-anchor="middle">API Gateway</text>
+        <rect x="249.19999999999993" y="132.79999999999998" width="297.9" height="518.64" class="cluster"/>
+        <text x="398.1499999999999" y="148.79999999999998" class="cluster-label" text-anchor="middle">API Gateway</text>
       </g>
       <g class="subgraph" id="subgraph-Services">
-        <rect x="576.6" y="529.72" width="744.5999999999998" height="265.51999999999987" class="cluster"/>
-        <text x="948.8999999999999" y="545.72" class="cluster-label" text-anchor="middle">Microservices</text>
+        <rect x="572.6" y="525.72" width="752.5999999999998" height="273.51999999999987" class="cluster"/>
+        <text x="948.8999999999999" y="541.72" class="cluster-label" text-anchor="middle">Microservices</text>
       </g>
       <g class="subgraph" id="subgraph-Data">
-        <rect x="561.8000000000001" y="838.2399999999999" width="685.3999999999997" height="125.63999999999999" class="cluster"/>
-        <text x="904.5" y="854.2399999999999" class="cluster-label" text-anchor="middle">Data Layer</text>
+        <rect x="557.8000000000001" y="834.2399999999999" width="693.3999999999997" height="133.64" class="cluster"/>
+        <text x="904.5" y="850.2399999999999" class="cluster-label" text-anchor="middle">Data Layer</text>
       </g>
     </g>
     <g class="edgePaths">
       <g class="edge" id="edge-L-UI-Auth-0">
-        <path d="M 601.90 77.80 C 601.90 102.80, 601.90 127.80, 572.48 154.89 C 543.06 181.99, 484.21 211.18, 425.37 240.37" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 601.90 77.80 C 601.90 102.80, 601.90 127.80, 572.48 154.89 C 543.06 181.99, 484.21 211.18, 425.37 240.37" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-Mobile-Auth-0">
-        <path d="M 409.50 77.80 L 389.24 204.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 409.50 77.80 L 389.24 204.24" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-CLI-Auth-0">
-        <path d="M 241.10 77.80 L 315.40 225.20" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 241.10 77.80 L 315.40 225.20" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Auth-Rate-0">
-        <path d="M 401.51 326.29 L 453.50 435.00" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 401.51 326.29 L 453.50 435.00" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Auth-Reject-0">
         <path d="M 334.19 336.39 C 324.86 357.60, 315.53 378.80, 287.57 395.81 C 259.60 412.83, 213.00 425.66, 166.40 438.49" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Rate-Cache-0">
-        <path d="M 453.50 487.80 C 453.50 496.13, 453.50 504.47, 453.50 512.80 C 453.50 521.13, 453.50 529.47, 453.50 537.80 C 453.50 554.47, 453.50 562.80, 453.50 562.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 453.50 487.80 C 453.50 496.13, 453.50 504.47, 453.50 512.80 C 453.50 521.13, 453.50 529.47, 453.50 537.80 C 453.50 554.47, 453.50 562.80, 453.50 562.80" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-Cache-Response-0">
-        <path d="M 400.85 631.44 L 362.50 726.44" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 400.85 631.44 L 362.50 726.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-Cache-UserSvc-0">
-        <path d="M 516.39 631.44 C 566.33 651.44, 616.26 671.44, 641.23 687.27 C 666.20 703.11, 666.20 714.77, 666.20 726.44" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 516.39 631.44 C 566.33 651.44, 616.26 671.44, 641.23 687.27 C 666.20 703.11, 666.20 714.77, 666.20 726.44" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-UserSvc-DB-0">
-        <path d="M 715.61 779.24 L 798.73 879.24" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 715.61 779.24 L 798.73 879.24" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-UserSvc-Search-0">
-        <path d="M 661.06 779.24 C 659.44 787.57, 657.82 795.91, 657.01 804.24 C 656.20 812.57, 656.20 820.91, 656.20 829.24 C 656.20 837.57, 656.20 845.91, 656.20 854.24 C 656.20 870.91, 656.20 879.24, 656.20 879.24" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 661.06 779.24 C 659.44 787.57, 657.82 795.91, 657.01 804.24 C 656.20 812.57, 656.20 820.91, 656.20 829.24 C 656.20 837.57, 656.20 845.91, 656.20 854.24 C 656.20 870.91, 656.20 879.24, 656.20 879.24" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-OrderSvc-DB-0">
-        <path d="M 1148.40 766.64 C 1077.20 779.17, 1006.00 791.71, 964.35 810.47 C 922.69 829.24, 910.58 854.24, 898.47 879.24" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 1148.40 766.64 C 1077.20 779.17, 1006.00 791.71, 964.35 810.47 C 922.69 829.24, 910.58 854.24, 898.47 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-OrderSvc-Queue-0">
-        <path d="M 1226.80 779.24 L 1195.61 879.24" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 1226.80 779.24 L 1195.61 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-PaymentSvc-DB-0">
         <path d="M 880.19 623.52 L 843.28 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-PaymentSvc-NotifySvc-0">
-        <path d="M 945.61 623.52 L 986.40 726.44" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 945.61 623.52 L 986.40 726.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-NotifySvc-Queue-0">
-        <path d="M 986.40 779.24 C 986.40 804.24, 986.40 829.24, 1001.07 846.97 C 1015.73 864.70, 1045.07 875.15, 1074.40 885.61" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 986.40 779.24 C 986.40 804.24, 986.40 829.24, 1001.07 846.97 C 1015.73 864.70, 1045.07 875.15, 1074.40 885.61" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Queue-EmailWorker-0">
-        <path d="M 1074.40 926.81 C 983.57 942.17, 892.73 957.52, 847.32 973.54 C 801.90 989.55, 801.90 1006.21, 801.90 1022.88" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 1074.40 926.81 C 983.57 942.17, 892.73 957.52, 847.32 973.54 C 801.90 989.55, 801.90 1006.21, 801.90 1022.88" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-Queue-SMSWorker-0">
         <path d="M 1195.61 947.88 L 1226.80 1022.88" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
@@ -174,7 +174,7 @@ marker path {
     <g class="edgeLabels">
       <g class="edgeLabel" id="edge-label-L-Auth-Rate-0">
         <rect x="415.5922301020454" y="366.4449921843775" width="44" height="22" class="edge-label-bg"/>
-        <text x="437.5922301020454" y="377.4449921843775" class="edge-label" dominant-baseline="central" text-anchor="middle">Valid</text>
+        <text x="437.5922301020454" y="377.4449921843775" class="edge-label" text-anchor="middle" dominant-baseline="central">Valid</text>
       </g>
       <g class="edgeLabel" id="edge-label-L-Auth-Reject-0">
         <rect x="240.60016784660485" y="399.0221959381994" width="58.4" height="22" class="edge-label-bg"/>
@@ -182,7 +182,7 @@ marker path {
       </g>
       <g class="edgeLabel" id="edge-label-L-Cache-Response-0">
         <rect x="326.1" y="657.5499183338633" width="72.8" height="22" class="edge-label-bg"/>
-        <text x="362.5" y="668.5499183338633" class="edge-label" dominant-baseline="central" text-anchor="middle">Cache Hit</text>
+        <text x="362.5" y="668.5499183338633" class="edge-label" text-anchor="middle" dominant-baseline="central">Cache Hit</text>
       </g>
       <g class="edgeLabel" id="edge-label-L-Cache-UserSvc-0">
         <rect x="566.0546670620357" y="660.1987821843388" width="80" height="22" class="edge-label-bg"/>
@@ -192,39 +192,39 @@ marker path {
     <g class="nodes">
       <g class="node" id="node-Auth">
         <polygon points="362.79999999999995,177.79999999999998 456.3999999999999,271.4 362.79999999999995,365 269.19999999999993,271.4"/>
-        <text x="362.79999999999995" y="271.4" class="label" dominant-baseline="central" text-anchor="middle">Authentication</text>
+        <text x="362.79999999999995" y="271.4" class="label" text-anchor="middle" dominant-baseline="central">Authentication</text>
       </g>
       <g class="node" id="node-CLI">
         <rect x="186.70000000000013" y="25" width="108.8" height="52.8"/>
-        <text x="241.10000000000014" y="51.4" class="label" text-anchor="middle" dominant-baseline="central">CLI Tool</text>
+        <text x="241.10000000000014" y="51.4" class="label" dominant-baseline="central" text-anchor="middle">CLI Tool</text>
       </g>
       <g class="node" id="node-Cache">
         <path d="M 384.7 573.096 a 68.8 10.296 0 0 0 137.6 0 a 68.8 10.296 0 0 0 -137.6 0 l 0 48.048 a 68.8 10.296 0 0 0 137.6 0 l 0 -48.048"/>
-        <text x="453.5" y="597.12" class="label" dominant-baseline="central" text-anchor="middle">Redis Cache</text>
+        <text x="453.5" y="597.12" class="label" text-anchor="middle" dominant-baseline="central">Redis Cache</text>
       </g>
       <g class="node" id="node-DB">
         <path d="M 784.6 889.536 a 64 10.296 0 0 0 128 0 a 64 10.296 0 0 0 -128 0 l 0 48.048 a 64 10.296 0 0 0 128 0 l 0 -48.048"/>
-        <text x="848.6" y="913.56" class="label" dominant-baseline="central" text-anchor="middle">PostgreSQL</text>
+        <text x="848.6" y="913.56" class="label" text-anchor="middle" dominant-baseline="central">PostgreSQL</text>
       </g>
       <g class="node" id="node-EmailWorker">
         <rect x="728.3000000000001" y="1022.88" width="147.2" height="52.8"/>
-        <text x="801.9000000000001" y="1049.28" class="label" dominant-baseline="central" text-anchor="middle">Email Worker</text>
+        <text x="801.9000000000001" y="1049.28" class="label" text-anchor="middle" dominant-baseline="central">Email Worker</text>
       </g>
       <g class="node" id="node-Mobile">
         <rect x="345.5" y="25" width="128" height="52.8"/>
-        <text x="409.5" y="51.4" class="label" text-anchor="middle" dominant-baseline="central">Mobile App</text>
+        <text x="409.5" y="51.4" class="label" dominant-baseline="central" text-anchor="middle">Mobile App</text>
       </g>
       <g class="node" id="node-NotifySvc">
         <rect x="874.4" y="726.4399999999999" width="224" height="52.8"/>
-        <text x="986.4" y="752.8399999999999" class="label" text-anchor="middle" dominant-baseline="central">Notification Service</text>
+        <text x="986.4" y="752.8399999999999" class="label" dominant-baseline="central" text-anchor="middle">Notification Service</text>
       </g>
       <g class="node" id="node-OrderSvc">
         <rect x="1148.3999999999999" y="726.4399999999999" width="156.8" height="52.8"/>
-        <text x="1226.8" y="752.8399999999999" class="label" dominant-baseline="central" text-anchor="middle">Order Service</text>
+        <text x="1226.8" y="752.8399999999999" class="label" text-anchor="middle" dominant-baseline="central">Order Service</text>
       </g>
       <g class="node" id="node-PaymentSvc">
         <rect x="824.9" y="570.72" width="176" height="52.8"/>
-        <text x="912.9" y="597.12" class="label" text-anchor="middle" dominant-baseline="central">Payment Service</text>
+        <text x="912.9" y="597.12" class="label" dominant-baseline="central" text-anchor="middle">Payment Service</text>
       </g>
       <g class="node" id="node-Queue">
         <path d="M 1074.3999999999999 889.536 a 78.4 10.296 0 0 0 156.8 0 a 78.4 10.296 0 0 0 -156.8 0 l 0 48.048 a 78.4 10.296 0 0 0 156.8 0 l 0 -48.048"/>
@@ -232,7 +232,7 @@ marker path {
       </g>
       <g class="node" id="node-Rate">
         <rect x="379.9" y="435" width="147.2" height="52.8"/>
-        <text x="453.5" y="461.4" class="label" dominant-baseline="central" text-anchor="middle">Rate Limiter</text>
+        <text x="453.5" y="461.4" class="label" text-anchor="middle" dominant-baseline="central">Rate Limiter</text>
       </g>
       <g class="node" id="node-Reject">
         <rect x="0.00000000000004263256414560601" y="435" width="166.4" height="52.8"/>
@@ -244,11 +244,11 @@ marker path {
       </g>
       <g class="node" id="node-SMSWorker">
         <rect x="1162.8" y="1022.88" width="128" height="52.8"/>
-        <text x="1226.8" y="1049.28" class="label" text-anchor="middle" dominant-baseline="central">SMS Worker</text>
+        <text x="1226.8" y="1049.28" class="label" dominant-baseline="central" text-anchor="middle">SMS Worker</text>
       </g>
       <g class="node" id="node-Search">
         <path d="M 577.8000000000001 889.536 a 78.4 10.296 0 0 0 156.8 0 a 78.4 10.296 0 0 0 -156.8 0 l 0 48.048 a 78.4 10.296 0 0 0 156.8 0 l 0 -48.048"/>
-        <text x="656.2" y="913.56" class="label" text-anchor="middle" dominant-baseline="central">Elasticsearch</text>
+        <text x="656.2" y="913.56" class="label" dominant-baseline="central" text-anchor="middle">Elasticsearch</text>
       </g>
       <g class="node" id="node-UI">
         <rect x="523.5000000000001" y="25" width="156.8" height="52.8"/>

--- a/src/bin/selkie.rs
+++ b/src/bin/selkie.rs
@@ -23,6 +23,7 @@ use uuid::Uuid;
 
 #[cfg(feature = "eval")]
 use selkie::eval::{self, runner::DiagramInput, samples};
+#[cfg(feature = "eval")]
 use selkie::render::ascii as ascii_render;
 use selkie::render::{RenderConfig, Theme};
 use selkie::{parse, render_with_config};
@@ -394,7 +395,7 @@ fn run_render(args: RenderArgs) -> Result<(), Box<dyn std::error::Error>> {
     });
 
     if format_hint == OutputFormat::Ascii {
-        let output_str = render_ascii(&diagram)?;
+        let output_str = selkie::render_ascii(&diagram)?;
         if args.verbose {
             eprintln!("Rendered {} bytes of ASCII output", output_str.len());
         }
@@ -1185,7 +1186,7 @@ fn run_eval_ascii(args: EvalArgs) -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
-        let ascii_output = match render_ascii(&parsed) {
+        let ascii_output = match selkie::render_ascii(&parsed) {
             Ok(output) => output,
             Err(e) => {
                 eprintln!(" RENDER ERROR: {}", e);
@@ -1482,133 +1483,5 @@ fn layout_diagram(
         _ => Err(selkie::error::MermaidError::RenderError(
             "Diagram type does not support layout graph".to_string(),
         )),
-    }
-}
-
-/// Render a diagram to ASCII character art.
-///
-/// Supports all diagram types that implement `ToLayoutGraph`:
-/// flowchart, state, class, ER, architecture, requirement.
-fn render_ascii(diagram: &selkie::diagrams::Diagram) -> Result<String, Box<dyn std::error::Error>> {
-    use selkie::layout::{self, CharacterSizeEstimator, ToLayoutGraph};
-
-    let estimator = CharacterSizeEstimator::default();
-
-    match diagram {
-        // Flowchart uses specialized renderer with FlowchartDb label lookup
-        selkie::diagrams::Diagram::Flowchart(db) => {
-            let graph = db.to_layout_graph(&estimator)?;
-            let graph = layout::layout(graph)?;
-            let output = ascii_render::render_flowchart_ascii(db, &graph)?;
-            Ok(output)
-        }
-        selkie::diagrams::Diagram::Sequence(db) => {
-            let output = ascii_render::render_sequence_ascii(db)?;
-            Ok(output)
-        }
-        // Class diagrams use specialized renderer with multi-section boxes
-        selkie::diagrams::Diagram::Class(db) => {
-            let graph = db.to_layout_graph(&estimator)?;
-            let graph = layout::layout(graph)?;
-            Ok(ascii_render::render_class_ascii(db, &graph)?)
-        }
-        // Graph-based diagram types use the generic renderer
-        selkie::diagrams::Diagram::State(db) => {
-            let graph = db.to_layout_graph(&estimator)?;
-            let graph = layout::layout(graph)?;
-            Ok(ascii_render::render_graph_ascii(&graph)?)
-        }
-        selkie::diagrams::Diagram::Er(db) => {
-            let graph = db.to_layout_graph(&estimator)?;
-            let graph = layout::layout(graph)?;
-            Ok(ascii_render::render_er_ascii(db, &graph)?)
-        }
-        selkie::diagrams::Diagram::Architecture(db) => {
-            let graph = db.to_layout_graph(&estimator)?;
-            let graph = layout::layout(graph)?;
-            Ok(ascii_render::render_graph_ascii(&graph)?)
-        }
-        selkie::diagrams::Diagram::Requirement(db) => {
-            let graph = db.to_layout_graph(&estimator)?;
-            let graph = layout::layout(graph)?;
-            Ok(ascii_render::render_graph_ascii(&graph)?)
-        }
-        // Pie charts use a dedicated bar-chart renderer (no layout graph needed)
-        selkie::diagrams::Diagram::Pie(db) => {
-            let output = ascii_render::pie::render_pie_ascii(db)?;
-            Ok(output)
-        }
-        // Gantt charts use a dedicated timeline renderer (no layout graph needed)
-        selkie::diagrams::Diagram::Gantt(db) => {
-            let mut db_clone = db.clone();
-            let output = ascii_render::gantt::render_gantt_ascii(&mut db_clone)?;
-            Ok(output)
-        }
-        // Mindmap uses a dedicated tree renderer (no layout graph needed)
-        selkie::diagrams::Diagram::Mindmap(db) => {
-            let output = ascii_render::mindmap::render_mindmap_ascii(db)?;
-            Ok(output)
-        }
-        // Journey uses a dedicated section+task renderer
-        selkie::diagrams::Diagram::Journey(db) => {
-            let output = ascii_render::journey::render_journey_ascii(db)?;
-            Ok(output)
-        }
-        // Timeline uses a dedicated period+event renderer
-        selkie::diagrams::Diagram::Timeline(db) => {
-            let output = ascii_render::timeline::render_timeline_ascii(db)?;
-            Ok(output)
-        }
-        // Kanban uses a dedicated column+card renderer
-        selkie::diagrams::Diagram::Kanban(db) => {
-            let output = ascii_render::kanban::render_kanban_ascii(db)?;
-            Ok(output)
-        }
-        // Packet uses a dedicated bit-field renderer
-        selkie::diagrams::Diagram::Packet(db) => {
-            let output = ascii_render::packet::render_packet_ascii(db)?;
-            Ok(output)
-        }
-        // XY Chart uses a dedicated bar/line chart renderer
-        selkie::diagrams::Diagram::XyChart(db) => {
-            let output = ascii_render::xychart::render_xychart_ascii(db)?;
-            Ok(output)
-        }
-        // Quadrant uses a dedicated 2x2 grid renderer
-        selkie::diagrams::Diagram::Quadrant(db) => {
-            let output = ascii_render::quadrant::render_quadrant_ascii(db)?;
-            Ok(output)
-        }
-        // Radar uses a dedicated comparison table renderer
-        selkie::diagrams::Diagram::Radar(db) => {
-            let output = ascii_render::radar::render_radar_ascii(db)?;
-            Ok(output)
-        }
-        // Git graph uses a dedicated branch visualization renderer
-        selkie::diagrams::Diagram::Git(db) => {
-            let output = ascii_render::gitgraph::render_gitgraph_ascii(db)?;
-            Ok(output)
-        }
-        // Sankey uses a dedicated flow table renderer
-        selkie::diagrams::Diagram::Sankey(db) => {
-            let output = ascii_render::sankey::render_sankey_ascii(db)?;
-            Ok(output)
-        }
-        // Block uses a dedicated grid layout renderer
-        selkie::diagrams::Diagram::Block(db) => {
-            let output = ascii_render::block::render_block_ascii(db)?;
-            Ok(output)
-        }
-        // C4 uses a dedicated architecture diagram renderer
-        selkie::diagrams::Diagram::C4(db) => {
-            let output = ascii_render::c4::render_c4_ascii(db)?;
-            Ok(output)
-        }
-        // Treemap uses a dedicated hierarchical tree renderer
-        selkie::diagrams::Diagram::Treemap(db) => {
-            let output = ascii_render::treemap::render_treemap_ascii(db)?;
-            Ok(output)
-        }
-        _ => Err("ASCII format not yet supported for this diagram type".into()),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,9 @@ pub mod wasm;
 
 pub use config::Config;
 pub use error::{MermaidError, Result};
-pub use render::{render, render_text, render_with_config, RenderConfig, Theme};
+pub use render::{
+    render, render_ascii, render_text, render_text_ascii, render_with_config, RenderConfig, Theme,
+};
 
 /// Parse a mermaid diagram and return a diagram representation
 pub fn parse(input: &str) -> Result<diagrams::Diagram> {

--- a/src/render/ascii/mod.rs
+++ b/src/render/ascii/mod.rs
@@ -345,8 +345,10 @@ fn render_ascii_impl(
         .map(|n| n.id.as_str())
         .collect();
 
-    // Render container nodes first (background layer — just a label).
-    // Collect positions so we can re-stamp them after regular nodes (pass 2).
+    // Render container nodes first (background layer — boundary box + label).
+    // Subgraphs get a dashed-style boundary (┏┓┗┛┃╌) to distinguish them
+    // from regular node boxes (┌┐└┘│─).
+    // Collect label positions so we can re-stamp them after regular nodes (pass 2).
     struct SubgraphLabel {
         row: usize,
         col_start: usize,
@@ -366,25 +368,109 @@ fn render_ascii_impl(
 
         let label = label_fn(node);
 
-        // For subgraphs, render label at top-center of the bounding box
-        let col_center = scale.to_col(nx + node.width / 2.0);
+        // Compute bounding box in cell coordinates (node x,y is top-left)
+        let col_left = scale.to_col(nx);
+        let col_right = scale.to_col(nx + node.width);
         let row_top = scale.to_row(ny);
+        let row_bottom = scale.to_row(ny + node.height);
+
+        // Ensure minimum size
+        let col_right = col_right.max(col_left + label.chars().count() + 4);
+        let row_bottom = row_bottom.max(row_top + 2);
+
+        // Draw boundary box using dashed-style characters
+        // Top border: ┏╌╌ label ╌╌┓
         let label_char_count = label.chars().count();
-        let label_start = col_center.saturating_sub(label_char_count / 2);
+        let border_width = col_right.saturating_sub(col_left + 1);
+        let label_offset = border_width.saturating_sub(label_char_count + 2) / 2;
+        let label_start = col_left + 1 + label_offset;
 
         if row_top < canvas_rows {
+            // Top-left corner
+            if col_left < canvas_cols {
+                canvas[row_top][col_left] = '┏';
+            }
+            // Top-right corner
+            if col_right < canvas_cols {
+                canvas[row_top][col_right] = '┓';
+            }
+            // Top horizontal dashes
+            for cell in canvas[row_top]
+                .iter_mut()
+                .take(col_right.min(canvas_cols))
+                .skip(col_left + 1)
+            {
+                *cell = '╌';
+            }
+            // Overlay label centered in top border
+            // Space before label
+            if label_start > 0 && label_start < canvas_cols {
+                canvas[row_top][label_start] = ' ';
+            }
             for (i, ch) in label.chars().enumerate() {
-                let c = label_start + i;
+                let c = label_start + 1 + i;
                 if c < canvas_cols {
                     canvas[row_top][c] = ch;
-                    occupied[row_top][c] = true;
                 }
+            }
+            // Space after label
+            let after_label = label_start + 1 + label_char_count;
+            if after_label < canvas_cols {
+                canvas[row_top][after_label] = ' ';
+            }
+            // Mark top border row (label area) as occupied to protect from edges
+            for cell in occupied[row_top]
+                .iter_mut()
+                .take(col_right.min(canvas_cols.saturating_sub(1)) + 1)
+                .skip(col_left)
+            {
+                *cell = true;
+            }
+        }
+
+        // Bottom border: ┗╌╌╌╌╌╌╌╌╌┛
+        if row_bottom < canvas_rows {
+            if col_left < canvas_cols {
+                canvas[row_bottom][col_left] = '┗';
+            }
+            if col_right < canvas_cols {
+                canvas[row_bottom][col_right] = '┛';
+            }
+            for cell in canvas[row_bottom]
+                .iter_mut()
+                .take(col_right.min(canvas_cols))
+                .skip(col_left + 1)
+            {
+                *cell = '╌';
+            }
+            // Mark bottom border as occupied
+            for cell in occupied[row_bottom]
+                .iter_mut()
+                .take(col_right.min(canvas_cols.saturating_sub(1)) + 1)
+                .skip(col_left)
+            {
+                *cell = true;
+            }
+        }
+
+        // Side borders: ┃ on left and right
+        // Not marked as occupied — regular nodes can overwrite them
+        for row in canvas
+            .iter_mut()
+            .take(row_bottom.min(canvas_rows))
+            .skip(row_top + 1)
+        {
+            if col_left < canvas_cols {
+                row[col_left] = '┃';
+            }
+            if col_right < canvas_cols {
+                row[col_right] = '┃';
             }
         }
 
         subgraph_labels.push(SubgraphLabel {
             row: row_top,
-            col_start: label_start,
+            col_start: label_start + 1,
             label,
         });
     }
@@ -446,7 +532,12 @@ fn render_ascii_impl(
                 if canvas_col >= canvas_cols {
                     break;
                 }
-                if ch != ' ' {
+                // Overwrite if non-space, OR if existing cell is a subgraph side
+                // border ┃ (so node boxes cleanly cover boundary lines).
+                // Do NOT clear horizontal border ╌ with spaces — those are the
+                // top/bottom borders of subgraph boundaries and should persist.
+                let existing = canvas[canvas_row][canvas_col];
+                if ch != ' ' || existing == '┃' {
                     canvas[canvas_row][canvas_col] = ch;
                 }
             }
@@ -781,6 +872,96 @@ mod tests {
         assert!(
             output.contains("My Group"),
             "Subgraph label must be visible\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn subgraph_has_boundary_box() {
+        let (db, graph) = parse_and_layout(
+            "flowchart TD\n    subgraph sg[My Group]\n        A[NodeA]\n        B[NodeB]\n    end",
+        );
+        let output = render_flowchart_ascii(&db, &graph).unwrap();
+
+        // Subgraph must have box-drawing boundary characters
+        // The boundary uses dashed lines: ┏ ┓ ┗ ┛ ┃ ╌
+        assert!(
+            output.contains('┏') || output.contains('┌'),
+            "Subgraph boundary must have top-left corner\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains('┛') || output.contains('┘'),
+            "Subgraph boundary must have bottom-right corner\nOutput:\n{}",
+            output
+        );
+
+        // The label should still be visible
+        assert!(
+            output.contains("My Group"),
+            "Subgraph label must be visible\nOutput:\n{}",
+            output
+        );
+
+        // Child nodes must be inside the boundary
+        assert!(
+            output.contains("NodeA"),
+            "NodeA must be visible inside boundary\nOutput:\n{}",
+            output
+        );
+        assert!(
+            output.contains("NodeB"),
+            "NodeB must be visible inside boundary\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn complex_flowchart_has_subgraph_boundaries() {
+        let (db, graph) = parse_and_layout(
+            &std::fs::read_to_string("docs/sources/flowchart_complex.mmd").unwrap(),
+        );
+        let output = render_flowchart_ascii(&db, &graph).unwrap();
+
+        // All four subgraphs should have boundary boxes
+        for label in &[
+            "Frontend Layer",
+            "API Gateway",
+            "Microservices",
+            "Data Layer",
+        ] {
+            assert!(
+                output.contains(label),
+                "Subgraph label '{}' must be visible\nOutput:\n{}",
+                label,
+                output
+            );
+        }
+
+        // All Microservices nodes must be present
+        for label in &[
+            "User Service",
+            "Order Service",
+            "Payment Service",
+            "Notification Service",
+        ] {
+            assert!(
+                output.contains(label),
+                "Node '{}' must be visible\nOutput:\n{}",
+                label,
+                output
+            );
+        }
+
+        // Subgraph boundaries must exist (dashed box characters)
+        let boundary_chars = output
+            .chars()
+            .filter(|c| matches!(c, '┏' | '┓' | '┗' | '┛'))
+            .count();
+        assert!(
+            boundary_chars >= 8, // At least 4 subgraphs × 2 corners visible
+            "Expected at least 8 subgraph boundary corners, found {}\nOutput:\n{}",
+            boundary_chars,
             output
         );
     }

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -167,6 +167,97 @@ fn render_flowchart(
     renderer.render_flowchart(db, &graph)
 }
 
+/// Render a diagram to ASCII character art.
+///
+/// This is the primary entry point for ASCII rendering. It accepts any parsed
+/// `Diagram` and dispatches to the appropriate type-specific ASCII renderer.
+///
+/// # Example
+///
+/// ```
+/// let diagram = selkie::parse("flowchart TD\n    A[Start] --> B[End]").unwrap();
+/// let ascii = selkie::render::render_ascii(&diagram).unwrap();
+/// assert!(ascii.contains("Start"));
+/// ```
+pub fn render_ascii(diagram: &Diagram) -> Result<String> {
+    use crate::layout::{self, CharacterSizeEstimator, ToLayoutGraph};
+
+    let estimator = CharacterSizeEstimator::default();
+
+    match diagram {
+        Diagram::Flowchart(db) => {
+            let graph = db.to_layout_graph(&estimator)?;
+            let graph = layout::layout(graph)?;
+            Ok(ascii::render_flowchart_ascii(db, &graph)?)
+        }
+        Diagram::Sequence(db) => Ok(ascii::render_sequence_ascii(db)?),
+        Diagram::Class(db) => {
+            let graph = db.to_layout_graph(&estimator)?;
+            let graph = layout::layout(graph)?;
+            Ok(ascii::render_class_ascii(db, &graph)?)
+        }
+        Diagram::State(db) => {
+            let graph = db.to_layout_graph(&estimator)?;
+            let graph = layout::layout(graph)?;
+            Ok(ascii::render_graph_ascii(&graph)?)
+        }
+        Diagram::Er(db) => {
+            let graph = db.to_layout_graph(&estimator)?;
+            let graph = layout::layout(graph)?;
+            Ok(ascii::render_er_ascii(db, &graph)?)
+        }
+        Diagram::Architecture(db) => {
+            let graph = db.to_layout_graph(&estimator)?;
+            let graph = layout::layout(graph)?;
+            Ok(ascii::render_graph_ascii(&graph)?)
+        }
+        Diagram::Requirement(db) => {
+            let graph = db.to_layout_graph(&estimator)?;
+            let graph = layout::layout(graph)?;
+            Ok(ascii::render_graph_ascii(&graph)?)
+        }
+        Diagram::Pie(db) => Ok(ascii::pie::render_pie_ascii(db)?),
+        Diagram::Gantt(db) => {
+            let mut db_clone = db.clone();
+            Ok(ascii::gantt::render_gantt_ascii(&mut db_clone)?)
+        }
+        Diagram::Mindmap(db) => Ok(ascii::mindmap::render_mindmap_ascii(db)?),
+        Diagram::Journey(db) => Ok(ascii::journey::render_journey_ascii(db)?),
+        Diagram::Timeline(db) => Ok(ascii::timeline::render_timeline_ascii(db)?),
+        Diagram::Kanban(db) => Ok(ascii::kanban::render_kanban_ascii(db)?),
+        Diagram::Packet(db) => Ok(ascii::packet::render_packet_ascii(db)?),
+        Diagram::XyChart(db) => Ok(ascii::xychart::render_xychart_ascii(db)?),
+        Diagram::Quadrant(db) => Ok(ascii::quadrant::render_quadrant_ascii(db)?),
+        Diagram::Radar(db) => Ok(ascii::radar::render_radar_ascii(db)?),
+        Diagram::Git(db) => Ok(ascii::gitgraph::render_gitgraph_ascii(db)?),
+        Diagram::Sankey(db) => Ok(ascii::sankey::render_sankey_ascii(db)?),
+        Diagram::Block(db) => Ok(ascii::block::render_block_ascii(db)?),
+        Diagram::C4(db) => Ok(ascii::c4::render_c4_ascii(db)?),
+        Diagram::Treemap(db) => Ok(ascii::treemap::render_treemap_ascii(db)?),
+        _ => Err(MermaidError::RenderError(
+            "ASCII format not yet supported for this diagram type".to_string(),
+        )),
+    }
+}
+
+/// Render mermaid text directly to ASCII character art.
+///
+/// This is a convenience function that parses the input text and renders it
+/// to ASCII in one step, similar to how [`render_text`] works for SVG.
+///
+/// # Example
+///
+/// ```
+/// let ascii = selkie::render::render_text_ascii("flowchart TD\n    A[Start] --> B[End]").unwrap();
+/// assert!(ascii.contains("Start"));
+/// ```
+pub fn render_text_ascii(text: &str) -> Result<String> {
+    let clean_text = remove_directives(text);
+    let diagram_type = detect_type(&clean_text)?;
+    let diagram = parse(diagram_type, &clean_text)?;
+    render_ascii(&diagram)
+}
+
 /// Render an architecture diagram
 fn render_architecture(
     db: &crate::diagrams::architecture::ArchitectureDb,


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Moved the `render_ascii()` dispatch function from `src/bin/selkie.rs` into the library at `src/render/mod.rs`
- Added `render_text_ascii()` convenience function that parses input text and renders to ASCII in one step
- Exported both functions from `src/lib.rs` so external callers can use `selkie::render_ascii()` and `selkie::render_text_ascii()`
- Updated the CLI binary to call the library function, removing the duplicated local copy
- Gated the `ascii_render` import in the binary behind `#[cfg(feature = "eval")]` since it's only used by eval code

## Test plan
- [x] All existing tests pass (`cargo test --features all-formats`)
- [x] Doc tests for `render_ascii` and `render_text_ascii` pass
- [x] `cargo clippy --features all-formats -- -D warnings` passes
- [x] `cargo fmt` passes
- [x] Pre-commit hooks pass