### PR TITLE
feat: expose render_ascii and render_text_ascii in public library API [Midtown #157]

### DIFF
--- a/tests/test_ascii_edge_case.rs
+++ b/tests/test_ascii_edge_case.rs
@@ -1,0 +1,35 @@
+#[test]
+fn show_edge_case_small_subgraph() {
+    use selkie::layout::{CharacterSizeEstimator, ToLayoutGraph};
+    use selkie::render::ascii::render_flowchart_ascii;
+
+    // Create a very small subgraph to test edge positioning
+    let input = "flowchart TD\n    subgraph sg[A]\n        X[X]\n    end";
+    let diagram = selkie::parse(input).unwrap();
+    let db = match diagram {
+        selkie::diagrams::Diagram::Flowchart(db) => db,
+        _ => panic!("Expected flowchart"),
+    };
+    let estimator = CharacterSizeEstimator::default();
+    let graph = db.to_layout_graph(&estimator).unwrap();
+    let graph = selkie::layout::layout(graph).unwrap();
+
+    let output = render_flowchart_ascii(&db, &graph).unwrap();
+    println!("\n=== SMALL SUBGRAPH ASCII ===\n{}\n=== END ===", output);
+
+    // Check for proper spacing
+    let lines: Vec<&str> = output.lines().collect();
+    if let Some(first_line) = lines.first() {
+        println!(
+            "First line chars: {:?}",
+            first_line.chars().collect::<Vec<_>>()
+        );
+        println!("First line: '{}'", first_line);
+        // The pattern should be: ┏ + dashes + space + label + space + dashes + ┓
+        assert!(
+            !first_line.starts_with("┏A"),
+            "Label should have leading space"
+        );
+    }
+    assert!(output.contains("A"), "Should contain label");
+}

--- a/tests/test_ascii_label.rs
+++ b/tests/test_ascii_label.rs
@@ -1,0 +1,20 @@
+#[test]
+fn show_subgraph_ascii() {
+    use selkie::layout::{CharacterSizeEstimator, ToLayoutGraph};
+    use selkie::render::ascii::render_flowchart_ascii;
+
+    let input =
+        "flowchart TD\n    subgraph sg[TestLabel]\n        A[NodeA]\n        B[NodeB]\n    end";
+    let diagram = selkie::parse(input).unwrap();
+    let db = match diagram {
+        selkie::diagrams::Diagram::Flowchart(db) => db,
+        _ => panic!("Expected flowchart"),
+    };
+    let estimator = CharacterSizeEstimator::default();
+    let graph = db.to_layout_graph(&estimator).unwrap();
+    let graph = selkie::layout::layout(graph).unwrap();
+
+    let output = render_flowchart_ascii(&db, &graph).unwrap();
+    println!("\n=== ASCII OUTPUT ===\n{}\n=== END ===", output);
+    assert!(output.contains("TestLabel"), "Should contain label");
+}


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary

- Moved `render_ascii()` dispatch function from `src/bin/selkie.rs` into the library at `src/render/mod.rs`
- Added `render_text_ascii(input: &str) -> Result<String>` convenience function that parses and renders in one step
- Exported both functions via `src/lib.rs` as part of the public API
- Updated CLI binary to call the library functions instead of maintaining a local copy
- Added integration tests for ASCII subgraph rendering

## Details

Previously, `render_ascii()` was a private function inside the CLI binary (`src/bin/selkie.rs`). Library consumers had no way to get ASCII output without reimplementing the diagram-type dispatch logic themselves. Now the API mirrors the existing SVG pattern:

| SVG | ASCII |
|-----|-------|
| `selkie::render(diagram)` | `selkie::render_ascii(diagram)` |
| `selkie::render_text(input)` | `selkie::render_text_ascii(input)` |

## Test plan

- [x] All existing tests pass (`cargo test --features all-formats`)
- [x] Doc-tests on both new public functions pass
- [x] New integration tests for subgraph ASCII rendering pass
- [x] `cargo clippy --features all-formats -- -D warnings` clean
- [x] `cargo fmt` clean