### PR TITLE
feat: support max_width constraint for ASCII rendering [Midtown #187]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@ pub mod wasm;
 pub use config::Config;
 pub use error::{MermaidError, Result};
 pub use render::{
-    render, render_ascii, render_text, render_text_ascii, render_with_config, RenderConfig, Theme,
+    render, render_ascii, render_ascii_with_config, render_text, render_text_ascii,
+    render_text_ascii_with_config, render_with_config, RenderConfig, Theme,
 };
 
 /// Parse a mermaid diagram and return a diagram representation

--- a/src/render/ascii/mod.rs
+++ b/src/render/ascii/mod.rs
@@ -41,13 +41,44 @@ pub use sequence::render_sequence_ascii;
 use scale::CellScale;
 use shapes::{render_class_box, render_shape};
 
+/// Configuration for ASCII rendering.
+///
+/// Controls output constraints like maximum width. Use `Default::default()` for
+/// unconstrained rendering.
+///
+/// # Example
+///
+/// ```
+/// use selkie::render::ascii::AsciiRenderConfig;
+///
+/// let config = AsciiRenderConfig {
+///     max_width: Some(80),
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct AsciiRenderConfig {
+    /// Maximum output width in columns. When set, the renderer adjusts its
+    /// horizontal scale so the diagram fits within this width. Lines that
+    /// still exceed the limit after scaling are hard-truncated.
+    pub max_width: Option<usize>,
+}
+
 /// Render any laid-out graph as character art.
 ///
 /// This is the generic entry point for ASCII rendering. It works with any diagram
 /// type that produces a `LayoutGraph` via `ToLayoutGraph`. Node labels are taken
 /// from `node.label` (falling back to `node.id`), with HTML tags cleaned.
 pub fn render_graph_ascii(graph: &LayoutGraph) -> Result<String> {
-    render_ascii_impl(graph, &|node| generic_node_label(node))
+    render_graph_ascii_with_config(graph, &AsciiRenderConfig::default())
+}
+
+/// Render any laid-out graph as character art with configuration.
+pub fn render_graph_ascii_with_config(
+    graph: &LayoutGraph,
+    config: &AsciiRenderConfig,
+) -> Result<String> {
+    render_ascii_impl(graph, &|node| generic_node_label(node), config)
 }
 
 /// Render a flowchart as character art.
@@ -55,7 +86,16 @@ pub fn render_graph_ascii(graph: &LayoutGraph) -> Result<String> {
 /// Uses `FlowchartDb` for richer label lookup (vertex text), falling back to
 /// the layout node label. For non-flowchart diagrams, use `render_graph_ascii`.
 pub fn render_flowchart_ascii(db: &FlowchartDb, graph: &LayoutGraph) -> Result<String> {
-    render_ascii_impl(graph, &|node| flowchart_node_label(db, node))
+    render_flowchart_ascii_with_config(db, graph, &AsciiRenderConfig::default())
+}
+
+/// Render a flowchart as character art with configuration.
+pub fn render_flowchart_ascii_with_config(
+    db: &FlowchartDb,
+    graph: &LayoutGraph,
+    config: &AsciiRenderConfig,
+) -> Result<String> {
+    render_ascii_impl(graph, &|node| flowchart_node_label(db, node), config)
 }
 
 /// Render an ER diagram as character art.
@@ -310,8 +350,9 @@ fn format_cell(text: &str, width: usize) -> String {
 fn render_ascii_impl(
     graph: &LayoutGraph,
     label_fn: &dyn Fn(&crate::layout::LayoutNode) -> String,
+    config: &AsciiRenderConfig,
 ) -> Result<String> {
-    let scale = CellScale::default();
+    let mut scale = CellScale::default();
 
     // Determine canvas dimensions from graph bounds
     let graph_width = graph.width.unwrap_or(400.0);
@@ -319,7 +360,24 @@ fn render_ascii_impl(
     let offset_x = graph.bounds_x.unwrap_or(0.0);
     let offset_y = graph.bounds_y.unwrap_or(0.0);
 
-    let canvas_cols = scale.to_col(graph_width) + 8;
+    let padding_cols: usize = 8;
+    let natural_cols = scale.to_col(graph_width) + padding_cols;
+
+    // When max_width is set and the natural width exceeds it, widen the
+    // cell_width so the graph compresses horizontally to fit.
+    if let Some(max_w) = config.max_width {
+        if max_w > 0 && natural_cols > max_w {
+            // Solve: graph_width / new_cell_width + padding_cols = max_w
+            let available = max_w.saturating_sub(padding_cols).max(1);
+            scale.cell_width = graph_width / available as f64;
+        }
+    }
+
+    let canvas_cols = if let Some(max_w) = config.max_width {
+        (scale.to_col(graph_width) + padding_cols).min(max_w)
+    } else {
+        scale.to_col(graph_width) + padding_cols
+    };
     let canvas_rows = scale.to_row(graph_height) + 4;
 
     // Create a canvas (2D grid of characters)
@@ -636,7 +694,15 @@ fn render_ascii_impl(
 
     for row in &canvas[..=last_non_empty] {
         let line: String = row.iter().collect();
-        result.push_str(line.trim_end());
+        let trimmed = line.trim_end();
+        // Hard-truncate to max_width if set (defensive — canvas should
+        // already be sized correctly, but edges can extend slightly).
+        if let Some(max_w) = config.max_width {
+            let truncated: String = trimmed.chars().take(max_w).collect();
+            result.push_str(&truncated);
+        } else {
+            result.push_str(trimmed);
+        }
         result.push('\n');
     }
 
@@ -856,6 +922,97 @@ mod tests {
         let graph = db.to_layout_graph(&estimator).unwrap();
         let graph = crate::layout::layout(graph).unwrap();
         (db, graph)
+    }
+
+    #[test]
+    fn max_width_constrains_output_columns() {
+        let (db, graph) = parse_and_layout("flowchart TD\n    A[Start] --> B[End]");
+        let config = AsciiRenderConfig {
+            max_width: Some(40),
+            ..Default::default()
+        };
+        let output = render_flowchart_ascii_with_config(&db, &graph, &config).unwrap();
+        for line in output.lines() {
+            assert!(
+                line.chars().count() <= 40,
+                "Line exceeds max_width 40 ({} chars): {:?}",
+                line.chars().count(),
+                line,
+            );
+        }
+        // Should still produce output
+        assert!(!output.trim().is_empty(), "Output should not be empty");
+    }
+
+    #[test]
+    fn max_width_none_is_unconstrained() {
+        let (db, graph) = parse_and_layout("flowchart TD\n    A[Start] --> B[End]");
+        let default_output = render_flowchart_ascii(&db, &graph).unwrap();
+        let config = AsciiRenderConfig {
+            max_width: None,
+            ..Default::default()
+        };
+        let config_output = render_flowchart_ascii_with_config(&db, &graph, &config).unwrap();
+        assert_eq!(
+            default_output, config_output,
+            "Default and None config should produce identical output"
+        );
+    }
+
+    #[test]
+    fn max_width_preserves_labels_when_possible() {
+        let (db, graph) = parse_and_layout("flowchart TD\n    A[Hello] --> B[World]");
+        let config = AsciiRenderConfig {
+            max_width: Some(60),
+            ..Default::default()
+        };
+        let output = render_flowchart_ascii_with_config(&db, &graph, &config).unwrap();
+        // With a reasonable max_width, labels should still be visible
+        assert!(
+            output.contains("Hello"),
+            "Label 'Hello' should be present\nOutput:\n{}",
+            output,
+        );
+        assert!(
+            output.contains("World"),
+            "Label 'World' should be present\nOutput:\n{}",
+            output,
+        );
+    }
+
+    #[test]
+    fn max_width_via_render_graph_ascii() {
+        // Test the generic render_graph_ascii_with_config path (used by state,
+        // architecture, requirement diagrams).
+        let (_, graph) = parse_and_layout("flowchart TD\n    A[Start] --> B[End]");
+        let config = AsciiRenderConfig {
+            max_width: Some(35),
+            ..Default::default()
+        };
+        let output = render_graph_ascii_with_config(&graph, &config).unwrap();
+        for line in output.lines() {
+            assert!(
+                line.chars().count() <= 35,
+                "Line exceeds max_width 35 ({} chars): {:?}",
+                line.chars().count(),
+                line,
+            );
+        }
+    }
+
+    #[test]
+    fn max_width_large_value_no_effect() {
+        let (db, graph) = parse_and_layout("flowchart TD\n    A[Start] --> B[End]");
+        let default_output = render_flowchart_ascii(&db, &graph).unwrap();
+        let config = AsciiRenderConfig {
+            max_width: Some(500),
+            ..Default::default()
+        };
+        let config_output = render_flowchart_ascii_with_config(&db, &graph, &config).unwrap();
+        assert_eq!(
+            default_output, config_output,
+            "Large max_width should not change output"
+        );
     }
 
     #[test]

--- a/src/render/ascii/mod.rs
+++ b/src/render/ascii/mod.rs
@@ -1001,6 +1001,141 @@ mod tests {
     }
 
     #[test]
+    fn max_width_text_api_constrains_output() {
+        // Test the render_text_ascii_with_config end-to-end path
+        let config = AsciiRenderConfig {
+            max_width: Some(50),
+            ..Default::default()
+        };
+        let output = crate::render::render_text_ascii_with_config(
+            "flowchart TD\n    A[Start] --> B[End]",
+            &config,
+        )
+        .unwrap();
+        for line in output.lines() {
+            assert!(
+                line.chars().count() <= 50,
+                "render_text_ascii_with_config line exceeds 50 ({} chars): {:?}",
+                line.chars().count(),
+                line,
+            );
+        }
+        assert!(!output.trim().is_empty());
+    }
+
+    #[test]
+    fn max_width_truncation_fallback_for_sequence() {
+        // Sequence diagrams don't thread config internally — they use the
+        // truncation fallback in render_ascii_with_config.
+        let config = AsciiRenderConfig {
+            max_width: Some(30),
+            ..Default::default()
+        };
+        let output = crate::render::render_text_ascii_with_config(
+            "sequenceDiagram\n    Alice->>Bob: Hello",
+            &config,
+        )
+        .unwrap();
+        for line in output.lines() {
+            assert!(
+                line.chars().count() <= 30,
+                "Sequence line exceeds max_width 30 ({} chars): {:?}",
+                line.chars().count(),
+                line,
+            );
+        }
+    }
+
+    #[test]
+    fn max_width_wide_flowchart_triggers_compression() {
+        // Wide diagram with many parallel nodes — natural width should exceed
+        // max_width, triggering the scale compression code path.
+        let input = "flowchart LR\n    A[Alpha] --> B[Beta]\n    B --> C[Gamma]\n    C --> D[Delta]\n    D --> E[Epsilon]\n    E --> F[Final]";
+        let (db, graph) = parse_and_layout(input);
+
+        // First check the unconstrained width is wide enough to need compression
+        let unconstrained = render_flowchart_ascii(&db, &graph).unwrap();
+        let max_unconstrained = unconstrained
+            .lines()
+            .map(|l| l.chars().count())
+            .max()
+            .unwrap_or(0);
+
+        let max_w = 60;
+        // Only test compression if the unconstrained output actually exceeds max_w
+        if max_unconstrained > max_w {
+            let config = AsciiRenderConfig {
+                max_width: Some(max_w),
+                ..Default::default()
+            };
+            let output = render_flowchart_ascii_with_config(&db, &graph, &config).unwrap();
+            for line in output.lines() {
+                assert!(
+                    line.chars().count() <= max_w,
+                    "Wide flowchart line exceeds max_width {} ({} chars): {:?}",
+                    max_w,
+                    line.chars().count(),
+                    line,
+                );
+            }
+            assert!(
+                !output.trim().is_empty(),
+                "Compressed output should not be empty"
+            );
+        }
+    }
+
+    #[test]
+    fn max_width_state_diagram() {
+        let input = "stateDiagram-v2\n    [*] --> Idle\n    Idle --> Running : start\n    Running --> Idle : stop";
+        let graph = parse_and_layout_generic(input);
+        let config = AsciiRenderConfig {
+            max_width: Some(40),
+            ..Default::default()
+        };
+        let output = render_graph_ascii_with_config(&graph, &config).unwrap();
+        for line in output.lines() {
+            assert!(
+                line.chars().count() <= 40,
+                "State diagram line exceeds max_width 40 ({} chars): {:?}",
+                line.chars().count(),
+                line,
+            );
+        }
+        assert!(!output.trim().is_empty());
+    }
+
+    #[test]
+    fn max_width_requirement_diagram() {
+        let input = r#"requirementDiagram
+    requirement test_req {
+        id: 1
+        text: the test text
+        risk: high
+        verifymethod: test
+    }
+    element test_entity {
+        type: simulation
+    }
+    test_entity - satisfies -> test_req"#;
+        let graph = parse_and_layout_generic(input);
+        let config = AsciiRenderConfig {
+            max_width: Some(50),
+            ..Default::default()
+        };
+        let output = render_graph_ascii_with_config(&graph, &config).unwrap();
+        for line in output.lines() {
+            assert!(
+                line.chars().count() <= 50,
+                "Requirement diagram line exceeds max_width 50 ({} chars): {:?}",
+                line.chars().count(),
+                line,
+            );
+        }
+        assert!(!output.trim().is_empty());
+    }
+
+    #[test]
     fn max_width_large_value_no_effect() {
         let (db, graph) = parse_and_layout("flowchart TD\n    A[Start] --> B[End]");
         let default_output = render_flowchart_ascii(&db, &graph).unwrap();

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -180,15 +180,39 @@ fn render_flowchart(
 /// assert!(ascii.contains("Start"));
 /// ```
 pub fn render_ascii(diagram: &Diagram) -> Result<String> {
+    render_ascii_with_config(diagram, &ascii::AsciiRenderConfig::default())
+}
+
+/// Render a diagram to ASCII character art with configuration.
+///
+/// Like [`render_ascii`], but accepts an [`AsciiRenderConfig`](ascii::AsciiRenderConfig)
+/// to control output constraints such as maximum width.
+///
+/// # Example
+///
+/// ```
+/// use selkie::render::ascii::AsciiRenderConfig;
+///
+/// let diagram = selkie::parse("flowchart TD\n    A[Start] --> B[End]").unwrap();
+/// let config = AsciiRenderConfig { max_width: Some(60), ..Default::default() };
+/// let ascii = selkie::render::render_ascii_with_config(&diagram, &config).unwrap();
+/// assert!(ascii.lines().all(|line| line.len() <= 60));
+/// ```
+pub fn render_ascii_with_config(
+    diagram: &Diagram,
+    config: &ascii::AsciiRenderConfig,
+) -> Result<String> {
     use crate::layout::{self, CharacterSizeEstimator, ToLayoutGraph};
 
     let estimator = CharacterSizeEstimator::default();
 
-    match diagram {
+    let result = match diagram {
         Diagram::Flowchart(db) => {
             let graph = db.to_layout_graph(&estimator)?;
             let graph = layout::layout(graph)?;
-            Ok(ascii::render_flowchart_ascii(db, &graph)?)
+            Ok(ascii::render_flowchart_ascii_with_config(
+                db, &graph, config,
+            )?)
         }
         Diagram::Sequence(db) => Ok(ascii::render_sequence_ascii(db)?),
         Diagram::Class(db) => {
@@ -199,7 +223,7 @@ pub fn render_ascii(diagram: &Diagram) -> Result<String> {
         Diagram::State(db) => {
             let graph = db.to_layout_graph(&estimator)?;
             let graph = layout::layout(graph)?;
-            Ok(ascii::render_graph_ascii(&graph)?)
+            Ok(ascii::render_graph_ascii_with_config(&graph, config)?)
         }
         Diagram::Er(db) => {
             let graph = db.to_layout_graph(&estimator)?;
@@ -209,12 +233,12 @@ pub fn render_ascii(diagram: &Diagram) -> Result<String> {
         Diagram::Architecture(db) => {
             let graph = db.to_layout_graph(&estimator)?;
             let graph = layout::layout(graph)?;
-            Ok(ascii::render_graph_ascii(&graph)?)
+            Ok(ascii::render_graph_ascii_with_config(&graph, config)?)
         }
         Diagram::Requirement(db) => {
             let graph = db.to_layout_graph(&estimator)?;
             let graph = layout::layout(graph)?;
-            Ok(ascii::render_graph_ascii(&graph)?)
+            Ok(ascii::render_graph_ascii_with_config(&graph, config)?)
         }
         Diagram::Pie(db) => Ok(ascii::pie::render_pie_ascii(db)?),
         Diagram::Gantt(db) => {
@@ -237,6 +261,38 @@ pub fn render_ascii(diagram: &Diagram) -> Result<String> {
         _ => Err(MermaidError::RenderError(
             "ASCII format not yet supported for this diagram type".to_string(),
         )),
+    }?;
+
+    // For diagram types that don't yet thread config internally,
+    // apply max_width truncation at the output level.
+    Ok(truncate_ascii_width(&result, config))
+}
+
+/// Truncate each line of ASCII output to the configured max_width.
+fn truncate_ascii_width(output: &str, config: &ascii::AsciiRenderConfig) -> String {
+    match config.max_width {
+        Some(max_w) if max_w > 0 => {
+            let mut result = String::with_capacity(output.len());
+            for line in output.split('\n') {
+                let char_count = line.chars().count();
+                if char_count > max_w {
+                    let truncated: String = line.chars().take(max_w).collect();
+                    result.push_str(&truncated);
+                } else {
+                    result.push_str(line);
+                }
+                result.push('\n');
+            }
+            // Remove trailing extra newline if original didn't end with double newline
+            if !output.ends_with("\n\n") && result.ends_with("\n\n") {
+                result.pop();
+            }
+            if output.is_empty() {
+                result.clear();
+            }
+            result
+        }
+        _ => output.to_string(),
     }
 }
 
@@ -252,10 +308,34 @@ pub fn render_ascii(diagram: &Diagram) -> Result<String> {
 /// assert!(ascii.contains("Start"));
 /// ```
 pub fn render_text_ascii(text: &str) -> Result<String> {
+    render_text_ascii_with_config(text, &ascii::AsciiRenderConfig::default())
+}
+
+/// Render mermaid text directly to ASCII character art with configuration.
+///
+/// Like [`render_text_ascii`], but accepts an [`AsciiRenderConfig`](ascii::AsciiRenderConfig)
+/// for output constraints.
+///
+/// # Example
+///
+/// ```
+/// use selkie::render::ascii::AsciiRenderConfig;
+///
+/// let config = AsciiRenderConfig { max_width: Some(80), ..Default::default() };
+/// let ascii = selkie::render::render_text_ascii_with_config(
+///     "flowchart TD\n    A[Start] --> B[End]",
+///     &config,
+/// ).unwrap();
+/// assert!(ascii.lines().all(|line| line.len() <= 80));
+/// ```
+pub fn render_text_ascii_with_config(
+    text: &str,
+    config: &ascii::AsciiRenderConfig,
+) -> Result<String> {
     let clean_text = remove_directives(text);
     let diagram_type = detect_type(&clean_text)?;
     let diagram = parse(diagram_type, &clean_text)?;
-    render_ascii(&diagram)
+    render_ascii_with_config(&diagram, config)
 }
 
 /// Render an architecture diagram


### PR DESCRIPTION
<!-- midtown: park -->

## Summary
- Add `AsciiRenderConfig` struct with `max_width: Option<usize>` to control maximum output width
- Add `render_ascii_with_config` and `render_text_ascii_with_config` public API functions
- Implement scale compression in `render_ascii_impl` that adjusts `CellScale::cell_width` when natural output exceeds `max_width`, so diagrams compress horizontally to fit
- Add `truncate_ascii_width` fallback for diagram types that don't thread config internally (e.g., sequence diagrams)
- Thread config through flowchart, state, architecture, and requirement diagram renderers
- Hard-truncate lines in the canvas-to-string conversion as a defensive final pass

## Test plan
- [x] `max_width_constrains_output_columns` — verifies no line exceeds the configured width
- [x] `max_width_none_is_unconstrained` — verifies `None` produces identical output to default
- [x] `max_width_preserves_labels_when_possible` — verifies labels survive reasonable widths
- [x] `max_width_via_render_graph_ascii` — tests the generic path used by state/requirement
- [x] `max_width_text_api_constrains_output` — end-to-end test through `render_text_ascii_with_config`
- [x] `max_width_truncation_fallback_for_sequence` — tests fallback truncation path
- [x] `max_width_wide_flowchart_triggers_compression` — tests scale compression on wide LR flowcharts
- [x] `max_width_state_diagram` — state diagram respects constraint
- [x] `max_width_requirement_diagram` — requirement diagram respects constraint
- [x] `max_width_large_value_no_effect` — large max_width produces same output as unconstrained
- [x] All existing tests pass (`cargo test --features all-formats`)
- [x] `cargo fmt` and `cargo clippy --features all-formats -- -D warnings` clean