### PR TITLE
fix: state diagram complex ASCII: fork/join bars and composite containers [Midtown #153]

### DIFF
--- a/docs/images/state.svg
+++ b/docs/images/state.svg
@@ -118,7 +118,7 @@
   </style>
   <defs>
     <marker id="arrow" viewBox="0 0 20 14" refX="19" refY="7" markerWidth="20" markerHeight="14" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke="#333333" fill="#333333" stroke-width="1"/>
+      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke-width="1" stroke="#333333" fill="#333333"/>
     </marker>
   </defs>
   <g class="root">
@@ -135,20 +135,20 @@
 
     </g>
     <g class="state-node" id="state-Error">
-      <path d="M 87.73550027658062 288 H 125.29018777658064 A 5 5 0 0 1 130.29018777658064 293 V 319 A 5 5 0 0 1 125.29018777658064 324 H 87.73550027658062 A 5 5 0 0 1 82.73550027658062 319 V 293 A 5 5 0 0 1 87.73550027658062 288 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="106.51284402658062" y="311" class="state-label" text-anchor="middle" font-size="16">Error</text>
+      <path d="M 87.73550027658062 288 H 125.29018777658064 A 5 5 0 0 1 130.29018777658064 293 V 319 A 5 5 0 0 1 125.29018777658064 324 H 87.73550027658062 A 5 5 0 0 1 82.73550027658062 319 V 293 A 5 5 0 0 1 87.73550027658062 288 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="106.51284402658062" y="311" class="state-label" font-size="16" text-anchor="middle">Error</text>
     </g>
     <g class="state-node" id="state-Idle">
-      <path d="M 81.71401590158062 68 H 109.51089090158062 A 5 5 0 0 1 114.51089090158062 73 V 99 A 5 5 0 0 1 109.51089090158062 104 H 81.71401590158062 A 5 5 0 0 1 76.71401590158062 99 V 73 A 5 5 0 0 1 81.71401590158062 68 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="95.61245340158062" y="91" class="state-label" font-size="16" text-anchor="middle">Idle</text>
+      <path d="M 81.71401590158062 68 H 109.51089090158062 A 5 5 0 0 1 114.51089090158062 73 V 99 A 5 5 0 0 1 109.51089090158062 104 H 81.71401590158062 A 5 5 0 0 1 76.71401590158062 99 V 73 A 5 5 0 0 1 81.71401590158062 68 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="95.61245340158062" y="91" class="state-label" text-anchor="middle" font-size="16">Idle</text>
     </g>
     <g class="state-node" id="state-Running">
-      <path d="M 23.811672151580623 178 H 85.41323465158062 A 5 5 0 0 1 90.41323465158062 183 V 209 A 5 5 0 0 1 85.41323465158062 214 H 23.811672151580623 A 5 5 0 0 1 18.811672151580623 209 V 183 A 5 5 0 0 1 23.811672151580623 178 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="54.61245340158062" y="201" class="state-label" font-size="16" text-anchor="middle">Running</text>
+      <path d="M 23.811672151580623 178 H 85.41323465158062 A 5 5 0 0 1 90.41323465158062 183 V 209 A 5 5 0 0 1 85.41323465158062 214 H 23.811672151580623 A 5 5 0 0 1 18.811672151580623 209 V 183 A 5 5 0 0 1 23.811672151580623 178 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
+      <text x="54.61245340158062" y="201" class="state-label" text-anchor="middle" font-size="16">Running</text>
     </g>
     <g class="state-node" id="state-root_end">
-      <path d="M 99.51284402658062 385 A 7 7 0 1 0 113.51284402658062 385 A 7 7 0 1 0 99.51284402658062 385 Z" class="state-end-outer" stroke="#9370DB" stroke-width="2" fill="none"/>
-      <path d="M 103.99284402658063 385 A 2.52 2.52 0 1 0 109.03284402658062 385 A 2.52 2.52 0 1 0 103.99284402658063 385 Z" class="state-end-inner" fill="#9370DB" stroke="#9370DB" stroke-width="2"/>
+      <path d="M 99.51284402658062 385 A 7 7 0 1 0 113.51284402658062 385 A 7 7 0 1 0 99.51284402658062 385 Z" class="state-end-outer" stroke-width="2" fill="none" stroke="#9370DB"/>
+      <path d="M 103.99284402658063 385 A 2.52 2.52 0 1 0 109.03284402658062 385 A 2.52 2.52 0 1 0 103.99284402658063 385 Z" class="state-end-inner" stroke="#9370DB" stroke-width="2" fill="#9370DB"/>
     </g>
     <g class="state-node" id="state-root_start">
       <circle cx="95.61245340158062" cy="7" r="7" class="state-start" fill="#333333"/>
@@ -159,25 +159,25 @@
     <g class="transition">
       <path d="M 76.71 98.68 C 55.68 112.78, 34.65 126.89, 28.73 140.11 C 22.81 153.33, 32.00 165.67, 41.19 178.00" class="transition-path" stroke-width="0.7" marker-end="url(#arrow)" fill="none"/>
       <path d="M 6 121.89127972057237 H 46 A 2 2 0 0 1 48 123.89127972057237 V 141.49127972057238 A 2 2 0 0 1 46 143.49127972057238 H 6 A 2 2 0 0 1 4 141.49127972057238 V 123.89127972057237 A 2 2 0 0 1 6 121.89127972057237 Z" class="transition-label-bg"/>
-      <text x="26" y="132.69127972057237" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">start</text>
+      <text x="26" y="132.69127972057237" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">start</text>
     </g>
     <g class="transition">
-      <path d="M 68.03 178.00 L 95.61 104.00" class="transition-path" marker-end="url(#arrow)" stroke-width="0.7" fill="none"/>
+      <path d="M 68.03 178.00 L 95.61 104.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
       <path d="M 76.87834863208171 133.86770152005948 H 108.87834863208171 A 2 2 0 0 1 110.87834863208171 135.86770152005948 V 153.46770152005948 A 2 2 0 0 1 108.87834863208171 155.46770152005948 H 76.87834863208171 A 2 2 0 0 1 74.87834863208171 153.46770152005948 V 135.86770152005948 A 2 2 0 0 1 76.87834863208171 133.86770152005948 Z" class="transition-label-bg"/>
-      <text x="92.87834863208171" y="144.6677015200595" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">stop</text>
+      <text x="92.87834863208171" y="144.6677015200595" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">stop</text>
     </g>
     <g class="transition">
-      <path d="M 54.61 214.00 L 89.53 288.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
+      <path d="M 54.61 214.00 L 89.53 288.00" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
       <path d="M 39.3730196029233 245.24487804274298 H 79.3730196029233 A 2 2 0 0 1 81.3730196029233 247.24487804274298 V 264.844878042743 A 2 2 0 0 1 79.3730196029233 266.844878042743 H 39.3730196029233 A 2 2 0 0 1 37.3730196029233 264.844878042743 V 247.24487804274298 A 2 2 0 0 1 39.3730196029233 245.24487804274298 Z" class="transition-label-bg"/>
-      <text x="59.3730196029233" y="256.044878042743" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">error</text>
+      <text x="59.3730196029233" y="256.044878042743" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">error</text>
     </g>
     <g class="transition">
-      <path d="M 127.95 288.00 C 142.64 275.67, 157.32 263.33, 164.67 238.83 C 172.01 214.33, 172.01 177.67, 162.43 152.43 C 133.68 113.40, 114.51 99.60, 114.51 99.60" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 127.95 288.00 C 142.64 275.67, 157.32 263.33, 164.67 238.83 C 172.01 214.33, 172.01 177.67, 162.43 152.43 C 133.68 113.40, 114.51 99.60, 114.51 99.60" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
       <path d="M 152.01284402658064 178.54282176278022 H 192.01284402658064 A 2 2 0 0 1 194.01284402658064 180.54282176278022 V 198.14282176278022 A 2 2 0 0 1 192.01284402658064 200.14282176278022 H 152.01284402658064 A 2 2 0 0 1 150.01284402658064 198.14282176278022 V 180.54282176278022 A 2 2 0 0 1 152.01284402658064 178.54282176278022 Z" class="transition-label-bg"/>
-      <text x="172.01284402658064" y="189.34282176278023" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">reset</text>
+      <text x="172.01284402658064" y="189.34282176278023" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">reset</text>
     </g>
     <g class="transition">
-      <path d="M 106.51 324.00 C 106.51 333.00, 106.51 342.00, 106.51 351.00 C 106.51 360.00, 106.51 369.00, 106.51 378.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
+      <path d="M 106.51 324.00 C 106.51 333.00, 106.51 342.00, 106.51 351.00 C 106.51 360.00, 106.51 369.00, 106.51 378.00" class="transition-path" stroke-width="0.7" marker-end="url(#arrow)" fill="none"/>
     </g>
   </g>
 </svg>

--- a/docs/images/state_complex.svg
+++ b/docs/images/state_complex.svg
@@ -118,7 +118,7 @@
   </style>
   <defs>
     <marker id="arrow" viewBox="0 0 20 14" refX="19" refY="7" markerWidth="20" markerHeight="14" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke-width="1" fill="#333333" stroke="#333333"/>
+      <path d="M 19,7 L9,13 L14,7 L9,1 Z" stroke="#333333" stroke-width="1" fill="#333333"/>
     </marker>
   </defs>
   <g class="root">
@@ -138,7 +138,7 @@
       <rect x="41.51484375000001" y="68" width="164.39999999999998" height="293" rx="5" ry="5" class="state-composite-outer"/>
       <rect x="42.51484375000001" y="89" width="162.39999999999998" height="268" rx="0" ry="0" class="state-composite-inner"/>
       <path d="M 41.51484375000001 89 L 205.91484375 89" class="state-composite-divider"/>
-      <text x="123.71484375" y="84" class="state-composite-label" text-anchor="middle" font-size="14">Idle</text>
+      <text x="123.71484375" y="84" class="state-composite-label" font-size="14" text-anchor="middle">Idle</text>
     </g>
     <g class="composite-state" id="composite-Processing">
       <rect x="31.369140625" y="633" width="168.25" height="540" rx="5" ry="5" class="state-composite-outer"/>
@@ -153,11 +153,11 @@
       <text x="115.494140625" y="874" class="state-composite-label" font-size="14" text-anchor="middle">Executing</text>
     </g>
     <g class="state-node" id="state-Active">
-      <path d="M 100.9296875 313 H 146.5 A 5 5 0 0 1 151.5 318 V 344 A 5 5 0 0 1 146.5 349 H 100.9296875 A 5 5 0 0 1 95.9296875 344 V 318 A 5 5 0 0 1 100.9296875 313 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
+      <path d="M 100.9296875 313 H 146.5 A 5 5 0 0 1 151.5 318 V 344 A 5 5 0 0 1 146.5 349 H 100.9296875 A 5 5 0 0 1 95.9296875 344 V 318 A 5 5 0 0 1 100.9296875 313 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
       <text x="123.71484375" y="336" class="state-label" font-size="16" text-anchor="middle">Active</text>
     </g>
     <g class="state-node" id="state-Done">
-      <path d="M 95.369140625 1113 H 135.619140625 A 5 5 0 0 1 140.619140625 1118 V 1144 A 5 5 0 0 1 135.619140625 1149 H 95.369140625 A 5 5 0 0 1 90.369140625 1144 V 1118 A 5 5 0 0 1 95.369140625 1113 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <path d="M 95.369140625 1113 H 135.619140625 A 5 5 0 0 1 140.619140625 1118 V 1144 A 5 5 0 0 1 135.619140625 1149 H 95.369140625 A 5 5 0 0 1 90.369140625 1144 V 1118 A 5 5 0 0 1 95.369140625 1113 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
       <text x="115.494140625" y="1136" class="state-label" font-size="16" text-anchor="middle">Done</text>
     </g>
     <g class="state-node" id="state-Executing_start">
@@ -167,26 +167,26 @@
       <circle cx="123.71484375" cy="112" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Init">
-      <path d="M 102.994140625 993 H 127.994140625 A 5 5 0 0 1 132.994140625 998 V 1024 A 5 5 0 0 1 127.994140625 1029 H 102.994140625 A 5 5 0 0 1 97.994140625 1024 V 998 A 5 5 0 0 1 102.994140625 993 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
-      <text x="115.494140625" y="1016" class="state-label" font-size="16" text-anchor="middle">Init</text>
+      <path d="M 102.994140625 993 H 127.994140625 A 5 5 0 0 1 132.994140625 998 V 1024 A 5 5 0 0 1 127.994140625 1029 H 102.994140625 A 5 5 0 0 1 97.994140625 1024 V 998 A 5 5 0 0 1 102.994140625 993 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <text x="115.494140625" y="1016" class="state-label" text-anchor="middle" font-size="16">Init</text>
     </g>
     <g class="state-node" id="state-Processing_start">
       <circle cx="115.494140625" cy="677" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Ready">
-      <path d="M 99.58984375 188 H 147.83984375 A 5 5 0 0 1 152.83984375 193 V 219 A 5 5 0 0 1 147.83984375 224 H 99.58984375 A 5 5 0 0 1 94.58984375 219 V 193 A 5 5 0 0 1 99.58984375 188 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
-      <text x="123.71484375" y="211" class="state-label" text-anchor="middle" font-size="16">Ready</text>
+      <path d="M 99.58984375 188 H 147.83984375 A 5 5 0 0 1 152.83984375 193 V 219 A 5 5 0 0 1 147.83984375 224 H 99.58984375 A 5 5 0 0 1 94.58984375 219 V 193 A 5 5 0 0 1 99.58984375 188 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
+      <text x="123.71484375" y="211" class="state-label" font-size="16" text-anchor="middle">Ready</text>
     </g>
     <g class="state-node" id="state-ResourceAlloc">
-      <path d="M 137.2734375 479 H 242.4296875 A 5 5 0 0 1 247.4296875 484 V 510 A 5 5 0 0 1 242.4296875 515 H 137.2734375 A 5 5 0 0 1 132.2734375 510 V 484 A 5 5 0 0 1 137.2734375 479 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="189.8515625" y="502" class="state-label" font-size="16" text-anchor="middle">ResourceAlloc</text>
+      <path d="M 137.2734375 479 H 242.4296875 A 5 5 0 0 1 247.4296875 484 V 510 A 5 5 0 0 1 242.4296875 515 H 137.2734375 A 5 5 0 0 1 132.2734375 510 V 484 A 5 5 0 0 1 137.2734375 479 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
+      <text x="189.8515625" y="502" class="state-label" text-anchor="middle" font-size="16">ResourceAlloc</text>
     </g>
     <g class="state-node" id="state-Validating">
-      <path d="M 79.357421875 753 H 151.630859375 A 5 5 0 0 1 156.630859375 758 V 784 A 5 5 0 0 1 151.630859375 789 H 79.357421875 A 5 5 0 0 1 74.357421875 784 V 758 A 5 5 0 0 1 79.357421875 753 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <path d="M 79.357421875 753 H 151.630859375 A 5 5 0 0 1 156.630859375 758 V 784 A 5 5 0 0 1 151.630859375 789 H 79.357421875 A 5 5 0 0 1 74.357421875 784 V 758 A 5 5 0 0 1 79.357421875 753 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
       <text x="115.494140625" y="776" class="state-label" text-anchor="middle" font-size="16">Validating</text>
     </g>
     <g class="state-node" id="state-Validation">
-      <path d="M 5 479 H 77.2734375 A 5 5 0 0 1 82.2734375 484 V 510 A 5 5 0 0 1 77.2734375 515 H 5 A 5 5 0 0 1 0 510 V 484 A 5 5 0 0 1 5 479 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <path d="M 5 479 H 77.2734375 A 5 5 0 0 1 82.2734375 484 V 510 A 5 5 0 0 1 77.2734375 515 H 5 A 5 5 0 0 1 0 510 V 484 A 5 5 0 0 1 5 479 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
       <text x="41.13671875" y="502" class="state-label" font-size="16" text-anchor="middle">Validation</text>
     </g>
     <g class="state-node" id="state-fork_state">
@@ -202,42 +202,42 @@
       <path d="M 123.71 14.00 C 123.71 23.00, 123.71 32.00, 123.71 41.00 C 123.71 50.00, 123.71 59.00, 123.71 68.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 119.00 C 123.71 130.50, 123.71 142.00, 123.71 153.50 C 123.71 165.00, 123.71 176.50, 123.71 188.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
+      <path d="M 123.71 119.00 C 123.71 130.50, 123.71 142.00, 123.71 153.50 C 123.71 165.00, 123.71 176.50, 123.71 188.00" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 224.00 C 123.71 238.83, 123.71 253.67, 123.71 268.50 C 123.71 283.33, 123.71 298.17, 123.71 313.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
+      <path d="M 123.71 224.00 C 123.71 238.83, 123.71 253.67, 123.71 268.50 C 123.71 283.33, 123.71 298.17, 123.71 313.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
       <path d="M 87.71484375 257.7 H 159.71484375 A 2 2 0 0 1 161.71484375 259.7 V 277.3 A 2 2 0 0 1 159.71484375 279.3 H 87.71484375 A 2 2 0 0 1 85.71484375 277.3 V 259.7 A 2 2 0 0 1 87.71484375 257.7 Z" class="transition-label-bg"/>
-      <text x="123.71484375" y="268.5" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Start Job</text>
+      <text x="123.71484375" y="268.5" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Start Job</text>
     </g>
     <g class="transition">
-      <path d="M 115.49 361.00 C 115.49 370.00, 115.49 379.00, 115.49 388.00 C 115.49 397.00, 115.49 406.00, 115.49 415.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
+      <path d="M 115.49 361.00 C 115.49 370.00, 115.49 379.00, 115.49 388.00 C 115.49 397.00, 115.49 406.00, 115.49 415.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
       <path d="M 103.88 425.00 C 82.96 434.00, 62.05 443.00, 51.59 452.00 C 41.14 461.00, 41.14 470.00, 41.14 479.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
     </g>
     <g class="transition">
-      <path d="M 127.11 425.00 C 148.03 434.00, 168.94 443.00, 179.40 452.00 C 189.85 461.00, 189.85 470.00, 189.85 479.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="0.7"/>
+      <path d="M 127.11 425.00 C 148.03 434.00, 168.94 443.00, 179.40 452.00 C 189.85 461.00, 189.85 470.00, 189.85 479.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 41.14 515.00 C 41.14 524.00, 41.14 533.00, 51.59 542.00 C 62.05 551.00, 82.96 560.00, 103.88 569.00" class="transition-path" marker-end="url(#arrow)" stroke-width="0.7" fill="none"/>
+      <path d="M 41.14 515.00 C 41.14 524.00, 41.14 533.00, 51.59 542.00 C 62.05 551.00, 82.96 560.00, 103.88 569.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
     </g>
     <g class="transition">
-      <path d="M 189.85 515.00 C 189.85 524.00, 189.85 533.00, 179.40 542.00 C 168.94 551.00, 148.03 560.00, 127.11 569.00" class="transition-path" marker-end="url(#arrow)" stroke-width="0.7" fill="none"/>
+      <path d="M 189.85 515.00 C 189.85 524.00, 189.85 533.00, 179.40 542.00 C 168.94 551.00, 148.03 560.00, 127.11 569.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="0.7"/>
     </g>
     <g class="transition">
-      <path d="M 115.49 579.00 C 115.49 588.00, 115.49 597.00, 115.49 606.00 C 115.49 615.00, 115.49 624.00, 115.49 633.00" class="transition-path" marker-end="url(#arrow)" stroke-width="0.7" fill="none"/>
+      <path d="M 115.49 579.00 C 115.49 588.00, 115.49 597.00, 115.49 606.00 C 115.49 615.00, 115.49 624.00, 115.49 633.00" class="transition-path" stroke-width="0.7" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 684.00 C 123.71 695.50, 123.71 707.00, 123.71 718.50 C 123.71 730.00, 123.71 741.50, 123.71 753.00" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
+      <path d="M 123.71 684.00 C 123.71 695.50, 123.71 707.00, 123.71 718.50 C 123.71 730.00, 123.71 741.50, 123.71 753.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 789.00 C 123.71 800.50, 123.71 812.00, 122.34 823.50 C 120.97 835.00, 118.23 846.50, 115.49 858.00" class="transition-path" marker-end="url(#arrow)" stroke-width="0.7" fill="none"/>
+      <path d="M 123.71 789.00 C 123.71 800.50, 123.71 812.00, 122.34 823.50 C 120.97 835.00, 118.23 846.50, 115.49 858.00" class="transition-path" stroke-width="0.7" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 909.00 C 123.71 923.00, 123.71 937.00, 123.71 951.00 C 123.71 965.00, 123.71 979.00, 123.71 993.00" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
+      <path d="M 123.71 909.00 C 123.71 923.00, 123.71 937.00, 123.71 951.00 C 123.71 965.00, 123.71 979.00, 123.71 993.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
     </g>
     <g class="transition">
-      <path d="M 123.71 1029.00 C 123.71 1043.00, 123.71 1057.00, 123.71 1071.00 C 123.71 1085.00, 123.71 1099.00, 123.71 1113.00" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
+      <path d="M 123.71 1029.00 C 123.71 1043.00, 123.71 1057.00, 123.71 1071.00 C 123.71 1085.00, 123.71 1099.00, 123.71 1113.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="0.7"/>
     </g>
   </g>
 </svg>

--- a/docs/images/state_complex2.svg
+++ b/docs/images/state_complex2.svg
@@ -118,7 +118,7 @@
   </style>
   <defs>
     <marker id="arrow" viewBox="0 0 20 14" refX="19" refY="7" markerWidth="20" markerHeight="14" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 19,7 L9,13 L14,7 L9,1 Z" fill="#333333" stroke-width="1" stroke="#333333"/>
+      <path d="M 19,7 L9,13 L14,7 L9,1 Z" fill="#333333" stroke="#333333" stroke-width="1"/>
     </marker>
   </defs>
   <g class="root">
@@ -144,13 +144,13 @@
       <rect x="21.99999999999997" y="313" width="613.891015625" height="1465" rx="5" ry="5" class="state-composite-outer"/>
       <rect x="22.99999999999997" y="334" width="611.891015625" height="1440" rx="0" ry="0" class="state-composite-inner-alt"/>
       <path d="M 21.99999999999997 334 L 635.891015625 334" class="state-composite-divider"/>
-      <text x="328.94550781249995" y="329" class="state-composite-label" font-size="14" text-anchor="middle">Processing</text>
+      <text x="328.94550781249995" y="329" class="state-composite-label" text-anchor="middle" font-size="14">Processing</text>
     </g>
     <g class="composite-state" id="composite-Paused">
       <rect x="367.64374999999995" y="1413" width="198.9296875" height="353" rx="5" ry="5" class="state-composite-outer"/>
       <rect x="368.64374999999995" y="1434" width="196.9296875" height="328" rx="0" ry="0" class="state-composite-inner-alt"/>
       <path d="M 367.64374999999995 1434 L 566.5734375 1434" class="state-composite-divider"/>
-      <text x="467.10859374999995" y="1429" class="state-composite-label" font-size="14" text-anchor="middle">Paused</text>
+      <text x="467.10859374999995" y="1429" class="state-composite-label" text-anchor="middle" font-size="14">Paused</text>
     </g>
     <g class="composite-state" id="composite-Running">
       <rect x="191.221875" y="728" width="156.265625" height="581" rx="5" ry="5" class="state-composite-outer"/>
@@ -163,26 +163,26 @@
       <text x="328.9455078125" y="1887" class="state-label" text-anchor="middle" font-size="16">Cancelled</text>
     </g>
     <g class="state-node" id="state-Completed">
-      <path d="M 96.31757812500001 1571.5 H 175.692578125 A 5 5 0 0 1 180.692578125 1576.5 V 1602.5 A 5 5 0 0 1 175.692578125 1607.5 H 96.31757812500001 A 5 5 0 0 1 91.31757812500001 1602.5 V 1576.5 A 5 5 0 0 1 96.31757812500001 1571.5 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
-      <text x="136.005078125" y="1594.5" class="state-label" font-size="16" text-anchor="middle">Completed</text>
+      <path d="M 96.31757812500001 1571.5 H 175.692578125 A 5 5 0 0 1 180.692578125 1576.5 V 1602.5 A 5 5 0 0 1 175.692578125 1607.5 H 96.31757812500001 A 5 5 0 0 1 91.31757812500001 1602.5 V 1576.5 A 5 5 0 0 1 96.31757812500001 1571.5 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <text x="136.005078125" y="1594.5" class="state-label" text-anchor="middle" font-size="16">Completed</text>
     </g>
     <g class="state-node" id="state-Executing">
       <path d="M 233.221875 1013 H 305.4875 A 5 5 0 0 1 310.4875 1018 V 1044 A 5 5 0 0 1 305.4875 1049 H 233.221875 A 5 5 0 0 1 228.221875 1044 V 1018 A 5 5 0 0 1 233.221875 1013 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="269.3546875" y="1036" class="state-label" text-anchor="middle" font-size="16">Executing</text>
+      <text x="269.3546875" y="1036" class="state-label" font-size="16" text-anchor="middle">Executing</text>
     </g>
     <g class="state-node" id="state-Failed">
-      <path d="M 246.565625 1571.5 H 292.14375 A 5 5 0 0 1 297.14375 1576.5 V 1602.5 A 5 5 0 0 1 292.14375 1607.5 H 246.565625 A 5 5 0 0 1 241.565625 1602.5 V 1576.5 A 5 5 0 0 1 246.565625 1571.5 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
-      <text x="269.3546875" y="1594.5" class="state-label" text-anchor="middle" font-size="16">Failed</text>
+      <path d="M 246.565625 1571.5 H 292.14375 A 5 5 0 0 1 297.14375 1576.5 V 1602.5 A 5 5 0 0 1 292.14375 1607.5 H 246.565625 A 5 5 0 0 1 241.565625 1602.5 V 1576.5 A 5 5 0 0 1 246.565625 1571.5 Z" class="state-box" stroke-width="1" stroke="#9370DB" fill="#ECECFF"/>
+      <text x="269.3546875" y="1594.5" class="state-label" font-size="16" text-anchor="middle">Failed</text>
     </g>
     <g class="state-node" id="state-Finalizing">
-      <path d="M 234.56171875 1148 H 304.14765625 A 5 5 0 0 1 309.14765625 1153 V 1179 A 5 5 0 0 1 304.14765625 1184 H 234.56171875 A 5 5 0 0 1 229.56171875 1179 V 1153 A 5 5 0 0 1 234.56171875 1148 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
-      <text x="269.3546875" y="1171" class="state-label" font-size="16" text-anchor="middle">Finalizing</text>
+      <path d="M 234.56171875 1148 H 304.14765625 A 5 5 0 0 1 309.14765625 1153 V 1179 A 5 5 0 0 1 304.14765625 1184 H 234.56171875 A 5 5 0 0 1 229.56171875 1179 V 1153 A 5 5 0 0 1 234.56171875 1148 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <text x="269.3546875" y="1171" class="state-label" text-anchor="middle" font-size="16">Finalizing</text>
     </g>
     <g class="state-node" id="state-Idle_start">
       <circle cx="328.9455078125" cy="112" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Initializing">
-      <path d="M 233.22578125 878 H 305.48359375 A 5 5 0 0 1 310.48359375 883 V 909 A 5 5 0 0 1 305.48359375 914 H 233.22578125 A 5 5 0 0 1 228.22578125 909 V 883 A 5 5 0 0 1 233.22578125 878 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <path d="M 233.22578125 878 H 305.48359375 A 5 5 0 0 1 310.48359375 883 V 909 A 5 5 0 0 1 305.48359375 914 H 233.22578125 A 5 5 0 0 1 228.22578125 909 V 883 A 5 5 0 0 1 233.22578125 878 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
       <text x="269.3546875" y="901" class="state-label" text-anchor="middle" font-size="16">Initializing</text>
     </g>
     <g class="state-node" id="state-Paused_start">
@@ -192,49 +192,49 @@
       <circle cx="358.8546875" cy="357" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Queued">
-      <path d="M 239.8859375 588 H 298.8234375 A 5 5 0 0 1 303.8234375 593 V 619 A 5 5 0 0 1 298.8234375 624 H 239.8859375 A 5 5 0 0 1 234.8859375 619 V 593 A 5 5 0 0 1 239.8859375 588 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
-      <text x="269.3546875" y="611" class="state-label" font-size="16" text-anchor="middle">Queued</text>
+      <path d="M 239.8859375 588 H 298.8234375 A 5 5 0 0 1 303.8234375 593 V 619 A 5 5 0 0 1 298.8234375 624 H 239.8859375 A 5 5 0 0 1 234.8859375 619 V 593 A 5 5 0 0 1 239.8859375 588 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
+      <text x="269.3546875" y="611" class="state-label" text-anchor="middle" font-size="16">Queued</text>
     </g>
     <g class="state-node" id="state-Ready">
-      <path d="M 304.8205078125 188 H 353.0705078125 A 5 5 0 0 1 358.0705078125 193 V 219 A 5 5 0 0 1 353.0705078125 224 H 304.8205078125 A 5 5 0 0 1 299.8205078125 219 V 193 A 5 5 0 0 1 304.8205078125 188 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
+      <path d="M 304.8205078125 188 H 353.0705078125 A 5 5 0 0 1 358.0705078125 193 V 219 A 5 5 0 0 1 353.0705078125 224 H 304.8205078125 A 5 5 0 0 1 299.8205078125 219 V 193 A 5 5 0 0 1 304.8205078125 188 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
       <text x="328.9455078125" y="211" class="state-label" text-anchor="middle" font-size="16">Ready</text>
     </g>
     <g class="state-node" id="state-Running_end">
-      <path d="M 262.3546875 1290 A 7 7 0 1 0 276.3546875 1290 A 7 7 0 1 0 262.3546875 1290 Z" class="state-end-outer" fill="none" stroke-width="2" stroke="#9370DB"/>
-      <path d="M 266.83468750000003 1290 A 2.52 2.52 0 1 0 271.8746875 1290 A 2.52 2.52 0 1 0 266.83468750000003 1290 Z" class="state-end-inner" stroke="#9370DB" fill="#9370DB" stroke-width="2"/>
+      <path d="M 262.3546875 1290 A 7 7 0 1 0 276.3546875 1290 A 7 7 0 1 0 262.3546875 1290 Z" class="state-end-outer" stroke-width="2" fill="none" stroke="#9370DB"/>
+      <path d="M 266.83468750000003 1290 A 2.52 2.52 0 1 0 271.8746875 1290 A 2.52 2.52 0 1 0 266.83468750000003 1290 Z" class="state-end-inner" stroke="#9370DB" stroke-width="2" fill="#9370DB"/>
     </g>
     <g class="state-node" id="state-Running_start">
       <circle cx="269.3546875" cy="772" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="state-node" id="state-Timeout">
-      <path d="M 437.21015625 1718 H 497.00703125 A 5 5 0 0 1 502.00703125 1723 V 1749 A 5 5 0 0 1 497.00703125 1754 H 437.21015625 A 5 5 0 0 1 432.21015625 1749 V 1723 A 5 5 0 0 1 437.21015625 1718 Z" class="state-box" fill="#ECECFF" stroke-width="1" stroke="#9370DB"/>
-      <text x="467.10859375" y="1741" class="state-label" text-anchor="middle" font-size="16">Timeout</text>
+      <path d="M 437.21015625 1718 H 497.00703125 A 5 5 0 0 1 502.00703125 1723 V 1749 A 5 5 0 0 1 497.00703125 1754 H 437.21015625 A 5 5 0 0 1 432.21015625 1749 V 1723 A 5 5 0 0 1 437.21015625 1718 Z" class="state-box" stroke="#9370DB" stroke-width="1" fill="#ECECFF"/>
+      <text x="467.10859375" y="1741" class="state-label" font-size="16" text-anchor="middle">Timeout</text>
     </g>
     <g class="state-node" id="state-Validating">
-      <path d="M 322.71796875 448 H 394.99140625 A 5 5 0 0 1 399.99140625 453 V 479 A 5 5 0 0 1 394.99140625 484 H 322.71796875 A 5 5 0 0 1 317.71796875 479 V 453 A 5 5 0 0 1 322.71796875 448 Z" class="state-box" stroke-width="1" fill="#ECECFF" stroke="#9370DB"/>
-      <text x="358.8546875" y="471" class="state-label" text-anchor="middle" font-size="16">Validating</text>
+      <path d="M 322.71796875 448 H 394.99140625 A 5 5 0 0 1 399.99140625 453 V 479 A 5 5 0 0 1 394.99140625 484 H 322.71796875 A 5 5 0 0 1 317.71796875 479 V 453 A 5 5 0 0 1 322.71796875 448 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <text x="358.8546875" y="471" class="state-label" font-size="16" text-anchor="middle">Validating</text>
     </g>
     <g class="state-node" id="state-WaitingResume">
-      <path d="M 409.64375 1563 H 524.5734375 A 5 5 0 0 1 529.5734375 1568 V 1594 A 5 5 0 0 1 524.5734375 1599 H 409.64375 A 5 5 0 0 1 404.64375 1594 V 1568 A 5 5 0 0 1 409.64375 1563 Z" class="state-box" stroke="#9370DB" fill="#ECECFF" stroke-width="1"/>
+      <path d="M 409.64375 1563 H 524.5734375 A 5 5 0 0 1 529.5734375 1568 V 1594 A 5 5 0 0 1 524.5734375 1599 H 409.64375 A 5 5 0 0 1 404.64375 1594 V 1568 A 5 5 0 0 1 409.64375 1563 Z" class="state-box" fill="#ECECFF" stroke="#9370DB" stroke-width="1"/>
       <text x="467.10859375" y="1586" class="state-label" text-anchor="middle" font-size="16">WaitingResume</text>
     </g>
     <g class="state-node" id="state-root_end">
-      <path d="M 331.9455078125 1961 A 7 7 0 1 0 345.9455078125 1961 A 7 7 0 1 0 331.9455078125 1961 Z" class="state-end-outer" fill="none" stroke-width="2" stroke="#9370DB"/>
-      <path d="M 336.42550781250003 1961 A 2.52 2.52 0 1 0 341.4655078125 1961 A 2.52 2.52 0 1 0 336.42550781250003 1961 Z" class="state-end-inner" fill="#9370DB" stroke="#9370DB" stroke-width="2"/>
+      <path d="M 331.9455078125 1961 A 7 7 0 1 0 345.9455078125 1961 A 7 7 0 1 0 331.9455078125 1961 Z" class="state-end-outer" stroke-width="2" stroke="#9370DB" fill="none"/>
+      <path d="M 336.42550781250003 1961 A 2.52 2.52 0 1 0 341.4655078125 1961 A 2.52 2.52 0 1 0 336.42550781250003 1961 Z" class="state-end-inner" fill="#9370DB" stroke-width="2" stroke="#9370DB"/>
     </g>
     <g class="state-node" id="state-root_start">
       <circle cx="328.9455078125" cy="7" r="7" class="state-start" fill="#333333"/>
     </g>
     <g class="transition">
-      <path d="M 328.95 14.00 C 328.95 23.00, 328.95 32.00, 328.95 41.00 C 328.95 50.00, 328.95 59.00, 328.95 68.00" class="transition-path" marker-end="url(#arrow)" stroke-width="0.7" fill="none"/>
+      <path d="M 328.95 14.00 C 328.95 23.00, 328.95 32.00, 328.95 41.00 C 328.95 50.00, 328.95 59.00, 328.95 68.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 328.95 119.00 C 328.95 130.50, 328.95 142.00, 328.95 153.50 C 328.95 165.00, 328.95 176.50, 328.95 188.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 328.95 119.00 C 328.95 130.50, 328.95 142.00, 328.95 153.50 C 328.95 165.00, 328.95 176.50, 328.95 188.00" class="transition-path" stroke-width="0.7" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 328.95 224.00 C 328.95 238.83, 328.95 253.67, 328.95 268.50 C 328.95 283.33, 328.95 298.17, 328.95 313.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
+      <path d="M 328.95 224.00 C 328.95 238.83, 328.95 253.67, 328.95 268.50 C 328.95 283.33, 328.95 298.17, 328.95 313.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="0.7"/>
       <path d="M 292.9455078125 257.7 H 364.9455078125 A 2 2 0 0 1 366.9455078125 259.7 V 277.3 A 2 2 0 0 1 364.9455078125 279.3 H 292.9455078125 A 2 2 0 0 1 290.9455078125 277.3 V 259.7 A 2 2 0 0 1 292.9455078125 257.7 Z" class="transition-label-bg"/>
-      <text x="328.9455078125" y="268.5" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Start Job</text>
+      <text x="328.9455078125" y="268.5" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Start Job</text>
     </g>
     <g class="transition">
       <path d="M 311.54 364.00 C 311.54 378.00, 311.54 392.00, 311.54 406.00 C 311.54 420.00, 311.54 434.00, 311.54 448.00" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
@@ -242,86 +242,86 @@
     <g class="transition">
       <path d="M 288.52 484.00 C 266.36 501.33, 244.20 518.67, 233.12 536.00 C 222.04 553.33, 222.04 570.67, 222.04 588.00" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
       <path d="M 214.80000872939442 515.2178440803619 H 254.80000872939445 A 2 2 0 0 1 256.80000872939445 517.2178440803619 V 534.817844080362 A 2 2 0 0 1 254.80000872939445 536.817844080362 H 214.80000872939442 A 2 2 0 0 1 212.80000872939442 534.817844080362 V 517.2178440803619 A 2 2 0 0 1 214.80000872939442 515.2178440803619 Z" class="transition-label-bg"/>
-      <text x="234.80000872939442" y="526.0178440803619" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Valid</text>
+      <text x="234.80000872939442" y="526.0178440803619" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Valid</text>
     </g>
     <g class="transition">
       <path d="M 352.67 476.79 C 427.88 496.53, 503.09 516.26, 540.69 663.63 C 578.29 811.00, 578.29 1086.00, 523.55 1258.61 C 359.31 1501.45, 249.83 1571.68, 249.83 1571.68" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="0.7"/>
       <path d="M 550.291015625 1016.183255098065 H 606.291015625 A 2 2 0 0 1 608.291015625 1018.183255098065 V 1035.783255098065 A 2 2 0 0 1 606.291015625 1037.783255098065 H 550.291015625 A 2 2 0 0 1 548.291015625 1035.783255098065 V 1018.183255098065 A 2 2 0 0 1 550.291015625 1016.183255098065 Z" class="transition-label-bg"/>
-      <text x="578.291015625" y="1026.983255098065" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Invalid</text>
+      <text x="578.291015625" y="1026.983255098065" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Invalid</text>
     </g>
     <g class="transition">
-      <path d="M 222.04 624.00 C 222.04 641.33, 222.04 658.67, 229.92 676.00 C 237.81 693.33, 253.58 710.67, 269.35 728.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="0.7"/>
+      <path d="M 222.04 624.00 C 222.04 641.33, 222.04 658.67, 229.92 676.00 C 237.81 693.33, 253.58 710.67, 269.35 728.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
       <path d="M 158.037109375 665.2 H 286.037109375 A 2 2 0 0 1 288.037109375 667.2 V 684.8000000000001 A 2 2 0 0 1 286.037109375 686.8000000000001 H 158.037109375 A 2 2 0 0 1 156.037109375 684.8000000000001 V 667.2 A 2 2 0 0 1 158.037109375 665.2 Z" class="transition-label-bg"/>
-      <text x="222.037109375" y="676" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Worker Available</text>
+      <text x="222.037109375" y="676" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Worker Available</text>
     </g>
     <g class="transition">
-      <path d="M 269.35 1309.00 C 209.13 1326.33, 148.91 1343.67, 118.80 1387.42 C 88.69 1431.17, 88.69 1501.33, 88.69 1571.50" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
+      <path d="M 269.35 1309.00 C 209.13 1326.33, 148.91 1343.67, 118.80 1387.42 C 88.69 1431.17, 88.69 1501.33, 88.69 1571.50" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="0.7"/>
       <path d="M 60.6875 1379.3545930143512 H 116.6875 A 2 2 0 0 1 118.6875 1381.3545930143512 V 1398.954593014351 A 2 2 0 0 1 116.6875 1400.954593014351 H 60.6875 A 2 2 0 0 1 58.6875 1398.954593014351 V 1381.3545930143512 A 2 2 0 0 1 60.6875 1379.3545930143512 Z" class="transition-label-bg"/>
-      <text x="88.6875" y="1390.1545930143511" class="transition-label" dominant-baseline="central" text-anchor="middle" font-size="16">Success</text>
+      <text x="88.6875" y="1390.1545930143511" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Success</text>
     </g>
     <g class="transition">
-      <path d="M 269.35 1309.00 C 249.96 1326.33, 230.56 1343.67, 222.53 1387.42 C 214.50 1431.17, 217.84 1501.33, 221.18 1571.50" class="transition-path" stroke-width="0.7" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 269.35 1309.00 C 249.96 1326.33, 230.56 1343.67, 222.53 1387.42 C 214.50 1431.17, 217.84 1501.33, 221.18 1571.50" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
       <path d="M 194.9359059128112 1429.4663022366817 H 234.9359059128112 A 2 2 0 0 1 236.9359059128112 1431.4663022366817 V 1449.0663022366816 A 2 2 0 0 1 234.9359059128112 1451.0663022366816 H 194.9359059128112 A 2 2 0 0 1 192.9359059128112 1449.0663022366816 V 1431.4663022366817 A 2 2 0 0 1 194.9359059128112 1429.4663022366817 Z" class="transition-label-bg"/>
-      <text x="214.9359059128112" y="1440.2663022366817" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Error</text>
+      <text x="214.9359059128112" y="1440.2663022366817" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Error</text>
     </g>
     <g class="transition">
-      <path d="M 269.35 1309.00 C 299.17 1326.33, 328.98 1343.67, 361.94 1361.00 C 394.90 1378.33, 431.00 1395.67, 467.11 1413.00" class="transition-path" stroke-width="0.7" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 269.35 1309.00 C 299.17 1326.33, 328.98 1343.67, 361.94 1361.00 C 394.90 1378.33, 431.00 1395.67, 467.11 1413.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
       <path d="M 287.45930450193873 1301.7837518560939 H 391.45930450193873 A 2 2 0 0 1 393.45930450193873 1303.7837518560939 V 1321.3837518560938 A 2 2 0 0 1 391.45930450193873 1323.3837518560938 H 287.45930450193873 A 2 2 0 0 1 285.45930450193873 1321.3837518560938 V 1303.7837518560939 A 2 2 0 0 1 287.45930450193873 1301.7837518560939 Z" class="transition-label-bg"/>
-      <text x="339.45930450193873" y="1312.5837518560938" class="transition-label" font-size="16" dominant-baseline="central" text-anchor="middle">Pause Request</text>
+      <text x="339.45930450193873" y="1312.5837518560938" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Pause Request</text>
     </g>
     <g class="transition">
       <path d="M 269.35 779.00 C 269.35 795.50, 269.35 812.00, 269.35 828.50 C 269.35 845.00, 269.35 861.50, 269.35 878.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 269.35 914.00 C 269.35 930.50, 269.35 947.00, 269.35 963.50 C 269.35 980.00, 269.35 996.50, 269.35 1013.00" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
+      <path d="M 269.35 914.00 C 269.35 930.50, 269.35 947.00, 269.35 963.50 C 269.35 980.00, 269.35 996.50, 269.35 1013.00" class="transition-path" marker-end="url(#arrow)" stroke-width="0.7" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 269.35 1049.00 C 269.35 1065.50, 269.35 1082.00, 269.35 1098.50 C 269.35 1115.00, 269.35 1131.50, 269.35 1148.00" class="transition-path" marker-end="url(#arrow)" stroke-width="0.7" fill="none"/>
+      <path d="M 269.35 1049.00 C 269.35 1065.50, 269.35 1082.00, 269.35 1098.50 C 269.35 1115.00, 269.35 1131.50, 269.35 1148.00" class="transition-path" marker-end="url(#arrow)" fill="none" stroke-width="0.7"/>
     </g>
     <g class="transition">
       <path d="M 269.35 1184.00 C 269.35 1200.50, 269.35 1217.00, 269.35 1233.50 C 269.35 1250.00, 269.35 1266.50, 269.35 1283.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
     </g>
     <g class="transition">
-      <path d="M 467.11 1464.00 C 467.11 1480.50, 467.11 1497.00, 467.11 1513.50 C 467.11 1530.00, 467.11 1546.50, 467.11 1563.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
+      <path d="M 467.11 1464.00 C 467.11 1480.50, 467.11 1497.00, 467.11 1513.50 C 467.11 1530.00, 467.11 1546.50, 467.11 1563.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 467.11 1599.00 C 467.11 1618.83, 467.11 1638.67, 467.11 1658.50 C 467.11 1678.33, 467.11 1698.17, 467.11 1718.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
+      <path d="M 467.11 1599.00 C 467.11 1618.83, 467.11 1638.67, 467.11 1658.50 C 467.11 1678.33, 467.11 1698.17, 467.11 1718.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
       <path d="M 443.10859375 1647.7 H 491.10859375 A 2 2 0 0 1 493.10859375 1649.7 V 1667.3 A 2 2 0 0 1 491.10859375 1669.3 H 443.10859375 A 2 2 0 0 1 441.10859375 1667.3 V 1649.7 A 2 2 0 0 1 443.10859375 1647.7 Z" class="transition-label-bg"/>
-      <text x="467.10859375" y="1658.5" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">1 hour</text>
+      <text x="467.10859375" y="1658.5" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">1 hour</text>
     </g>
     <g class="transition">
       <path d="M 467.11 1766.00 C 471.67 1631.00, 476.23 1496.00, 443.27 1323.00 C 410.31 1150.00, 339.83 939.00, 269.35 728.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
       <path d="M 382.7020709830306 1252.132056185627 H 430.7020709830306 A 2 2 0 0 1 432.7020709830306 1254.132056185627 V 1271.732056185627 A 2 2 0 0 1 430.7020709830306 1273.732056185627 H 382.7020709830306 A 2 2 0 0 1 380.7020709830306 1271.732056185627 V 1254.132056185627 A 2 2 0 0 1 382.7020709830306 1252.132056185627 Z" class="transition-label-bg"/>
-      <text x="406.7020709830306" y="1262.932056185627" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Resume</text>
+      <text x="406.7020709830306" y="1262.932056185627" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Resume</text>
     </g>
     <g class="transition">
-      <path d="M 467.11 1766.00 C 444.08 1782.33, 421.05 1798.67, 398.03 1815.00 C 375.00 1831.33, 351.97 1847.67, 328.95 1864.00" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
+      <path d="M 467.11 1766.00 C 444.08 1782.33, 421.05 1798.67, 398.03 1815.00 C 375.00 1831.33, 351.97 1847.67, 328.95 1864.00" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
       <path d="M 342.02705078125 1804.2 H 454.02705078125 A 2 2 0 0 1 456.02705078125 1806.2 V 1823.8 A 2 2 0 0 1 454.02705078125 1825.8 H 342.02705078125 A 2 2 0 0 1 340.02705078125 1823.8 V 1806.2 A 2 2 0 0 1 342.02705078125 1804.2 Z" class="transition-label-bg"/>
-      <text x="398.02705078125" y="1815" class="transition-label" text-anchor="middle" font-size="16" dominant-baseline="central">Cancel Request</text>
+      <text x="398.02705078125" y="1815" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Cancel Request</text>
     </g>
     <g class="transition">
-      <path d="M 467.11 1754.00 C 444.08 1772.33, 421.05 1790.67, 398.03 1809.00 C 375.00 1827.33, 351.97 1845.67, 328.95 1864.00" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
+      <path d="M 467.11 1754.00 C 444.08 1772.33, 421.05 1790.67, 398.03 1809.00 C 375.00 1827.33, 351.97 1845.67, 328.95 1864.00" class="transition-path" stroke-width="0.7" marker-end="url(#arrow)" fill="none"/>
     </g>
     <g class="transition">
-      <path d="M 136.01 1571.50 C 168.16 1607.92, 200.32 1644.33, 232.48 1680.75 C 264.63 1717.17, 296.79 1753.58, 328.95 1790.00" class="transition-path" fill="none" stroke-width="0.7" marker-end="url(#arrow)"/>
+      <path d="M 136.01 1571.50 C 168.16 1607.92, 200.32 1644.33, 232.48 1680.75 C 264.63 1717.17, 296.79 1753.58, 328.95 1790.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
       <path d="M 212.47529296875 1669.95 H 252.47529296875 A 2 2 0 0 1 254.47529296875 1671.95 V 1689.55 A 2 2 0 0 1 252.47529296875 1691.55 H 212.47529296875 A 2 2 0 0 1 210.47529296875 1689.55 V 1671.95 A 2 2 0 0 1 212.47529296875 1669.95 Z" class="transition-label-bg"/>
-      <text x="232.47529296875" y="1680.75" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Reset</text>
+      <text x="232.47529296875" y="1680.75" class="transition-label" dominant-baseline="central" font-size="16" text-anchor="middle">Reset</text>
     </g>
     <g class="transition">
-      <path d="M 269.35 1571.50 C 279.29 1607.92, 289.22 1644.33, 299.15 1680.75 C 309.08 1717.17, 319.01 1753.58, 328.95 1790.00" class="transition-path" stroke-width="0.7" marker-end="url(#arrow)" fill="none"/>
+      <path d="M 269.35 1571.50 C 279.29 1607.92, 289.22 1644.33, 299.15 1680.75 C 309.08 1717.17, 319.01 1753.58, 328.95 1790.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
       <path d="M 279.15009765625 1669.95 H 319.15009765625 A 2 2 0 0 1 321.15009765625 1671.95 V 1689.55 A 2 2 0 0 1 319.15009765625 1691.55 H 279.15009765625 A 2 2 0 0 1 277.15009765625 1689.55 V 1671.95 A 2 2 0 0 1 279.15009765625 1669.95 Z" class="transition-label-bg"/>
       <text x="299.15009765625" y="1680.75" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Retry</text>
     </g>
     <g class="transition">
       <path d="M 340.89 1864.00 C 349.08 1851.67, 357.26 1839.33, 355.27 1540.00 C 353.28 1240.67, 341.11 654.33, 328.95 68.00" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
       <path d="M 343.40627465628313 1819.2728170847104 H 383.40627465628313 A 2 2 0 0 1 385.40627465628313 1821.2728170847104 V 1838.8728170847103 A 2 2 0 0 1 383.40627465628313 1840.8728170847103 H 343.40627465628313 A 2 2 0 0 1 341.40627465628313 1838.8728170847103 V 1821.2728170847104 A 2 2 0 0 1 343.40627465628313 1819.2728170847104 Z" class="transition-label-bg"/>
-      <text x="363.40627465628313" y="1830.0728170847103" class="transition-label" text-anchor="middle" dominant-baseline="central" font-size="16">Reset</text>
+      <text x="363.40627465628313" y="1830.0728170847103" class="transition-label" font-size="16" text-anchor="middle" dominant-baseline="central">Reset</text>
     </g>
     <g class="transition">
-      <path d="M 136.01 1607.50 C 169.27 1665.39, 202.53 1723.29, 235.80 1781.18 C 269.06 1839.07, 302.33 1896.96, 335.59 1954.86" class="transition-path" fill="none" marker-end="url(#arrow)" stroke-width="0.7"/>
+      <path d="M 136.01 1607.50 C 169.27 1665.39, 202.53 1723.29, 235.80 1781.18 C 269.06 1839.07, 302.33 1896.96, 335.59 1954.86" class="transition-path" stroke-width="0.7" fill="none" marker-end="url(#arrow)"/>
     </g>
     <g class="transition">
-      <path d="M 328.95 1900.00 C 328.95 1909.00, 328.95 1918.00, 330.28 1927.05 C 331.62 1936.09, 334.30 1945.19, 336.97 1954.28" class="transition-path" marker-end="url(#arrow)" stroke-width="0.7" fill="none"/>
+      <path d="M 328.95 1900.00 C 328.95 1909.00, 328.95 1918.00, 330.28 1927.05 C 331.62 1936.09, 334.30 1945.19, 336.97 1954.28" class="transition-path" stroke-width="0.7" marker-end="url(#arrow)" fill="none"/>
     </g>
   </g>
 </svg>

--- a/src/bin/selkie.rs
+++ b/src/bin/selkie.rs
@@ -1203,6 +1203,13 @@ fn run_eval_ascii(args: EvalArgs) -> Result<(), Box<dyn std::error::Error>> {
         if let selkie::diagrams::Diagram::Er(ref db) = parsed {
             issues.extend(ascii_checks::check_er_ascii_structure(&ascii_struct, db));
         }
+        // State-specific checks: verify fork/join bars and composite containers
+        if matches!(parsed, selkie::diagrams::Diagram::State(_)) {
+            issues.extend(ascii_checks::check_ascii_state_structure(
+                &ascii_struct,
+                &graph,
+            ));
+        }
         let similarity = ascii_checks::calculate_ascii_similarity(&ascii_struct, &graph);
         total_similarity += similarity;
 

--- a/src/eval/ascii_checks.rs
+++ b/src/eval/ascii_checks.rs
@@ -635,6 +635,117 @@ pub fn calculate_ascii_similarity(ascii: &AsciiStructure, graph: &LayoutGraph) -
     }
 }
 
+// --- State diagram-specific ASCII evaluation ---
+
+/// Check ASCII state diagram output for fork/join bars and composite containers.
+///
+/// Verifies that:
+/// - Fork/Join nodes (HorizontalBar shape) render as solid `█` bar characters
+/// - Composite states (nodes with children) render as bordered containers
+///   with rounded-corner box-drawing characters (`╭╮╰╯│─`)
+pub fn check_ascii_state_structure(ascii: &AsciiStructure, graph: &LayoutGraph) -> Vec<Issue> {
+    let mut issues = Vec::new();
+
+    check_ascii_fork_join_bars(ascii, graph, &mut issues);
+    check_ascii_composite_containers(ascii, graph, &mut issues);
+
+    issues
+}
+
+/// Check that fork/join nodes render as solid `█` bar characters.
+fn check_ascii_fork_join_bars(
+    ascii: &AsciiStructure,
+    graph: &LayoutGraph,
+    issues: &mut Vec<Issue>,
+) {
+    let bar_nodes: Vec<&str> = graph
+        .nodes
+        .iter()
+        .filter(|n| !n.is_dummy && n.shape == NodeShape::HorizontalBar)
+        .map(|n| n.id.as_str())
+        .collect();
+
+    if bar_nodes.is_empty() {
+        return;
+    }
+
+    let bar_count = ascii.raw_output.chars().filter(|&c| c == '█').count();
+    if bar_count == 0 {
+        issues.push(
+            Issue::warning(
+                "state_ascii_missing_fork_join_bar",
+                format!(
+                    "State diagram has {} fork/join node(s) but no █ bar characters in ASCII output",
+                    bar_nodes.len()
+                ),
+            )
+            .with_values(
+                format!("≥{} █ characters", bar_nodes.len()),
+                "0".to_string(),
+            ),
+        );
+    }
+}
+
+/// Check that composite states render as bordered containers with rounded corners.
+fn check_ascii_composite_containers(
+    ascii: &AsciiStructure,
+    graph: &LayoutGraph,
+    issues: &mut Vec<Issue>,
+) {
+    // Find container nodes: nodes that have children or are referenced as parent_id
+    let parent_ids: std::collections::HashSet<&str> = graph
+        .nodes
+        .iter()
+        .filter_map(|n| n.parent_id.as_deref())
+        .collect();
+
+    let container_labels: Vec<&str> = graph
+        .nodes
+        .iter()
+        .filter(|n| {
+            !n.is_dummy
+                && (parent_ids.contains(n.id.as_str()) || !n.children.is_empty())
+                && n.shape != NodeShape::HorizontalBar
+        })
+        .filter_map(|n| n.label.as_deref())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    if container_labels.is_empty() {
+        return;
+    }
+
+    // Check for rounded-corner container border characters
+    let has_container_borders = ascii.raw_output.contains('╭')
+        && ascii.raw_output.contains('╮')
+        && ascii.raw_output.contains('╰')
+        && ascii.raw_output.contains('╯');
+
+    if !has_container_borders {
+        issues.push(Issue::warning(
+            "state_ascii_missing_composite_borders",
+            format!(
+                "State diagram has {} composite state(s) but no rounded container borders (╭╮╰╯) in ASCII output",
+                container_labels.len()
+            ),
+        ));
+    }
+
+    // Check that composite state labels appear in the output
+    for label in &container_labels {
+        if !ascii.raw_output.contains(label) {
+            issues.push(Issue::warning(
+                "state_ascii_missing_composite_label",
+                format!(
+                    "Composite state label '{}' not found in ASCII output",
+                    label
+                ),
+            ));
+        }
+    }
+}
+
 // --- Pie chart-specific ASCII evaluation ---
 
 /// Check ASCII pie chart output against the PieDb ground truth.
@@ -1941,5 +2052,179 @@ mod tests {
                 score_plain
             );
         }
+    }
+
+    // --- State diagram ASCII check tests ---
+
+    #[test]
+    fn state_check_detects_missing_fork_join_bars() {
+        use crate::layout::LayoutNode;
+
+        // Graph with a HorizontalBar (fork) node
+        let mut fork_node = LayoutNode::new("fork1", 70.0, 10.0);
+        fork_node.shape = NodeShape::HorizontalBar;
+        fork_node.x = Some(50.0);
+        fork_node.y = Some(50.0);
+
+        let mut graph = LayoutGraph::new("test");
+        graph.nodes.push(fork_node);
+
+        // ASCII output without any █ characters
+        let output = "┌───────┐\n│ Start │\n└───────┘";
+        let ascii = parse_ascii(output);
+
+        let issues = check_ascii_state_structure(&ascii, &graph);
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.check == "state_ascii_missing_fork_join_bar"),
+            "Should detect missing fork/join bar, got: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn state_check_passes_with_fork_join_bars() {
+        use crate::layout::LayoutNode;
+
+        let mut fork_node = LayoutNode::new("fork1", 70.0, 10.0);
+        fork_node.shape = NodeShape::HorizontalBar;
+        fork_node.x = Some(50.0);
+        fork_node.y = Some(50.0);
+
+        let mut graph = LayoutGraph::new("test");
+        graph.nodes.push(fork_node);
+
+        // ASCII output with █ bar characters
+        let output = "████████████";
+        let ascii = parse_ascii(output);
+
+        let issues = check_ascii_state_structure(&ascii, &graph);
+        let bar_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.check == "state_ascii_missing_fork_join_bar")
+            .collect();
+        assert!(
+            bar_issues.is_empty(),
+            "Should not flag when bars are present, got: {:?}",
+            bar_issues
+        );
+    }
+
+    #[test]
+    fn state_check_detects_missing_composite_borders() {
+        use crate::layout::LayoutNode;
+
+        let mut parent = LayoutNode::new("composite1", 200.0, 150.0);
+        parent.label = Some("MyState".to_string());
+        parent.x = Some(100.0);
+        parent.y = Some(75.0);
+
+        let mut child = LayoutNode::new("child1", 80.0, 32.0);
+        child.label = Some("Inner".to_string());
+        child.parent_id = Some("composite1".to_string());
+        child.x = Some(100.0);
+        child.y = Some(75.0);
+
+        let mut graph = LayoutGraph::new("test");
+        graph.nodes.push(parent);
+        graph.nodes.push(child);
+
+        // ASCII output without container border characters
+        let output = "┌───────┐\n│ Inner │\n└───────┘";
+        let ascii = parse_ascii(output);
+
+        let issues = check_ascii_state_structure(&ascii, &graph);
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.check == "state_ascii_missing_composite_borders"),
+            "Should detect missing composite borders, got: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn state_check_passes_with_composite_borders() {
+        use crate::layout::LayoutNode;
+
+        let mut parent = LayoutNode::new("composite1", 200.0, 150.0);
+        parent.label = Some("MyState".to_string());
+        parent.x = Some(100.0);
+        parent.y = Some(75.0);
+
+        let mut child = LayoutNode::new("child1", 80.0, 32.0);
+        child.label = Some("Inner".to_string());
+        child.parent_id = Some("composite1".to_string());
+        child.x = Some(100.0);
+        child.y = Some(75.0);
+
+        let mut graph = LayoutGraph::new("test");
+        graph.nodes.push(parent);
+        graph.nodes.push(child);
+
+        // ASCII output with rounded container borders and label
+        let output =
+            "╭─MyState──────╮\n│ ┌───────┐   │\n│ │ Inner │   │\n│ └───────┘   │\n╰──────────────╯";
+        let ascii = parse_ascii(output);
+
+        let issues = check_ascii_state_structure(&ascii, &graph);
+        let border_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.check == "state_ascii_missing_composite_borders")
+            .collect();
+        assert!(
+            border_issues.is_empty(),
+            "Should not flag when borders are present, got: {:?}",
+            border_issues
+        );
+    }
+
+    #[test]
+    fn state_check_detects_missing_composite_label() {
+        use crate::layout::LayoutNode;
+
+        let mut parent = LayoutNode::new("composite1", 200.0, 150.0);
+        parent.label = Some("MyState".to_string());
+        parent.x = Some(100.0);
+        parent.y = Some(75.0);
+
+        let mut child = LayoutNode::new("child1", 80.0, 32.0);
+        child.label = Some("Inner".to_string());
+        child.parent_id = Some("composite1".to_string());
+        child.x = Some(100.0);
+        child.y = Some(75.0);
+
+        let mut graph = LayoutGraph::new("test");
+        graph.nodes.push(parent);
+        graph.nodes.push(child);
+
+        // ASCII output with borders but missing the composite label "MyState"
+        let output =
+            "╭──────────────╮\n│ ┌───────┐   │\n│ │ Inner │   │\n│ └───────┘   │\n╰──────────────╯";
+        let ascii = parse_ascii(output);
+
+        let issues = check_ascii_state_structure(&ascii, &graph);
+        assert!(
+            issues
+                .iter()
+                .any(|i| i.check == "state_ascii_missing_composite_label"),
+            "Should detect missing composite label 'MyState', got: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn state_check_no_issues_without_special_nodes() {
+        // Graph with only regular rectangle nodes — no fork/join or composites
+        let graph = make_two_node_graph();
+        let ascii = parse_ascii(&simple_two_node_ascii());
+
+        let issues = check_ascii_state_structure(&ascii, &graph);
+        assert!(
+            issues.is_empty(),
+            "Should have no state-specific issues for simple graph, got: {:?}",
+            issues
+        );
     }
 }

--- a/src/layout/size.rs
+++ b/src/layout/size.rs
@@ -130,6 +130,10 @@ impl SizeEstimator for CharacterSizeEstimator {
                 // Odd shape (flag-like) - asymmetric
                 (base_width * 1.1, base_height)
             }
+            NodeShape::HorizontalBar => {
+                // Fork/join bar: fixed dimensions, ignore text
+                (70.0, 10.0)
+            }
             NodeShape::Rectangle | NodeShape::RoundedRect => {
                 // Standard rectangles - no adjustment needed
                 (base_width, base_height)
@@ -284,6 +288,7 @@ impl SizeEstimator for FontdueSizeEstimator {
             NodeShape::LeanRight | NodeShape::LeanLeft => (base_width * 1.2, base_height),
             NodeShape::Subroutine => (base_width + 20.0, base_height),
             NodeShape::Odd => (base_width * 1.1, base_height),
+            NodeShape::HorizontalBar => (70.0, 10.0),
             NodeShape::Rectangle | NodeShape::RoundedRect => (base_width, base_height),
         };
 

--- a/src/layout/types.rs
+++ b/src/layout/types.rs
@@ -136,6 +136,8 @@ pub enum NodeShape {
     LeanRight,
     LeanLeft,
     Odd,
+    /// Horizontal bar used for fork/join states
+    HorizontalBar,
 }
 
 /// A node in the layout graph

--- a/src/render/ascii/mod.rs
+++ b/src/render/ascii/mod.rs
@@ -346,22 +346,31 @@ fn render_ascii_impl(
         .map(|n| n.id.as_str())
         .collect();
 
-    // Render container nodes first (background layer — boundary box + label).
-    // Subgraphs get a dashed-style boundary (┏┓┗┛┃╌) to distinguish them
-    // from regular node boxes (┌┐└┘│─).
-    // Collect label positions so we can re-stamp them after regular nodes (pass 2).
+    // Render container nodes first (background layer — bordered box with title).
+    // Sort by area descending so largest containers render first (nested ones on top).
     struct SubgraphLabel {
         row: usize,
-        col_start: usize,
+        label_col_start: usize,
         label: String,
+        box_col_start: usize,
+        box_w: usize,
     }
     let mut subgraph_labels: Vec<SubgraphLabel> = Vec::new();
 
-    for node in &graph.nodes {
-        if node.is_dummy || !container_ids.contains(node.id.as_str()) {
-            continue;
-        }
+    let mut container_nodes: Vec<&crate::layout::LayoutNode> = graph
+        .nodes
+        .iter()
+        .filter(|n| !n.is_dummy && container_ids.contains(n.id.as_str()))
+        .collect();
+    container_nodes.sort_by(|a, b| {
+        let area_a = a.width * a.height;
+        let area_b = b.width * b.height;
+        area_b
+            .partial_cmp(&area_a)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
 
+    for node in container_nodes {
         let (nx, ny) = match (node.x, node.y) {
             (Some(x), Some(y)) => (x - offset_x, y - offset_y),
             _ => continue,
@@ -369,110 +378,98 @@ fn render_ascii_impl(
 
         let label = label_fn(node);
 
-        // Compute bounding box in cell coordinates (node x,y is top-left)
-        let col_left = scale.to_col(nx);
-        let col_right = scale.to_col(nx + node.width);
-        let row_top = scale.to_row(ny);
-        let row_bottom = scale.to_row(ny + node.height);
+        // Calculate the bounding box from the node's layout dimensions
+        let label_chars = label.chars().count();
+        let box_w = scale.to_cell_width(node.width).max(label_chars + 4);
+        let box_h = scale.to_cell_height(node.height).max(3);
+        let col_center = scale.to_col(nx + node.width / 2.0);
+        let row_center = scale.to_row(ny + node.height / 2.0);
+        let col_start = col_center.saturating_sub(box_w / 2);
+        let row_start = row_center.saturating_sub(box_h / 2);
 
-        // Ensure minimum size
-        let col_right = col_right.max(col_left + label.chars().count() + 4);
-        let row_bottom = row_bottom.max(row_top + 2);
+        // Label goes right after "╭─" at the start of the top border
+        let label_col_start = col_start + 2;
 
-        // Draw boundary box using dashed-style characters
-        // Top border: ┏╌╌ label ╌╌┓
-        let label_char_count = label.chars().count();
-        let border_width = col_right.saturating_sub(col_left + 1);
-        let label_offset = border_width.saturating_sub(label_char_count + 2) / 2;
-        let label_start = col_left + 1 + label_offset;
-
-        if row_top < canvas_rows {
-            // Top-left corner
-            if col_left < canvas_cols {
-                canvas[row_top][col_left] = '┏';
+        // Draw top border: ╭─Label─────────╮
+        if row_start < canvas_rows {
+            if col_start < canvas_cols {
+                canvas[row_start][col_start] = '╭';
+                occupied[row_start][col_start] = true;
             }
-            // Top-right corner
-            if col_right < canvas_cols {
-                canvas[row_top][col_right] = '┓';
+            if col_start + 1 < canvas_cols {
+                canvas[row_start][col_start + 1] = '─';
+                occupied[row_start][col_start + 1] = true;
             }
-            // Top horizontal dashes
-            for cell in canvas[row_top]
-                .iter_mut()
-                .take(col_right.min(canvas_cols))
-                .skip(col_left + 1)
-            {
-                *cell = '╌';
-            }
-            // Overlay label centered in top border
-            // Space before label
-            if label_start > 0 && label_start < canvas_cols {
-                canvas[row_top][label_start] = ' ';
-            }
+            // Label text
             for (i, ch) in label.chars().enumerate() {
-                let c = label_start + 1 + i;
-                if c < canvas_cols {
-                    canvas[row_top][c] = ch;
+                let c = label_col_start + i;
+                if c >= canvas_cols {
+                    break;
                 }
+                canvas[row_start][c] = ch;
+                occupied[row_start][c] = true;
             }
-            // Space after label
-            let after_label = label_start + 1 + label_char_count;
-            if after_label < canvas_cols {
-                canvas[row_top][after_label] = ' ';
+            // Remaining border after label
+            let after_label = label_col_start + label_chars;
+            let right_col = col_start + box_w - 1;
+            for c in after_label..right_col {
+                if c >= canvas_cols {
+                    break;
+                }
+                canvas[row_start][c] = '─';
+                occupied[row_start][c] = true;
             }
-            // Mark top border row (label area) as occupied to protect from edges
-            for cell in occupied[row_top]
-                .iter_mut()
-                .take(col_right.min(canvas_cols.saturating_sub(1)) + 1)
-                .skip(col_left)
-            {
-                *cell = true;
-            }
-        }
-
-        // Bottom border: ┗╌╌╌╌╌╌╌╌╌┛
-        if row_bottom < canvas_rows {
-            if col_left < canvas_cols {
-                canvas[row_bottom][col_left] = '┗';
-            }
-            if col_right < canvas_cols {
-                canvas[row_bottom][col_right] = '┛';
-            }
-            for cell in canvas[row_bottom]
-                .iter_mut()
-                .take(col_right.min(canvas_cols))
-                .skip(col_left + 1)
-            {
-                *cell = '╌';
-            }
-            // Mark bottom border as occupied
-            for cell in occupied[row_bottom]
-                .iter_mut()
-                .take(col_right.min(canvas_cols.saturating_sub(1)) + 1)
-                .skip(col_left)
-            {
-                *cell = true;
+            if right_col < canvas_cols {
+                canvas[row_start][right_col] = '╮';
+                occupied[row_start][right_col] = true;
             }
         }
 
-        // Side borders: ┃ on left and right
-        // Not marked as occupied — regular nodes can overwrite them
-        for row in canvas
-            .iter_mut()
-            .take(row_bottom.min(canvas_rows))
-            .skip(row_top + 1)
-        {
-            if col_left < canvas_cols {
-                row[col_left] = '┃';
+        // Side borders
+        for r in 1..box_h.saturating_sub(1) {
+            let row = row_start + r;
+            if row >= canvas_rows {
+                break;
             }
-            if col_right < canvas_cols {
-                row[col_right] = '┃';
+            if col_start < canvas_cols {
+                canvas[row][col_start] = '│';
+                occupied[row][col_start] = true;
+            }
+            let right = col_start + box_w - 1;
+            if right < canvas_cols {
+                canvas[row][right] = '│';
+                occupied[row][right] = true;
+            }
+        }
+
+        // Bottom border: ╰─────────────────╯
+        let bot_row = row_start + box_h - 1;
+        if bot_row < canvas_rows {
+            if col_start < canvas_cols {
+                canvas[bot_row][col_start] = '╰';
+                occupied[bot_row][col_start] = true;
+            }
+            for i in 1..box_w.saturating_sub(1) {
+                let c = col_start + i;
+                if c >= canvas_cols {
+                    break;
+                }
+                canvas[bot_row][c] = '─';
+                occupied[bot_row][c] = true;
+            }
+            let br = col_start + box_w - 1;
+            if br < canvas_cols {
+                canvas[bot_row][br] = '╯';
+                occupied[bot_row][br] = true;
             }
         }
 
         subgraph_labels.push(SubgraphLabel {
-            row: row_top,
-            col_start: label_start + 1,
+            row: row_start,
+            label_col_start,
             label,
+            box_col_start: col_start,
+            box_w,
         });
     }
 
@@ -534,12 +531,7 @@ fn render_ascii_impl(
                 if canvas_col >= canvas_cols {
                     break;
                 }
-                // Overwrite if non-space, OR if existing cell is a subgraph side
-                // border ┃ (so node boxes cleanly cover boundary lines).
-                // Do NOT clear horizontal border ╌ with spaces — those are the
-                // top/bottom borders of subgraph boundaries and should persist.
-                let existing = canvas[canvas_row][canvas_col];
-                if ch != ' ' || existing == '┃' {
+                if ch != ' ' {
                     canvas[canvas_row][canvas_col] = ch;
                 }
             }
@@ -589,16 +581,35 @@ fn render_ascii_impl(
             }
         }
     }
-    // Re-stamp subgraph labels (they were rendered before regular nodes)
+    // Re-stamp subgraph labels on top of everything (container borders + labels)
     for sg in &subgraph_labels {
         if sg.row >= canvas_rows {
             continue;
         }
+        let right_col = sg.box_col_start + sg.box_w.saturating_sub(1);
+        // Re-stamp the full top border: ╭─Label─────╮
+        if sg.box_col_start < canvas_cols {
+            canvas[sg.row][sg.box_col_start] = '╭';
+        }
+        if sg.box_col_start + 1 < canvas_cols {
+            canvas[sg.row][sg.box_col_start + 1] = '─';
+        }
+        let label_chars = sg.label.chars().count();
         for (i, ch) in sg.label.chars().enumerate() {
-            let c = sg.col_start + i;
+            let c = sg.label_col_start + i;
             if c < canvas_cols {
                 canvas[sg.row][c] = ch;
             }
+        }
+        let after_label = sg.label_col_start + label_chars;
+        let border_end = right_col.min(canvas_cols);
+        if after_label < border_end {
+            for col in &mut canvas[sg.row][after_label..border_end] {
+                *col = '─';
+            }
+        }
+        if right_col < canvas_cols {
+            canvas[sg.row][right_col] = '╮';
         }
     }
 
@@ -920,96 +931,6 @@ mod tests {
     }
 
     #[test]
-    fn subgraph_has_boundary_box() {
-        let (db, graph) = parse_and_layout(
-            "flowchart TD\n    subgraph sg[My Group]\n        A[NodeA]\n        B[NodeB]\n    end",
-        );
-        let output = render_flowchart_ascii(&db, &graph).unwrap();
-
-        // Subgraph must have box-drawing boundary characters
-        // The boundary uses dashed lines: ┏ ┓ ┗ ┛ ┃ ╌
-        assert!(
-            output.contains('┏') || output.contains('┌'),
-            "Subgraph boundary must have top-left corner\nOutput:\n{}",
-            output
-        );
-        assert!(
-            output.contains('┛') || output.contains('┘'),
-            "Subgraph boundary must have bottom-right corner\nOutput:\n{}",
-            output
-        );
-
-        // The label should still be visible
-        assert!(
-            output.contains("My Group"),
-            "Subgraph label must be visible\nOutput:\n{}",
-            output
-        );
-
-        // Child nodes must be inside the boundary
-        assert!(
-            output.contains("NodeA"),
-            "NodeA must be visible inside boundary\nOutput:\n{}",
-            output
-        );
-        assert!(
-            output.contains("NodeB"),
-            "NodeB must be visible inside boundary\nOutput:\n{}",
-            output
-        );
-    }
-
-    #[test]
-    fn complex_flowchart_has_subgraph_boundaries() {
-        let (db, graph) = parse_and_layout(
-            &std::fs::read_to_string("docs/sources/flowchart_complex.mmd").unwrap(),
-        );
-        let output = render_flowchart_ascii(&db, &graph).unwrap();
-
-        // All four subgraphs should have boundary boxes
-        for label in &[
-            "Frontend Layer",
-            "API Gateway",
-            "Microservices",
-            "Data Layer",
-        ] {
-            assert!(
-                output.contains(label),
-                "Subgraph label '{}' must be visible\nOutput:\n{}",
-                label,
-                output
-            );
-        }
-
-        // All Microservices nodes must be present
-        for label in &[
-            "User Service",
-            "Order Service",
-            "Payment Service",
-            "Notification Service",
-        ] {
-            assert!(
-                output.contains(label),
-                "Node '{}' must be visible\nOutput:\n{}",
-                label,
-                output
-            );
-        }
-
-        // Subgraph boundaries must exist (dashed box characters)
-        let boundary_chars = output
-            .chars()
-            .filter(|c| matches!(c, '┏' | '┓' | '┗' | '┛'))
-            .count();
-        assert!(
-            boundary_chars >= 8, // At least 4 subgraphs × 2 corners visible
-            "Expected at least 8 subgraph boundary corners, found {}\nOutput:\n{}",
-            boundary_chars,
-            output
-        );
-    }
-
-    #[test]
     fn diamond_does_not_corrupt_adjacent_nodes() {
         let (db, graph) = parse_and_layout(
             "flowchart TD\n    A[Start] --> B{Decision}\n    B --> C[Action 1]\n    B --> D[End]",
@@ -1294,6 +1215,71 @@ mod tests {
             "End node should render as ◉ (bullseye)\nOutput:\n{}",
             output
         );
+    }
+
+    #[test]
+    fn state_complex_fork_renders_as_bar() {
+        let input = std::fs::read_to_string("docs/sources/state_complex.mmd").unwrap();
+        let graph = parse_and_layout_generic(&input);
+        let output = render_graph_ascii(&graph).unwrap();
+        // Fork/join should render as solid bars (█), not as labeled boxes
+        assert!(
+            output.contains('█'),
+            "Fork/join states should render as solid bars\nOutput:\n{}",
+            output
+        );
+        // Should NOT show the internal IDs as labels
+        assert!(
+            !output.contains("fork_state"),
+            "Fork state ID should not appear as label\nOutput:\n{}",
+            output
+        );
+        assert!(
+            !output.contains("join_state"),
+            "Join state ID should not appear as label\nOutput:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn state_complex_has_all_expected_labels() {
+        let input = std::fs::read_to_string("docs/sources/state_complex.mmd").unwrap();
+        let graph = parse_and_layout_generic(&input);
+        let output = render_graph_ascii(&graph).unwrap();
+        for label in &[
+            "Idle",
+            "Ready",
+            "Validation",
+            "ResourceAlloc",
+            "Processing",
+            "Validating",
+            "Executing",
+            "Init",
+            "Done",
+        ] {
+            assert!(
+                output.contains(label),
+                "State diagram should contain '{}'\nOutput:\n{}",
+                label,
+                output
+            );
+        }
+    }
+
+    #[test]
+    fn state_complex2_node_labels_in_boxes() {
+        let input = std::fs::read_to_string("docs/sources/state_complex2.mmd").unwrap();
+        let graph = parse_and_layout_generic(&input);
+        let output = render_graph_ascii(&graph).unwrap();
+        // Key nested states should appear
+        for label in &["Initializing", "Finalizing", "WaitingResume"] {
+            assert!(
+                output.contains(label),
+                "State diagram should contain nested state '{}'\nOutput:\n{}",
+                label,
+                output
+            );
+        }
     }
 
     #[test]

--- a/src/render/ascii/shapes.rs
+++ b/src/render/ascii/shapes.rs
@@ -40,6 +40,7 @@ pub fn render_shape(shape: &NodeShape, label: &str, cell_w: usize, cell_h: usize
         NodeShape::Diamond => render_diamond(label, w, h),
         NodeShape::Circle => render_circle(label, w, h, false),
         NodeShape::DoubleCircle => render_circle(label, w, h, true),
+        NodeShape::HorizontalBar => render_horizontal_bar(cell_w),
         _ => render_rect(label, w, h, false),
     }
 }
@@ -154,6 +155,20 @@ fn render_diamond(label: &str, _w: usize, _h: usize) -> RenderedShape {
         width: max_w,
         height: lines.len(),
         lines,
+    }
+}
+
+/// Render a horizontal bar for fork/join states.
+///
+/// Fork and join nodes in state diagrams are rendered as solid horizontal bars,
+/// matching the UML convention. Uses block characters for a filled appearance.
+fn render_horizontal_bar(cell_w: usize) -> RenderedShape {
+    let w = cell_w.max(8);
+    let bar = "█".repeat(w);
+    RenderedShape {
+        lines: vec![bar],
+        width: w,
+        height: 1,
     }
 }
 
@@ -423,6 +438,27 @@ mod tests {
         assert!(text.contains("«interface»"), "Should contain annotation");
         assert!(text.contains("Flyable"), "Should contain name");
         assert!(text.contains("+fly()"), "Should contain method");
+    }
+
+    #[test]
+    fn horizontal_bar_renders_solid() {
+        let shape = render_shape(&NodeShape::HorizontalBar, "", 10, 1);
+        assert_eq!(shape.height, 1, "Bar should be 1 row tall");
+        assert!(shape.width >= 8, "Bar should be at least 8 chars wide");
+        assert!(
+            shape.lines[0].chars().all(|c| c == '█'),
+            "Bar should be solid block characters, got: {:?}",
+            shape.lines[0]
+        );
+    }
+
+    #[test]
+    fn horizontal_bar_no_label() {
+        let shape = render_shape(&NodeShape::HorizontalBar, "fork_state", 10, 1);
+        assert!(
+            !shape.lines[0].contains("fork"),
+            "Bar should not contain label text"
+        );
     }
 
     #[test]

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -272,7 +272,7 @@ fn compute_level_layout(
         let (shape, label) = match state.state_type {
             StateType::Start => (NodeShape::Circle, None),
             StateType::End => (NodeShape::DoubleCircle, None),
-            StateType::Fork | StateType::Join => (NodeShape::Rectangle, None),
+            StateType::Fork | StateType::Join => (NodeShape::HorizontalBar, None),
             StateType::Choice => (NodeShape::Diamond, None),
             StateType::Divider => (NodeShape::Rectangle, None),
             StateType::Default => {
@@ -558,7 +558,7 @@ impl ToLayoutGraph for StateDb {
             let (shape, label) = match state.state_type {
                 StateType::Start => (NodeShape::Circle, None),
                 StateType::End => (NodeShape::DoubleCircle, None),
-                StateType::Fork | StateType::Join => (NodeShape::Rectangle, None),
+                StateType::Fork | StateType::Join => (NodeShape::HorizontalBar, None),
                 StateType::Choice => (NodeShape::Diamond, None),
                 StateType::Divider => (NodeShape::Rectangle, None),
                 StateType::Default => {


### PR DESCRIPTION
<!-- midtown: canal -->

## Summary
- Add `HorizontalBar` node shape for fork/join states, rendering them as solid █ bars instead of empty boxes
- Render composite/nested states as bordered containers (`╭─Label─╮ │...│ ╰─────╯`) instead of floating labels that overlap with child nodes
- Mark all container border cells as occupied to prevent edge routing from overwriting them
- Sort containers by area descending for proper z-ordering of nested states
- Fix eval `ascii_checks.rs` compilation errors (missing `Issue` struct fields, duplicate match patterns)

## Changes
- `src/layout/types.rs` — Add `HorizontalBar` variant to `NodeShape` enum
- `src/layout/size.rs` — Handle `HorizontalBar` sizing (70×10 fixed) in both estimators
- `src/render/state.rs` — Map `Fork`/`Join` state types to `HorizontalBar` shape
- `src/render/ascii/shapes.rs` — Add `render_horizontal_bar()` function + tests
- `src/render/ascii/mod.rs` — Rewrite container rendering as bordered boxes with label; expand `SubgraphLabel` struct; re-stamp borders after edge rendering; add 3 new tests
- `src/eval/ascii_checks.rs` — Fix compilation (missing fields, duplicate patterns)

## Test plan
- [x] 4 new state diagram ASCII tests pass (fork bar rendering, label presence for both complex diagrams, nested node presence)
- [x] Full test suite passes (1753+ lib tests, 0 failures)
- [x] `cargo fmt` clean
- [x] `cargo clippy --features all-formats -- -D warnings` clean