### PR TITLE
fix(eval): add subgraph boundary chars to ascii_text_similarity scoring [Midtown #186]

### DIFF
--- a/src/eval/ascii_checks.rs
+++ b/src/eval/ascii_checks.rs
@@ -1479,35 +1479,32 @@ pub fn calculate_ascii_text_similarity(output: &str) -> f64 {
     }
 
     // Has structural characters like box drawing, bullets, or bars (20%)
+    // NOTE: This list must include ALL Unicode characters used by ASCII renderers.
+    // When adding new characters to any renderer in src/render/ascii/, add them here too.
+    // See the similarity_recognizes_all_renderer_unicode_chars test for enforcement.
     let has_structure = output.chars().any(|c| {
         matches!(
             c,
-            '┌' | '┐'
-                | '└'
-                | '┘'
-                | '│'
-                | '─'
-                | '├'
-                | '┤'
-                | '┬'
-                | '┴'
-                | '┼'
-                | '█'
-                | '▌'
-                | '░'
-                | '●'
-                | '◆'
-                | '◇'
-                | '■'
-                | '▲'
-                | '◉'
-                | '★'
-                | '§'
-                | '▶'
-                | '◈'
-                | '▼'
-                | '◀'
-                | '→'
+            // Box-drawing: single-line
+            '┌' | '┐' | '└' | '┘' | '│' | '─' | '├' | '┤' | '┬' | '┴' | '┼'
+            // Box-drawing: rounded corners
+            | '╭' | '╮' | '╰' | '╯'
+            // Box-drawing: heavy (subgraph boundaries)
+            | '┏' | '┓' | '┗' | '┛' | '┃'
+            // Box-drawing: dashed
+            | '╌'
+            // Box-drawing: double
+            | '═'
+            // Block elements
+            | '█' | '▌' | '░' | '▓' | '▀'
+            // Geometric shapes
+            | '●' | '◆' | '◇' | '■' | '▲' | '▼' | '◀' | '▶' | '◉' | '◈'
+            // Special symbols
+            | '★' | '☁' | '⚡' | '⬡'
+            // Arrows
+            | '→'
+            // Misc
+            | '§' | '✓' | '►'
         )
     });
     if has_structure {
@@ -1876,6 +1873,72 @@ mod tests {
                 marker as u32,
                 score,
                 score_plain,
+            );
+        }
+    }
+
+    #[test]
+    fn similarity_recognizes_subgraph_boundary_chars() {
+        // Subgraph boundary characters (┏┓┗┛┃╌) must be recognized as structural
+        let plain_text = "hello\nworld\nfoo";
+        let score_plain = calculate_ascii_text_similarity(plain_text);
+
+        for (ch, name) in [
+            ('┏', "heavy down-right corner"),
+            ('┓', "heavy down-left corner"),
+            ('┗', "heavy up-right corner"),
+            ('┛', "heavy up-left corner"),
+            ('┃', "heavy vertical"),
+            ('╌', "light dashed horizontal"),
+        ] {
+            let with_char = format!("  {}\nLabel\n  {}", ch, ch);
+            let score = calculate_ascii_text_similarity(&with_char);
+            assert!(
+                score > score_plain,
+                "Text with {} ({}) should score higher than plain text: {} vs {}",
+                ch,
+                name,
+                score,
+                score_plain
+            );
+        }
+    }
+
+    #[test]
+    fn similarity_recognizes_all_renderer_unicode_chars() {
+        // Comprehensive check: every Unicode character used by ASCII renderers
+        // must be recognized as structural in calculate_ascii_text_similarity.
+        // This prevents the recurring bug pattern where new renderer chars are
+        // not added to the eval scoring function.
+        let all_structural_chars = [
+            // Box-drawing (single)
+            '┌', '┐', '└', '┘', '│', '─', '├', '┤', '┬', '┴', '┼',
+            // Box-drawing (rounded)
+            '╭', '╮', '╰', '╯', // Box-drawing (heavy / subgraph boundary)
+            '┏', '┓', '┗', '┛', '┃', // Box-drawing (dashed)
+            '╌', // Box-drawing (double)
+            '═', // Block elements
+            '█', '▌', '░', '▓', '▀', // Geometric shapes
+            '●', '◆', '◇', '■', '▲', '▼', '◀', '▶', '◉', '◈',
+            // Special symbols used by renderers
+            '★', '☁', '⚡', '⬡', // Arrows
+            '→', // Misc
+            '§', '✓', '►',
+        ];
+
+        let plain_text = "hello\nworld\nfoo";
+        let score_plain = calculate_ascii_text_similarity(plain_text);
+
+        for &ch in &all_structural_chars {
+            let with_char = format!("  {}\nLabel\n  {}", ch, ch);
+            let score = calculate_ascii_text_similarity(&with_char);
+            assert!(
+                score > score_plain,
+                "Character '{}' (U+{:04X}) should be recognized as structural but isn't: score {} vs plain {}",
+                ch,
+                ch as u32,
+                score,
+                score_plain
             );
         }
     }


### PR DESCRIPTION
<!-- midtown: pleasant -->

## Summary
- Add subgraph boundary characters (`┏┓┗┛┃╌`) to `calculate_ascii_text_similarity` structural pattern
- Add all other missing renderer Unicode characters: rounded corners (`╭╮╰╯`), double lines (`═`), dark shade (`▓`), upper half block (`▀`), cloud (`☁`), lightning (`⚡`), hexagon (`⬡`), checkmark (`✓`), play symbol (`►`)
- Add comprehensive regression test that validates every Unicode character used by ASCII renderers is recognized, preventing this recurring class of bug (previously hit with `◇` in PR #167, `◈` in PR #171)

## Test plan
- [x] `similarity_recognizes_subgraph_boundary_chars` — verifies each of ┏┓┗┛┃╌ individually
- [x] `similarity_recognizes_all_renderer_unicode_chars` — comprehensive audit test for all 40+ renderer chars
- [x] Full test suite passes (1750+ lib tests, 6 doc tests)
- [x] `cargo clippy --features all-formats -- -D warnings` clean
- [x] `cargo fmt` clean