### PR TITLE
fix(er): use intersect-rect for edge routing [Midtown #159]

### DIFF
--- a/docs/images/er.svg
+++ b/docs/images/er.svg
@@ -187,7 +187,7 @@ marker path {
     <g class="relationship">
       <path d="M 107.10 187.00 C 107.10 203.67, 107.10 220.33, 107.10 237.00 C 107.10 253.67, 107.10 270.33, 107.10 287.00" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrMoreEnd)"/>
       <rect x="82.10000000000002" y="225" width="50" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="107.10000000000002" y="241" class="relationship-label" text-anchor="middle" font-size="14">places</text>
+      <text x="107.10000000000002" y="241" class="relationship-label" font-size="14" text-anchor="middle">places</text>
     </g>
     <g class="relationship">
       <path d="M 107.10 474.00 C 107.10 490.67, 107.10 507.33, 123.84 528.90 C 140.58 550.46, 174.07 576.92, 207.55 603.38" class="relationshipLine" marker-end="url(#er-oneOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
@@ -207,14 +207,14 @@ marker path {
       <line x1="15.600000000000009" y1="42.75" x2="198.60000000000002" y2="42.75" class="divider" stroke-width="1.3"/>
       <line x1="84.40000000000002" y1="42.75" x2="84.40000000000002" y2="187" class="divider" stroke-width="1.3"/>
       <line x1="161.00000000000003" y1="42.75" x2="161.00000000000003" y2="187" class="divider" stroke-width="1.3"/>
-      <text x="107.10000000000002" y="26.375" class="entity-name" text-anchor="middle" font-size="14">CUSTOMER</text>
+      <text x="107.10000000000002" y="26.375" class="entity-name" font-size="14" text-anchor="middle">CUSTOMER</text>
       <text x="27.60000000000001" y="68.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
       <text x="96.40000000000002" y="68.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">name</text>
       <text x="27.60000000000001" y="110.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="96.40000000000002" y="110.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">email</text>
-      <text x="173.00000000000003" y="110.875" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
-      <text x="27.60000000000001" y="153.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
-      <text x="96.40000000000002" y="153.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">address</text>
+      <text x="96.40000000000002" y="110.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">email</text>
+      <text x="173.00000000000003" y="110.875" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
+      <text x="27.60000000000001" y="153.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
+      <text x="96.40000000000002" y="153.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">address</text>
     </g>
     <g class="entity-node" id="entity-LINE-ITEM-2">
       <rect x="207.55" y="574" width="129.89999999999998" height="58.75" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -228,14 +228,14 @@ marker path {
       <line x1="0.000000000000014210854715202004" y1="329.75" x2="214.20000000000005" y2="329.75" class="divider" stroke-width="1.3"/>
       <line x1="68.80000000000003" y1="329.75" x2="68.80000000000003" y2="474" class="divider" stroke-width="1.3"/>
       <line x1="176.60000000000002" y1="329.75" x2="176.60000000000002" y2="474" class="divider" stroke-width="1.3"/>
-      <text x="107.10000000000002" y="313.375" class="entity-name" font-size="14" text-anchor="middle">ORDER</text>
-      <text x="12.000000000000014" y="355.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">int</text>
+      <text x="107.10000000000002" y="313.375" class="entity-name" text-anchor="middle" font-size="14">ORDER</text>
+      <text x="12.000000000000014" y="355.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">int</text>
       <text x="80.80000000000003" y="355.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">orderNumber</text>
       <text x="188.60000000000002" y="355.125" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
       <text x="12.000000000000014" y="397.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">date</text>
-      <text x="80.80000000000003" y="397.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">orderDate</text>
-      <text x="12.000000000000014" y="440.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="80.80000000000003" y="440.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">status</text>
+      <text x="80.80000000000003" y="397.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">orderDate</text>
+      <text x="12.000000000000014" y="440.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
+      <text x="80.80000000000003" y="440.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">status</text>
     </g>
     <g class="entity-node" id="entity-PRODUCT-3">
       <rect x="354.20000000000005" y="287" width="167.4" height="187" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -246,13 +246,13 @@ marker path {
       <line x1="423.00000000000006" y1="329.75" x2="423.00000000000006" y2="474" class="divider" stroke-width="1.3"/>
       <line x1="484.00000000000006" y1="329.75" x2="484.00000000000006" y2="474" class="divider" stroke-width="1.3"/>
       <text x="437.90000000000003" y="313.375" class="entity-name" text-anchor="middle" font-size="14">PRODUCT</text>
-      <text x="366.20000000000005" y="355.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">int</text>
+      <text x="366.20000000000005" y="355.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">int</text>
       <text x="435.00000000000006" y="355.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
       <text x="496.00000000000006" y="355.125" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
       <text x="366.20000000000005" y="397.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
       <text x="435.00000000000006" y="397.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">name</text>
-      <text x="366.20000000000005" y="440.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">float</text>
-      <text x="435.00000000000006" y="440.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">price</text>
+      <text x="366.20000000000005" y="440.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">float</text>
+      <text x="435.00000000000006" y="440.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">price</text>
     </g>
   </g>
 </svg>

--- a/docs/images/er_complex.svg
+++ b/docs/images/er_complex.svg
@@ -185,44 +185,44 @@ marker path {
 
     </g>
     <g class="relationship">
-      <path d="M 465.20 315.25 C 424.50 331.92, 383.80 348.58, 381.95 391.52 C 380.10 434.46, 417.10 503.67, 454.10 572.88" class="relationshipLine" marker-end="url(#er-zeroOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
-      <rect x="342.49691524954653" y="398.8843200782621" width="50" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="367.49691524954653" y="414.8843200782621" class="relationship-label" text-anchor="middle" font-size="14">places</text>
+      <path d="M 372.50 315.25 C 362.70 331.92, 352.90 348.58, 351.00 365.25 C 349.10 381.92, 355.09 398.58, 361.09 415.25" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrMoreEnd)"/>
+      <rect x="319.33359448512465" y="351.15233370209666" width="50" height="23" rx="0" ry="0" class="relationship-label-background"/>
+      <text x="344.33359448512465" y="367.15233370209666" class="relationship-label" font-size="14" text-anchor="middle">places</text>
     </g>
     <g class="relationship">
-      <path d="M 343.10 730.50 C 265.73 747.17, 188.37 763.83, 167.53 813.90 C 146.70 863.96, 182.40 947.42, 218.10 1030.88" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-oneOrMoreEnd)"/>
-      <rect x="85.86193020828127" y="784.5416038832719" width="64" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="117.86193020828127" y="800.5416038832719" class="relationship-label" text-anchor="middle" font-size="14">contains</text>
+      <path d="M 232.10 672.17 C 191.73 708.28, 151.37 744.39, 138.85 781.47 C 126.33 818.54, 141.67 856.58, 157.00 894.62" class="relationshipLine" marker-end="url(#er-oneOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
+      <rect x="93.69617221155804" y="755.3535426306561" width="64" height="23" rx="0" ry="0" class="relationship-label-background"/>
+      <text x="125.69617221155804" y="771.3535426306561" class="relationship-label" font-size="14" text-anchor="middle">contains</text>
     </g>
     <g class="relationship">
-      <path d="M 111.00 1167.12 C 111.00 1205.17, 111.00 1243.21, 111.00 1270.56 C 111.00 1297.92, 111.00 1314.58, 111.00 1331.25" class="relationshipLine" marker-end="url(#er-onlyOneEnd)" marker-start="url(#er-oneOrMoreStart)"/>
+      <path d="M 111.00 1167.12 C 111.00 1205.17, 111.00 1243.21, 111.00 1270.56 C 111.00 1297.92, 111.00 1314.58, 111.00 1331.25" class="relationshipLine" marker-start="url(#er-oneOrMoreStart)" marker-end="url(#er-onlyOneEnd)"/>
       <rect x="72" y="1237.1875" width="78" height="23" rx="0" ry="0" class="relationship-label-background"/>
       <text x="111" y="1253.1875" class="relationship-label" font-size="14" text-anchor="middle">references</text>
     </g>
     <g class="relationship">
-      <path d="M 111.00 1689.25 L 69.10 1861.38" class="relationshipLine" marker-end="url(#er-zeroOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
-      <rect x="59.16305827206496" y="1764.6655491294528" width="78" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="98.16305827206496" y="1780.6655491294528" class="relationship-label" font-size="14" text-anchor="middle">belongs_to</text>
+      <path d="M 111.00 1689.25 L 151.15 1789.25" class="relationshipLine" marker-end="url(#er-zeroOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
+      <rect x="76.42074083047767" y="1732.7559335415772" width="78" height="23" rx="0" ry="0" class="relationship-label-background"/>
+      <text x="115.42074083047767" y="1748.7559335415772" class="relationship-label" font-size="14" text-anchor="middle">belongs_to</text>
     </g>
     <g class="relationship">
       <path d="M 465.20 1625.12 C 465.20 1663.17, 465.20 1701.21, 436.18 1740.58 C 407.17 1779.96, 349.13 1820.67, 291.10 1861.38" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrMoreEnd)"/>
       <rect x="392.8652540233294" y="1755.543399496846" width="64" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="424.8652540233294" y="1771.543399496846" class="relationship-label" text-anchor="middle" font-size="14">contains</text>
+      <text x="424.8652540233294" y="1771.543399496846" class="relationship-label" font-size="14" text-anchor="middle">contains</text>
     </g>
     <g class="relationship">
-      <path d="M 465.20 315.25 C 596.03 331.92, 726.87 348.58, 792.28 426.12 C 857.70 503.67, 857.70 642.08, 792.28 719.62 C 596.03 813.83, 465.20 830.50, 465.20 830.50" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrMoreEnd)"/>
-      <rect x="843.2" y="560.875" width="29" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="857.7" y="576.875" class="relationship-label" font-size="14" text-anchor="middle">has</text>
+      <path d="M 572.30 214.28 C 667.43 264.60, 762.57 314.93, 810.13 409.30 C 857.70 503.67, 857.70 642.08, 810.13 741.63 C 667.43 901.87, 572.30 962.56, 572.30 962.56" class="relationshipLine" marker-end="url(#er-zeroOrMoreEnd)" marker-start="url(#er-onlyOneStart)"/>
+      <rect x="843.2" y="568.7010105890027" width="29" height="23" rx="0" ry="0" class="relationship-label-background"/>
+      <text x="857.7" y="584.7010105890027" class="relationship-label" font-size="14" text-anchor="middle">has</text>
     </g>
     <g class="relationship">
-      <path d="M 343.10 730.50 L 358.10 1030.88" class="relationshipLine" marker-end="url(#er-onlyOneEnd)" marker-start="url(#er-onlyOneStart)"/>
-      <rect x="325.55663052840094" y="867.7126317204154" width="64" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="357.55663052840094" y="883.7126317204154" class="relationship-label" font-size="14" text-anchor="middle">ships_to</text>
+      <path d="M 353.80 730.50 L 390.89 830.50" class="relationshipLine" marker-end="url(#er-onlyOneEnd)" marker-start="url(#er-onlyOneStart)"/>
+      <rect x="328.0430874098155" y="772.7194893425078" width="64" height="23" rx="0" ry="0" class="relationship-label-background"/>
+      <text x="360.0430874098155" y="788.7194893425078" class="relationship-label" text-anchor="middle" font-size="14">ships_to</text>
     </g>
     <g class="relationship">
-      <path d="M 454.10 572.88 C 542.47 642.08, 630.83 711.29, 693.02 761.35 C 755.20 811.42, 791.20 842.33, 827.20 873.25" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrOneEnd)"/>
-      <rect x="614.1889220168755" y="708.57690469164" width="57" height="23" rx="0" ry="0" class="relationship-label-background"/>
-      <text x="642.6889220168755" y="724.57690469164" class="relationship-label" text-anchor="middle" font-size="14">paid_by</text>
+      <path d="M 454.10 634.15 C 542.47 682.93, 630.83 731.72, 673.87 777.48 C 716.90 823.23, 714.60 865.97, 712.30 908.70" class="relationshipLine" marker-start="url(#er-onlyOneStart)" marker-end="url(#er-zeroOrOneEnd)"/>
+      <rect x="614.3481354970055" y="726.3501572256469" width="57" height="23" rx="0" ry="0" class="relationship-label-background"/>
+      <text x="642.8481354970055" y="742.3501572256469" class="relationship-label" text-anchor="middle" font-size="14">paid_by</text>
     </g>
     <g class="entity-node" id="entity-ADDRESS-6">
       <rect x="358.1" y="830.5" width="214.20000000000002" height="400.75" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -239,8 +239,8 @@ marker path {
       <line x1="534.7" y1="873.25" x2="534.7" y2="1231.25" class="divider" stroke-width="1.3"/>
       <text x="465.20000000000005" y="856.875" class="entity-name" font-size="14" text-anchor="middle">ADDRESS</text>
       <text x="370.1" y="898.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
-      <text x="438.90000000000003" y="898.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
-      <text x="546.7" y="898.625" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
+      <text x="438.90000000000003" y="898.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">id</text>
+      <text x="546.7" y="898.625" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
       <text x="370.1" y="941.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
       <text x="438.90000000000003" y="941.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">customer_id</text>
       <text x="546.7" y="941.375" class="entity-attr attribute-key" font-size="12" text-anchor="start">FK</text>
@@ -251,11 +251,11 @@ marker path {
       <text x="370.1" y="1069.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
       <text x="438.90000000000003" y="1069.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">city</text>
       <text x="370.1" y="1112.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="438.90000000000003" y="1112.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">state</text>
+      <text x="438.90000000000003" y="1112.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">state</text>
       <text x="370.1" y="1155.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
       <text x="438.90000000000003" y="1155.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">zip</text>
-      <text x="370.1" y="1197.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="438.90000000000003" y="1197.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">country</text>
+      <text x="370.1" y="1197.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
+      <text x="438.90000000000003" y="1197.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">country</text>
     </g>
     <g class="entity-node" id="entity-CATEGORY-5">
       <rect x="362" y="1395.375" width="206.4" height="229.75" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -267,16 +267,16 @@ marker path {
       <line x1="430.8" y1="1438.125" x2="430.8" y2="1625.125" class="divider" stroke-width="1.3"/>
       <line x1="530.8" y1="1438.125" x2="530.8" y2="1625.125" class="divider" stroke-width="1.3"/>
       <text x="465.2" y="1421.75" class="entity-name" text-anchor="middle" font-size="14">CATEGORY</text>
-      <text x="374" y="1463.5" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
+      <text x="374" y="1463.5" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
       <text x="442.8" y="1463.5" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
-      <text x="542.8" y="1463.5" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
+      <text x="542.8" y="1463.5" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
       <text x="374" y="1506.25" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
       <text x="442.8" y="1506.25" class="entity-attr attribute-name" text-anchor="start" font-size="12">name</text>
       <text x="542.8" y="1506.25" class="entity-attr attribute-key" font-size="12" text-anchor="start">UK</text>
       <text x="374" y="1549" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
-      <text x="442.8" y="1549" class="entity-attr attribute-name" font-size="12" text-anchor="start">parent_id</text>
-      <text x="542.8" y="1549" class="entity-attr attribute-key" text-anchor="start" font-size="12">FK</text>
-      <text x="374" y="1591.75" class="entity-attr attribute-type" text-anchor="start" font-size="12">int</text>
+      <text x="442.8" y="1549" class="entity-attr attribute-name" text-anchor="start" font-size="12">parent_id</text>
+      <text x="542.8" y="1549" class="entity-attr attribute-key" font-size="12" text-anchor="start">FK</text>
+      <text x="374" y="1591.75" class="entity-attr attribute-type" font-size="12" text-anchor="start">int</text>
       <text x="442.8" y="1591.75" class="entity-attr attribute-name" text-anchor="start" font-size="12">sort_order</text>
     </g>
     <g class="entity-node" id="entity-CUSTOMER-0">
@@ -291,19 +291,19 @@ marker path {
       <line x1="434.70000000000005" y1="42.75" x2="434.70000000000005" y2="315.25" class="divider" stroke-width="1.3"/>
       <line x1="534.7" y1="42.75" x2="534.7" y2="315.25" class="divider" stroke-width="1.3"/>
       <text x="465.20000000000005" y="26.375" class="entity-name" text-anchor="middle" font-size="14">CUSTOMER</text>
-      <text x="370.1" y="68.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
-      <text x="446.70000000000005" y="68.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
-      <text x="546.7" y="68.125" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
+      <text x="370.1" y="68.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
+      <text x="446.70000000000005" y="68.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">id</text>
+      <text x="546.7" y="68.125" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
       <text x="370.1" y="110.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="446.70000000000005" y="110.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">email</text>
-      <text x="546.7" y="110.875" class="entity-attr attribute-key" font-size="12" text-anchor="start">UK</text>
+      <text x="446.70000000000005" y="110.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">email</text>
+      <text x="546.7" y="110.875" class="entity-attr attribute-key" text-anchor="start" font-size="12">UK</text>
       <text x="370.1" y="153.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
       <text x="446.70000000000005" y="153.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">name</text>
       <text x="370.1" y="196.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
       <text x="446.70000000000005" y="196.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">phone</text>
-      <text x="370.1" y="239.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">date</text>
+      <text x="370.1" y="239.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">date</text>
       <text x="446.70000000000005" y="239.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">created_at</text>
-      <text x="370.1" y="281.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">boolean</text>
+      <text x="370.1" y="281.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">boolean</text>
       <text x="446.70000000000005" y="281.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">active</text>
     </g>
     <g class="entity-node" id="entity-ORDER-1">
@@ -318,8 +318,8 @@ marker path {
       <line x1="308.70000000000005" y1="458" x2="308.70000000000005" y2="730.5" class="divider" stroke-width="1.3"/>
       <line x1="416.50000000000006" y1="458" x2="416.50000000000006" y2="730.5" class="divider" stroke-width="1.3"/>
       <text x="343.1" y="441.625" class="entity-name" font-size="14" text-anchor="middle">ORDER</text>
-      <text x="244.10000000000002" y="483.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
-      <text x="320.70000000000005" y="483.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
+      <text x="244.10000000000002" y="483.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
+      <text x="320.70000000000005" y="483.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">id</text>
       <text x="428.50000000000006" y="483.375" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
       <text x="244.10000000000002" y="526.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
       <text x="320.70000000000005" y="526.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">customer_id</text>
@@ -327,11 +327,11 @@ marker path {
       <text x="244.10000000000002" y="568.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">decimal</text>
       <text x="320.70000000000005" y="568.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">total</text>
       <text x="244.10000000000002" y="611.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
-      <text x="320.70000000000005" y="611.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">status</text>
-      <text x="244.10000000000002" y="654.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">date</text>
-      <text x="320.70000000000005" y="654.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">ordered_at</text>
-      <text x="244.10000000000002" y="697.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">date</text>
-      <text x="320.70000000000005" y="697.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">shipped_at</text>
+      <text x="320.70000000000005" y="611.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">status</text>
+      <text x="244.10000000000002" y="654.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">date</text>
+      <text x="320.70000000000005" y="654.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">ordered_at</text>
+      <text x="244.10000000000002" y="697.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">date</text>
+      <text x="320.70000000000005" y="697.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">shipped_at</text>
     </g>
     <g class="entity-node" id="entity-ORDER_ITEM-2">
       <rect x="3.8999999999999915" y="894.625" width="214.20000000000002" height="272.5" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -343,20 +343,20 @@ marker path {
       <line x1="3.8999999999999915" y1="937.375" x2="218.10000000000002" y2="937.375" class="divider" stroke-width="1.3"/>
       <line x1="80.5" y1="937.375" x2="80.5" y2="1167.125" class="divider" stroke-width="1.3"/>
       <line x1="180.5" y1="937.375" x2="180.5" y2="1167.125" class="divider" stroke-width="1.3"/>
-      <text x="111" y="921" class="entity-name" font-size="14" text-anchor="middle">ORDER_ITEM</text>
+      <text x="111" y="921" class="entity-name" text-anchor="middle" font-size="14">ORDER_ITEM</text>
       <text x="15.899999999999991" y="962.75" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
-      <text x="92.5" y="962.75" class="entity-attr attribute-name" font-size="12" text-anchor="start">id</text>
+      <text x="92.5" y="962.75" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
       <text x="192.5" y="962.75" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
-      <text x="15.899999999999991" y="1005.5" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
-      <text x="92.5" y="1005.5" class="entity-attr attribute-name" text-anchor="start" font-size="12">order_id</text>
-      <text x="192.5" y="1005.5" class="entity-attr attribute-key" text-anchor="start" font-size="12">FK</text>
-      <text x="15.899999999999991" y="1048.25" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
-      <text x="92.5" y="1048.25" class="entity-attr attribute-name" text-anchor="start" font-size="12">product_id</text>
+      <text x="15.899999999999991" y="1005.5" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
+      <text x="92.5" y="1005.5" class="entity-attr attribute-name" font-size="12" text-anchor="start">order_id</text>
+      <text x="192.5" y="1005.5" class="entity-attr attribute-key" font-size="12" text-anchor="start">FK</text>
+      <text x="15.899999999999991" y="1048.25" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
+      <text x="92.5" y="1048.25" class="entity-attr attribute-name" font-size="12" text-anchor="start">product_id</text>
       <text x="192.5" y="1048.25" class="entity-attr attribute-key" text-anchor="start" font-size="12">FK</text>
       <text x="15.899999999999991" y="1091" class="entity-attr attribute-type" text-anchor="start" font-size="12">int</text>
-      <text x="92.5" y="1091" class="entity-attr attribute-name" text-anchor="start" font-size="12">quantity</text>
+      <text x="92.5" y="1091" class="entity-attr attribute-name" font-size="12" text-anchor="start">quantity</text>
       <text x="15.899999999999991" y="1133.75" class="entity-attr attribute-type" text-anchor="start" font-size="12">decimal</text>
-      <text x="92.5" y="1133.75" class="entity-attr attribute-name" text-anchor="start" font-size="12">price</text>
+      <text x="92.5" y="1133.75" class="entity-attr attribute-name" font-size="12" text-anchor="start">price</text>
     </g>
     <g class="entity-node" id="entity-PAYMENT-7">
       <rect x="712.3000000000001" y="873.25" width="229.8" height="315.25" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -369,21 +369,21 @@ marker path {
       <line x1="712.3000000000001" y1="916" x2="942.1000000000001" y2="916" class="divider" stroke-width="1.3"/>
       <line x1="788.9000000000001" y1="916" x2="788.9000000000001" y2="1188.5" class="divider" stroke-width="1.3"/>
       <line x1="904.5000000000001" y1="916" x2="904.5000000000001" y2="1188.5" class="divider" stroke-width="1.3"/>
-      <text x="827.2" y="899.625" class="entity-name" text-anchor="middle" font-size="14">PAYMENT</text>
+      <text x="827.2" y="899.625" class="entity-name" font-size="14" text-anchor="middle">PAYMENT</text>
       <text x="724.3000000000001" y="941.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
       <text x="800.9000000000001" y="941.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
-      <text x="916.5000000000001" y="941.375" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
-      <text x="724.3000000000001" y="984.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
+      <text x="916.5000000000001" y="941.375" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK</text>
+      <text x="724.3000000000001" y="984.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
       <text x="800.9000000000001" y="984.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">order_id</text>
-      <text x="916.5000000000001" y="984.125" class="entity-attr attribute-key" text-anchor="start" font-size="12">FK</text>
-      <text x="724.3000000000001" y="1026.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
-      <text x="800.9000000000001" y="1026.875" class="entity-attr attribute-name" font-size="12" text-anchor="start">method</text>
-      <text x="724.3000000000001" y="1069.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">decimal</text>
-      <text x="800.9000000000001" y="1069.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">amount</text>
+      <text x="916.5000000000001" y="984.125" class="entity-attr attribute-key" font-size="12" text-anchor="start">FK</text>
+      <text x="724.3000000000001" y="1026.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
+      <text x="800.9000000000001" y="1026.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">method</text>
+      <text x="724.3000000000001" y="1069.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">decimal</text>
+      <text x="800.9000000000001" y="1069.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">amount</text>
       <text x="724.3000000000001" y="1112.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
       <text x="800.9000000000001" y="1112.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">status</text>
-      <text x="724.3000000000001" y="1155.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">date</text>
-      <text x="800.9000000000001" y="1155.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">processed_at</text>
+      <text x="724.3000000000001" y="1155.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">date</text>
+      <text x="800.9000000000001" y="1155.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">processed_at</text>
     </g>
     <g class="entity-node" id="entity-PRODUCT-3">
       <rect x="-0.000000000000014210854715202004" y="1331.25" width="222.00000000000003" height="358" rx="0" ry="0" class="entity-box" stroke-width="1.3"/>
@@ -398,21 +398,21 @@ marker path {
       <line x1="76.6" y1="1374" x2="76.6" y2="1689.25" class="divider" stroke-width="1.3"/>
       <line x1="184.4" y1="1374" x2="184.4" y2="1689.25" class="divider" stroke-width="1.3"/>
       <text x="111" y="1357.625" class="entity-name" font-size="14" text-anchor="middle">PRODUCT</text>
-      <text x="11.999999999999986" y="1399.375" class="entity-attr attribute-type" text-anchor="start" font-size="12">uuid</text>
-      <text x="88.6" y="1399.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">id</text>
+      <text x="11.999999999999986" y="1399.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
+      <text x="88.6" y="1399.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">id</text>
       <text x="196.4" y="1399.375" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK</text>
       <text x="11.999999999999986" y="1442.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">string</text>
-      <text x="88.6" y="1442.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">sku</text>
-      <text x="196.4" y="1442.125" class="entity-attr attribute-key" text-anchor="start" font-size="12">UK</text>
+      <text x="88.6" y="1442.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">sku</text>
+      <text x="196.4" y="1442.125" class="entity-attr attribute-key" font-size="12" text-anchor="start">UK</text>
       <text x="11.999999999999986" y="1484.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">string</text>
       <text x="88.6" y="1484.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">name</text>
-      <text x="11.999999999999986" y="1527.625" class="entity-attr attribute-type" text-anchor="start" font-size="12">text</text>
-      <text x="88.6" y="1527.625" class="entity-attr attribute-name" font-size="12" text-anchor="start">description</text>
+      <text x="11.999999999999986" y="1527.625" class="entity-attr attribute-type" font-size="12" text-anchor="start">text</text>
+      <text x="88.6" y="1527.625" class="entity-attr attribute-name" text-anchor="start" font-size="12">description</text>
       <text x="11.999999999999986" y="1570.375" class="entity-attr attribute-type" font-size="12" text-anchor="start">decimal</text>
-      <text x="88.6" y="1570.375" class="entity-attr attribute-name" font-size="12" text-anchor="start">price</text>
+      <text x="88.6" y="1570.375" class="entity-attr attribute-name" text-anchor="start" font-size="12">price</text>
       <text x="11.999999999999986" y="1613.125" class="entity-attr attribute-type" text-anchor="start" font-size="12">int</text>
-      <text x="88.6" y="1613.125" class="entity-attr attribute-name" text-anchor="start" font-size="12">stock</text>
-      <text x="11.999999999999986" y="1655.875" class="entity-attr attribute-type" text-anchor="start" font-size="12">boolean</text>
+      <text x="88.6" y="1613.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">stock</text>
+      <text x="11.999999999999986" y="1655.875" class="entity-attr attribute-type" font-size="12" text-anchor="start">boolean</text>
       <text x="88.6" y="1655.875" class="entity-attr attribute-name" text-anchor="start" font-size="12">available</text>
     </g>
     <g class="entity-node" id="entity-PRODUCT_CATEGORY-4">
@@ -428,7 +428,7 @@ marker path {
       <text x="242.10000000000002" y="1857.375" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK,FK</text>
       <text x="81.10000000000002" y="1900.125" class="entity-attr attribute-type" font-size="12" text-anchor="start">uuid</text>
       <text x="134.3" y="1900.125" class="entity-attr attribute-name" font-size="12" text-anchor="start">category_id</text>
-      <text x="242.10000000000002" y="1900.125" class="entity-attr attribute-key" text-anchor="start" font-size="12">PK,FK</text>
+      <text x="242.10000000000002" y="1900.125" class="entity-attr attribute-key" font-size="12" text-anchor="start">PK,FK</text>
     </g>
   </g>
 </svg>

--- a/src/render/er.rs
+++ b/src/render/er.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use crate::diagrams::er::{Cardinality, Entity, ErDb, Identification};
+use crate::diagrams::er::{Cardinality, Entity, ErDb, Identification, Relationship};
 use crate::error::Result;
 use crate::layout::{
     layout, CharacterSizeEstimator, LayoutDirection, LayoutEdge, LayoutGraph, LayoutNode,
@@ -137,12 +137,50 @@ fn determine_attachment_sides(
     (side_a, side_b)
 }
 
+/// Compute where a line from a rectangle's center toward a given point
+/// intersects the rectangle boundary.
+///
+/// This is the `intersect-rect` algorithm used by mermaid.js/dagre.
+/// Given the rectangle's top-left (rx, ry), dimensions (w, h), and
+/// an external point (px, py), returns the boundary intersection point.
+fn intersect_rect(rx: f64, ry: f64, w: f64, h: f64, px: f64, py: f64) -> (f64, f64) {
+    let cx = rx + w / 2.0;
+    let cy = ry + h / 2.0;
+    let dx = px - cx;
+    let dy = py - cy;
+
+    if dx.abs() < 0.001 && dy.abs() < 0.001 {
+        return (cx, cy);
+    }
+
+    let hw = w / 2.0;
+    let hh = h / 2.0;
+
+    // Find the parameter t where the ray from center toward (px,py) hits the boundary.
+    // The ray intersects the vertical edges at t = hw/|dx| and horizontal at t = hh/|dy|.
+    // The smaller t is the first boundary crossing.
+    let sx = if dx.abs() > 0.001 {
+        hw / dx.abs()
+    } else {
+        f64::INFINITY
+    };
+    let sy = if dy.abs() > 0.001 {
+        hh / dy.abs()
+    } else {
+        f64::INFINITY
+    };
+    let t = sx.min(sy);
+
+    (cx + t * dx, cy + t * dy)
+}
+
 /// Adjust dagre bend_points to properly intersect entity boundaries
 ///
-/// Dagre computes edge paths between node centers, but we need the edges to
-/// attach to the correct sides of entity boxes based on relative entity positions.
-/// This determines which side each entity should use based on their layout positions,
-/// then calculates intersection points on those specific sides.
+/// Dagre computes edge paths between node centers. We use the direction
+/// of the edge at each endpoint (from the adjacent bend point) to compute
+/// where the edge intersects each entity's boundary via intersect-rect.
+/// This matches how mermaid.js determines attachment sides — from the actual
+/// edge routing direction, not a simple center-to-center heuristic.
 fn adjust_bend_points_for_intersection(
     bend_points: &[Point],
     entity_a_name: &str,
@@ -154,65 +192,188 @@ fn adjust_bend_points_for_intersection(
         return bend_points.to_vec();
     }
 
-    // Get both entities' positions and dimensions
     let a_pos = entity_positions.get(entity_a_name);
     let b_pos = entity_positions.get(entity_b_name);
     let a_dims = entity_dimensions.get(entity_a_name);
     let b_dims = entity_dimensions.get(entity_b_name);
 
-    // Need both entities to calculate attachment sides
     let (Some(&(ax, ay)), Some(&(bx, by)), Some(a_dims), Some(b_dims)) =
         (a_pos, b_pos, a_dims, b_dims)
     else {
         return bend_points.to_vec();
     };
 
-    // Determine which sides each entity should use based on their relative positions
-    let (side_a, side_b) = determine_attachment_sides(
-        ax,
-        ay,
-        a_dims.width,
-        a_dims.height,
-        bx,
-        by,
-        b_dims.width,
-        b_dims.height,
-    );
-
     let mut adjusted = bend_points.to_vec();
+    let last_idx = adjusted.len() - 1;
 
-    // Calculate intersection point on entity A's determined side
+    // For entity A: use the next bend point as the direction target.
+    // This captures which way dagre actually routes the edge out of A.
+    let a_target = if bend_points.len() > 2 {
+        bend_points[1]
+    } else {
+        // Only 2 points: use B's center as target
+        Point {
+            x: bx + b_dims.width / 2.0,
+            y: by + b_dims.height / 2.0,
+        }
+    };
+
     let (start_x, start_y) =
-        calculate_side_intersection(ax, ay, a_dims.width, a_dims.height, side_a);
+        intersect_rect(ax, ay, a_dims.width, a_dims.height, a_target.x, a_target.y);
     adjusted[0] = Point {
         x: start_x,
         y: start_y,
     };
 
-    // Calculate intersection point on entity B's determined side
-    let last_idx = adjusted.len() - 1;
-    let (end_x, end_y) = calculate_side_intersection(bx, by, b_dims.width, b_dims.height, side_b);
+    // For entity B: determine direction the edge approaches from.
+    // For long edges (many bend points), use the adjacent bend point which
+    // captures dagre's local routing direction near B.
+    // For short edges (≤3 points), dagre provides minimal routing so the
+    // adjacent point is near A's center — use the adjusted start point instead,
+    // which is on A's boundary and captures the actual horizontal offset.
+    let b_source = if bend_points.len() > 3 {
+        bend_points[last_idx - 1]
+    } else {
+        // Use the adjusted start point for better direction context
+        Point {
+            x: start_x,
+            y: start_y,
+        }
+    };
+
+    let (end_x, end_y) =
+        intersect_rect(bx, by, b_dims.width, b_dims.height, b_source.x, b_source.y);
     adjusted[last_idx] = Point { x: end_x, y: end_y };
 
     adjusted
 }
 
-/// Calculate the intersection point on a specific side of an entity box
-fn calculate_side_intersection(
-    x: f64,
-    y: f64,
-    width: f64,
-    height: f64,
-    side: AttachmentSide,
-) -> (f64, f64) {
-    let center_x = x + width / 2.0;
-    let center_y = y + height / 2.0;
+/// Determine which side of an entity a point falls on
+fn point_to_side(px: f64, py: f64, ex: f64, ey: f64, ew: f64, eh: f64) -> AttachmentSide {
+    let eps = 1.0;
+    if (py - ey).abs() < eps {
+        AttachmentSide::Top
+    } else if (py - (ey + eh)).abs() < eps {
+        AttachmentSide::Bottom
+    } else if (px - ex).abs() < eps {
+        AttachmentSide::Left
+    } else if (px - (ex + ew)).abs() < eps {
+        AttachmentSide::Right
+    } else {
+        // Fallback: determine by distance to edges
+        let to_top = (py - ey).abs();
+        let to_bottom = (py - (ey + eh)).abs();
+        let to_left = (px - ex).abs();
+        let to_right = (px - (ex + ew)).abs();
+        let min = to_top.min(to_bottom).min(to_left).min(to_right);
+        if (min - to_top).abs() < eps {
+            AttachmentSide::Top
+        } else if (min - to_bottom).abs() < eps {
+            AttachmentSide::Bottom
+        } else if (min - to_left).abs() < eps {
+            AttachmentSide::Left
+        } else {
+            AttachmentSide::Right
+        }
+    }
+}
 
-    match side {
-        AttachmentSide::Top => (center_x, y),
-        AttachmentSide::Bottom => (center_x, y + height),
-        AttachmentSide::Left => (x, center_y),
-        AttachmentSide::Right => (x + width, center_y),
+/// Redistribute edge endpoints that converge on the same side of a target entity.
+///
+/// When multiple edges arrive at the same side of an entity (e.g., two edges both
+/// arriving at the top of LINE-ITEM), redistribute them to left/right sides based
+/// on horizontal offset from the source. This matches mermaid.js behavior for
+/// converging diagonal edges in ER diagrams.
+fn redistribute_converging_endpoints(
+    all_adjusted: &mut HashMap<usize, Vec<Point>>,
+    relationships: &[Relationship],
+    entity_id_to_name: &HashMap<String, String>,
+    entity_positions: &HashMap<String, (f64, f64)>,
+    entity_dimensions: &HashMap<String, EntityDimensions>,
+) {
+    // Group edges by (target entity, target side)
+    let mut target_groups: HashMap<(String, AttachmentSide), Vec<usize>> = HashMap::new();
+
+    for (idx, relationship) in relationships.iter().enumerate() {
+        let Some(adjusted) = all_adjusted.get(&idx) else {
+            continue;
+        };
+        if adjusted.is_empty() {
+            continue;
+        }
+
+        let Some(b_name) = entity_id_to_name.get(&relationship.entity_b) else {
+            continue;
+        };
+        let Some(&(bx, by)) = entity_positions.get(b_name) else {
+            continue;
+        };
+        let Some(b_dims) = entity_dimensions.get(b_name) else {
+            continue;
+        };
+
+        let end_pt = adjusted[adjusted.len() - 1];
+        let side = point_to_side(end_pt.x, end_pt.y, bx, by, b_dims.width, b_dims.height);
+        target_groups
+            .entry((b_name.clone(), side))
+            .or_default()
+            .push(idx);
+    }
+
+    // For groups with 2+ converging edges on top/bottom, redistribute to left/right
+    for ((entity_name, side), edge_indices) in &target_groups {
+        if edge_indices.len() < 2 {
+            continue;
+        }
+        // Only redistribute top/bottom convergence to left/right
+        if !matches!(side, AttachmentSide::Top | AttachmentSide::Bottom) {
+            continue;
+        }
+
+        let Some(&(bx, by)) = entity_positions.get(entity_name) else {
+            continue;
+        };
+        let Some(b_dims) = entity_dimensions.get(entity_name) else {
+            continue;
+        };
+        let b_cy = by + b_dims.height / 2.0;
+
+        // Collect edges with their start x positions
+        let mut sorted_edges: Vec<(usize, f64)> = edge_indices
+            .iter()
+            .filter_map(|&idx| {
+                all_adjusted.get(&idx).map(|pts| (idx, pts[0].x)) // start point x
+            })
+            .collect();
+        sorted_edges.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        let b_cx = bx + b_dims.width / 2.0;
+        let half_width = b_dims.width / 2.0;
+
+        // Only redistribute edges that are significantly offset from the target center.
+        // If the start point is within 1x the target half-width, the edge approaches
+        // mostly from above/below and should stay on the original side (just offset).
+        // This avoids breaking edges that correctly converge on the same side.
+        for &(idx, start_x) in &sorted_edges {
+            let offset_ratio = (start_x - b_cx).abs() / half_width.max(1.0);
+            if offset_ratio <= 1.0 {
+                continue; // Not significantly offset — keep original side
+            }
+
+            let Some(adjusted) = all_adjusted.get_mut(&idx) else {
+                continue;
+            };
+            let last = adjusted.len() - 1;
+
+            if start_x < b_cx {
+                adjusted[last] = Point { x: bx, y: b_cy };
+            } else {
+                adjusted[last] = Point {
+                    x: bx + b_dims.width,
+                    y: b_cy,
+                };
+            }
+        }
     }
 }
 
@@ -643,34 +804,49 @@ pub fn render_er(db: &ErDb, config: &RenderConfig) -> Result<String> {
         marker_offset,
     );
 
-    // Render relationships FIRST so entity boxes paint on top and clip markers
-    // (SVG renders later elements on top of earlier ones)
+    // First pass: compute adjusted bend points for all edges with dagre routing.
+    // We need all edges to detect and fix converging endpoints on the same entity side.
+    let mut all_adjusted_points: HashMap<usize, Vec<Point>> = HashMap::new();
+
     for (idx, relationship) in relationships.iter().enumerate() {
         let edge_id = format!("relationship-{}", idx);
-
-        // Get entity information for intersection calculation
         let entity_a_name = entity_id_to_name.get(&relationship.entity_a);
         let entity_b_name = entity_id_to_name.get(&relationship.entity_b);
 
-        // Try to use dagre-computed bend points for the edge path
         if let Some(bend_points) = edge_bend_points.get(&edge_id) {
-            // Adjust bend_points endpoints to properly intersect entity boundaries
-            // using the mermaid.js intersect-rect algorithm
-            let adjusted_points =
-                if let (Some(a_name), Some(b_name)) = (entity_a_name, entity_b_name) {
-                    adjust_bend_points_for_intersection(
-                        bend_points,
-                        a_name,
-                        b_name,
-                        &entity_positions,
-                        &entity_dimensions,
-                    )
-                } else {
-                    bend_points.clone()
-                };
+            let adjusted = if let (Some(a_name), Some(b_name)) = (entity_a_name, entity_b_name) {
+                adjust_bend_points_for_intersection(
+                    bend_points,
+                    a_name,
+                    b_name,
+                    &entity_positions,
+                    &entity_dimensions,
+                )
+            } else {
+                bend_points.clone()
+            };
+            all_adjusted_points.insert(idx, adjusted);
+        }
+    }
 
+    // Second pass: redistribute converging edge endpoints.
+    // When multiple edges arrive at the same side of the same entity (e.g., both
+    // hitting the top of LINE-ITEM), redistribute them to left/right sides based
+    // on horizontal offset. This matches how mermaid distributes converging edges.
+    redistribute_converging_endpoints(
+        &mut all_adjusted_points,
+        relationships,
+        &entity_id_to_name,
+        &entity_positions,
+        &entity_dimensions,
+    );
+
+    // Render relationships FIRST so entity boxes paint on top and clip markers
+    // (SVG renders later elements on top of earlier ones)
+    for (idx, relationship) in relationships.iter().enumerate() {
+        if let Some(adjusted_points) = all_adjusted_points.get(&idx) {
             let rel_elem = render_relationship_from_bend_points(
-                &adjusted_points,
+                adjusted_points,
                 &relationship.role_a,
                 relationship.rel_spec.card_a,
                 relationship.rel_spec.card_b,
@@ -1896,6 +2072,149 @@ mod tests {
             css.contains(".relationship-label {\n  fill: #9370DB"),
             "Relationship label should use border color for fill. CSS: {}",
             css
+        );
+    }
+
+    #[test]
+    fn test_adjust_bend_points_respects_dagre_exit_direction() {
+        // When dagre routes an edge to exit rightward from entity A,
+        // the adjusted start point should be on A's right side,
+        // even when entity B is mostly below A (where the center-to-center
+        // heuristic would incorrectly pick bottom).
+        //
+        // This reproduces the eval error:
+        //   Edge 1 start: leaves from bottom in selkie but right in reference
+        use crate::layout::Point;
+
+        let mut entity_positions = HashMap::new();
+        let mut entity_dimensions = HashMap::new();
+
+        // Entity A at (100, 50), 200x150 — center at (200, 125)
+        entity_positions.insert("A".to_string(), (100.0, 50.0));
+        entity_dimensions.insert(
+            "A".to_string(),
+            EntityDimensions {
+                width: 200.0,
+                height: 150.0,
+                col_widths: [70.0, 70.0, 60.0],
+            },
+        );
+
+        // Entity B at (200, 400), 200x150 — center at (300, 475)
+        // dx=100, dy=350 → dy dominates → heuristic says Bottom for A
+        entity_positions.insert("B".to_string(), (200.0, 400.0));
+        entity_dimensions.insert(
+            "B".to_string(),
+            EntityDimensions {
+                width: 200.0,
+                height: 150.0,
+                col_widths: [70.0, 70.0, 60.0],
+            },
+        );
+
+        // Dagre routes the edge rightward from A, then down to B's top
+        let bend_points = vec![
+            Point { x: 200.0, y: 125.0 }, // A center
+            Point { x: 350.0, y: 125.0 }, // Right of A center (dagre says go right)
+            Point { x: 350.0, y: 400.0 }, // Then go down
+            Point { x: 300.0, y: 475.0 }, // B center
+        ];
+
+        let adjusted = adjust_bend_points_for_intersection(
+            &bend_points,
+            "A",
+            "B",
+            &entity_positions,
+            &entity_dimensions,
+        );
+
+        // Start should be on A's RIGHT side (x = 100 + 200 = 300),
+        // not A's BOTTOM, because dagre routes rightward
+        assert!(
+            (adjusted[0].x - 300.0).abs() < 1.0,
+            "Edge should exit from A's right side at x=300, got x={}",
+            adjusted[0].x
+        );
+        assert!(
+            (adjusted[0].y - 125.0).abs() < 1.0,
+            "Edge should exit at A's center y=125, got y={}",
+            adjusted[0].y
+        );
+
+        // End should be on B's TOP (y = 400), because dagre comes from above
+        let last = adjusted.len() - 1;
+        assert!(
+            (adjusted[last].y - 400.0).abs() < 1.0,
+            "Edge should enter B's top at y=400, got y={}",
+            adjusted[last].y
+        );
+    }
+
+    #[test]
+    fn test_adjust_bend_points_respects_dagre_left_exit() {
+        // When dagre routes an edge to exit leftward from entity A,
+        // the adjusted start point should be on A's left side.
+        //
+        // This reproduces the eval error:
+        //   Edge 2 start: leaves from bottom in selkie but left in reference
+        use crate::layout::Point;
+
+        let mut entity_positions = HashMap::new();
+        let mut entity_dimensions = HashMap::new();
+
+        // Entity A at (300, 50), 200x150 — center at (400, 125)
+        entity_positions.insert("A".to_string(), (300.0, 50.0));
+        entity_dimensions.insert(
+            "A".to_string(),
+            EntityDimensions {
+                width: 200.0,
+                height: 150.0,
+                col_widths: [70.0, 70.0, 60.0],
+            },
+        );
+
+        // Entity B at (100, 400), 200x150 — center at (200, 475)
+        // dx=-200, dy=350 → dy dominates → heuristic says Bottom for A
+        entity_positions.insert("B".to_string(), (100.0, 400.0));
+        entity_dimensions.insert(
+            "B".to_string(),
+            EntityDimensions {
+                width: 200.0,
+                height: 150.0,
+                col_widths: [70.0, 70.0, 60.0],
+            },
+        );
+
+        // Dagre routes the edge leftward from A, then down to B's top
+        let bend_points = vec![
+            Point { x: 400.0, y: 125.0 }, // A center
+            Point { x: 250.0, y: 125.0 }, // Left of A center (dagre says go left)
+            Point { x: 200.0, y: 400.0 }, // Toward B
+            Point { x: 200.0, y: 475.0 }, // B center
+        ];
+
+        let adjusted = adjust_bend_points_for_intersection(
+            &bend_points,
+            "A",
+            "B",
+            &entity_positions,
+            &entity_dimensions,
+        );
+
+        // Start should be on A's LEFT side (x = 300),
+        // not A's BOTTOM, because dagre routes leftward
+        assert!(
+            (adjusted[0].x - 300.0).abs() < 1.0,
+            "Edge should exit from A's left side at x=300, got x={}",
+            adjusted[0].x
+        );
+
+        // End should be on B's TOP (y = 400)
+        let last = adjusted.len() - 1;
+        assert!(
+            (adjusted[last].y - 400.0).abs() < 1.0,
+            "Edge should enter B's top at y=400, got y={}",
+            adjusted[last].y
         );
     }
 


### PR DESCRIPTION
<!-- midtown: riverside -->

## Summary
- Replace center-to-center heuristic with intersect-rect algorithm for determining edge attachment points on ER entity boxes
- Add convergence redistribution for edges that arrive on the same side of an entity
- Reduces er_complex edge attachment side mismatches from 9 to 5

## Test plan
- [x] Two new unit tests for dagre direction-aware edge routing
- [x] Eval: er_complex errors reduced 9→5, simple ER 0→0 (no regression)
- [x] cargo fmt, clippy, test all pass