### PR TITLE
test(ascii): add flowchart edge label truncation regression tests [Midtown #188]

### DIFF
--- a/docs/images/example_flowchart_basic.svg
+++ b/docs/images/example_flowchart_basic.svg
@@ -90,7 +90,7 @@ marker path {
       <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
     </marker>
     <marker id="arrow_circle" viewBox="0 0 10 10" refX="11" refY="5" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <circle cx="5" cy="5" r="5"/>
@@ -105,16 +105,16 @@ marker path {
     </g>
     <g class="edgePaths">
       <g class="edge" id="edge-L-A-B-0">
-        <path d="M 121.41 61.00 L 248.80 32.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 121.41 61.00 L 248.80 32.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-A-C-0">
-        <path d="M 121.41 113.80 L 217.60 142.00" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 121.41 113.80 L 217.60 142.00" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-B-D-0">
-        <path d="M 314.40 32.80 L 419.07 63.93" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 314.40 32.80 L 419.07 63.93" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-C-D-0">
-        <path d="M 345.60 142.00 L 419.07 110.87" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 345.60 142.00 L 419.07 110.87" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
     </g>
     <g class="edgeLabels">
@@ -126,7 +126,7 @@ marker path {
     <g class="nodes">
       <g class="node" id="node-A">
         <rect x="0" y="61.00000000000001" width="137.6" height="52.8"/>
-        <text x="68.8" y="87.4" class="label" text-anchor="middle" dominant-baseline="central">Square Rect</text>
+        <text x="68.8" y="87.4" class="label" dominant-baseline="central" text-anchor="middle">Square Rect</text>
       </g>
       <g class="node" id="node-B">
         <circle cx="281.6" cy="32.80000000000001" r="32.8"/>
@@ -138,7 +138,7 @@ marker path {
       </g>
       <g class="node" id="node-D">
         <polygon points="455.6,27.400000000000006 515.6,87.4 455.6,147.4 395.6,87.4"/>
-        <text x="455.6" y="87.4" class="label" dominant-baseline="central" text-anchor="middle">Rhombus</text>
+        <text x="455.6" y="87.4" class="label" text-anchor="middle" dominant-baseline="central">Rhombus</text>
       </g>
     </g>
   </g>

--- a/docs/images/example_flowchart_styled.svg
+++ b/docs/images/example_flowchart_styled.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1206.8400000000001" height="556.8" viewBox="-8 -24.000000000000014 1206.8400000000001 556.8" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="1085.72" height="560.8" viewBox="-8 -28.000000000000014 1085.72 560.8" class="mermaid">
   <style>
 
 .mermaid {
@@ -90,7 +90,7 @@ marker path {
       <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_circle" viewBox="0 0 10 10" refX="11" refY="5" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <circle cx="5" cy="5" r="5"/>
@@ -102,28 +102,28 @@ marker path {
   <g class="root">
     <g class="clusters">
       <g class="subgraph" id="subgraph-A">
-        <rect x="31.980000000000018" y="-16.000000000000014" width="436.2399999999999" height="524.8" class="cluster"/>
-        <text x="250.09999999999997" y="-0.000000000000014210854715202004" class="cluster-label" text-anchor="middle">A</text>
+        <rect x="113.9" y="-20.000000000000014" width="627.52" height="532.8" class="cluster"/>
+        <text x="427.65999999999997" y="-4.000000000000014" class="cluster-label" text-anchor="middle">A</text>
       </g>
     </g>
     <g class="edgePaths">
       <g class="edge" id="edge-L-sq-ci-0">
-        <path d="M 1130.02 158.60 C 1130.02 193.87, 1130.02 229.13, 1035.38 252.60 C 940.75 276.07, 751.47 287.73, 735.48 312.82 C 876.78 376.43, 1034.07 414.95, 1034.07 414.95" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 1130.02 158.60 C 1130.02 193.87, 1130.02 229.13, 1052.71 252.60 C 975.41 276.07, 820.79 287.73, 804.95 312.28 C 912.04 374.24, 1034.97 411.66, 1034.97 411.66" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-od-ro-0">
-        <path d="M 387.10 158.60 C 387.10 193.87, 387.10 229.13, 450.54 252.60 C 513.99 276.07, 640.87 287.73, 615.21 313.42 C 411.32 378.83, 233.10 418.55, 233.10 418.55" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 656.30 158.60 C 656.30 193.87, 656.30 229.13, 697.31 252.60 C 738.32 276.07, 820.34 287.73, 749.81 313.77 C 456.19 380.21, 233.10 420.62, 233.10 420.62" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-di-ro-0">
-        <path d="M 159.98 239.40 C 159.98 247.73, 159.98 256.07, 230.35 266.07 C 300.72 276.07, 441.46 287.73, 453.65 312.57 C 349.47 375.40, 233.10 413.40, 233.10 413.40" class="edge-path" fill="none" stroke-width="2" stroke-dasharray="3,3" marker-end="url(#arrow_point)"/>
+        <path d="M 429.18 239.40 C 429.18 247.73, 429.18 256.07, 472.01 266.07 C 514.85 276.07, 600.51 287.73, 567.83 313.13 C 384.13 377.64, 233.10 416.75, 233.10 416.75" class="edge-path" fill="none" stroke-dasharray="3,3" stroke-width="2" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-di-ro2-0">
-        <path d="M 159.98000000000002 132.2 L 159.98000000000002 132.2" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="3.5"/>
+        <path d="M 429.17999999999984 132.2 L 429.17999999999984 132.2" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="3.5"/>
       </g>
       <g class="edge" id="edge-L-e-od3-0">
-        <path d="M 866.17 207.61 C 853.65 226.54, 841.14 245.47, 737.74 260.77 C 634.34 276.07, 440.06 287.73, 389.68 307.80 C 432.81 356.33, 526.33 384.80, 526.33 384.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 866.17 207.61 C 853.65 226.54, 841.14 245.47, 737.74 260.77 C 634.34 276.07, 440.06 287.73, 389.68 307.80 C 432.81 356.33, 526.33 384.80, 526.33 384.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-e-f-0">
-        <path d="M 969.50 205.08 C 984.01 224.86, 998.51 244.63, 920.29 260.35 C 842.07 276.07, 671.13 287.73, 647.87 312.51 C 749.06 375.16, 873.50 413.04, 873.50 413.04" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 969.50 205.08 C 984.01 224.86, 998.51 244.63, 920.29 260.35 C 842.07 276.07, 671.13 287.73, 647.87 312.51 C 749.06 375.16, 873.50 413.04, 873.50 413.04" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-cyr-cyr2-0">
         <path d="M 721.22 158.60 C 721.22 193.87, 721.22 229.13, 601.02 252.60 C 480.81 276.07, 240.41 287.73, 168.25 310.10 C 192.19 365.55, 288.28 398.62, 288.28 398.62" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
@@ -131,14 +131,14 @@ marker path {
     </g>
     <g class="edgeLabels">
       <g class="edgeLabel" id="edge-label-L-od-ro-0">
-        <rect x="691.4201861519787" y="285.89369075927215" width="94.39999999999999" height="40" class="edge-label-bg"/>
-        <text x="738.6201861519787" y="305.89369075927215" class="edge-label" text-anchor="middle" dominant-baseline="central"><tspan x="738.6201861519787" y="305.89369075927215" dy="-0.6em">Two line</tspan><tspan x="738.6201861519787" dy="1.2em">edge comment</tspan></text>
+        <rect x="694.8620194396497" y="308.43318736465733" width="94.39999999999999" height="40" class="edge-label-bg"/>
+        <text x="742.0620194396497" y="328.43318736465733" class="edge-label" text-anchor="middle" dominant-baseline="central"><tspan x="742.0620194396497" y="328.43318736465733" dy="-0.6em">Two line</tspan><tspan x="742.0620194396497" dy="1.2em">edge comment</tspan></text>
       </g>
     </g>
     <g class="nodes">
       <g class="node" id="node-ci">
         <circle cx="1093.8999999999999" cy="429.6" r="61.599999999999994"/>
-        <text x="1093.8999999999999" y="429.6" class="label" dominant-baseline="central" text-anchor="middle">Circle shape</text>
+        <text x="1093.8999999999999" y="429.6" class="label" text-anchor="middle" dominant-baseline="central">Circle shape</text>
       </g>
       <g class="node" id="node-cyr">
         <rect x="666.8199999999999" y="105.79999999999998" width="108.8" height="52.8"/>
@@ -149,8 +149,8 @@ marker path {
         <text x="378.29999999999995" y="429.59999999999997" class="label" text-anchor="middle" dominant-baseline="central">Circle shape Начало</text>
       </g>
       <g class="node" id="node-di">
-        <polygon points="159.98000000000002,24.999999999999986 267.18,132.2 159.98000000000002,239.39999999999998 52.780000000000015,132.2" style="fill:#f96 !important;stroke:#333 !important;stroke-width:4px !important"/>
-        <text x="159.98000000000002" y="132.2" class="label" text-anchor="middle" dominant-baseline="central"><tspan x="159.98000000000002" y="132.2" dy="-0.6em">Diamond with </tspan><tspan x="159.98000000000002" dy="1.2em"> line break</tspan></text>
+        <polygon points="429.17999999999984,24.999999999999986 536.3799999999999,132.2 429.17999999999984,239.39999999999998 321.97999999999985,132.2" style="fill:#f96 !important;stroke:#333 !important;stroke-width:4px !important"/>
+        <text x="429.17999999999984" y="132.2" class="label" text-anchor="middle" dominant-baseline="central"><tspan x="429.17999999999984" y="132.2" dy="-0.6em">Diamond with </tspan><tspan x="429.17999999999984" dy="1.2em"> line break</tspan></text>
       </g>
       <g class="node" id="node-e">
         <circle cx="916.02" cy="132.2" r="90.39999999999999" style="fill:#9f6 !important;stroke:#333 !important;stroke-width:2px !important"/>
@@ -161,24 +161,24 @@ marker path {
         <text x="927.8999999999999" y="429.59999999999997" class="label" dominant-baseline="central" text-anchor="middle">,.?!+-*ز</text>
       </g>
       <g class="node" id="node-od">
-        <path d="M 321.9799999999999 105.79999999999998 L 452.2199999999999 105.79999999999998 L 432.6839999999999 132.2 L 452.2199999999999 158.59999999999997 L 321.9799999999999 158.59999999999997 Z"/>
-        <text x="387.0999999999999" y="132.2" class="label" text-anchor="middle" dominant-baseline="central">Odd shape</text>
+        <path d="M 591.18 105.79999999999998 L 721.42 105.79999999999998 L 701.884 132.2 L 721.42 158.59999999999997 L 591.18 158.59999999999997 Z"/>
+        <text x="656.3" y="132.2" class="label" dominant-baseline="central" text-anchor="middle">Odd shape</text>
       </g>
       <g class="node" id="node-od3">
         <path d="M 523.5 384.79999999999995 L 823.5 384.79999999999995 L 778.5 429.59999999999997 L 823.5 474.4 L 523.5 474.4 Z"/>
-        <text x="673.5" y="429.59999999999997" class="label" text-anchor="middle" dominant-baseline="central"><tspan x="673.5" y="429.59999999999997" dy="-0.6em">Really long text with linebreak</tspan><tspan x="673.5" dy="1.2em">in an Odd shape</tspan></text>
+        <text x="673.5" y="429.59999999999997" class="label" dominant-baseline="central" text-anchor="middle"><tspan x="673.5" y="429.59999999999997" dy="-0.6em">Really long text with linebreak</tspan><tspan x="673.5" dy="1.2em">in an Odd shape</tspan></text>
       </g>
       <g class="node" id="node-ro">
         <path d="M 138.9 366.4 H 228.10000000000002 A 5 5 0 0 1 233.10000000000002 371.4 V 487.79999999999995 A 5 5 0 0 1 228.10000000000002 492.79999999999995 H 138.9 A 5 5 0 0 1 133.9 487.79999999999995 V 371.4 A 5 5 0 0 1 138.9 366.4 Z"/>
         <text x="183.5" y="429.59999999999997" class="label" text-anchor="middle" dominant-baseline="central"><tspan x="183.5" y="429.59999999999997" dy="-1.2em">Rounded</tspan><tspan x="183.5" dy="1.2em">square</tspan><tspan x="183.5" dy="1.2em">shape</tspan></text>
       </g>
       <g class="node" id="node-ro2">
-        <path d="M 52.98000000000002 105.79999999999998 H 266.98 A 5 5 0 0 1 271.98 110.79999999999998 V 153.59999999999997 A 5 5 0 0 1 266.98 158.59999999999997 H 52.98000000000002 A 5 5 0 0 1 47.98000000000002 153.59999999999997 V 110.79999999999998 A 5 5 0 0 1 52.98000000000002 105.79999999999998 Z"/>
-        <text x="159.98000000000002" y="132.2" class="label" text-anchor="middle" dominant-baseline="central">Rounded square shape</text>
+        <path d="M 322.17999999999984 105.79999999999998 H 536.1799999999998 A 5 5 0 0 1 541.1799999999998 110.79999999999998 V 153.59999999999997 A 5 5 0 0 1 536.1799999999998 158.59999999999997 H 322.17999999999984 A 5 5 0 0 1 317.17999999999984 153.59999999999997 V 110.79999999999998 A 5 5 0 0 1 322.17999999999984 105.79999999999998 Z"/>
+        <text x="429.17999999999984" y="132.2" class="label" text-anchor="middle" dominant-baseline="central">Rounded square shape</text>
       </g>
       <g class="node" id="node-sq">
         <rect x="1056.42" y="105.79999999999998" width="147.2" height="52.8" style="fill:#9f6 !important;stroke:#333 !important;stroke-width:2px !important"/>
-        <text x="1130.02" y="132.2" class="label" text-anchor="middle" dominant-baseline="central">Square shape</text>
+        <text x="1130.02" y="132.2" class="label" dominant-baseline="central" text-anchor="middle">Square shape</text>
       </g>
     </g>
   </g>

--- a/docs/images/flowchart.svg
+++ b/docs/images/flowchart.svg
@@ -108,28 +108,28 @@ marker path {
         <path d="M 80.00 77.80 C 88.33 77.80, 96.67 77.80, 105.00 77.80 C 113.33 77.80, 121.67 77.80, 130.00 77.80" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-B-C-0">
-        <path d="M 238.28 56.48 L 339.60 26.40" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 238.28 56.48 L 339.60 26.40" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-B-D-0">
         <path d="M 238.28 99.12 L 339.60 129.20" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-C-E-0">
-        <path d="M 448.40 26.40 L 500.35 51.40" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 448.40 26.40 L 500.35 51.40" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-D-E-0">
-        <path d="M 448.40 129.20 L 500.35 104.20" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 448.40 129.20 L 500.35 104.20" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-E-F-0">
-        <path d="M 559.20 77.80 C 567.53 77.80, 575.87 77.80, 584.20 77.80 C 592.53 77.80, 600.87 77.80, 609.20 77.80" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 559.20 77.80 C 567.53 77.80, 575.87 77.80, 584.20 77.80 C 592.53 77.80, 600.87 77.80, 609.20 77.80" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-F-G-0">
-        <path d="M 742.00 77.80 C 750.33 77.80, 758.67 77.80, 767.00 77.80 C 775.33 77.80, 783.67 77.80, 792.00 77.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 742.00 77.80 C 750.33 77.80, 758.67 77.80, 767.00 77.80 C 775.33 77.80, 783.67 77.80, 792.00 77.80" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-G-H-0">
-        <path d="M 940.00 77.80 C 948.33 77.80, 956.67 77.80, 965.00 77.80 C 973.33 77.80, 981.67 77.80, 990.00 77.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 940.00 77.80 C 948.33 77.80, 956.67 77.80, 965.00 77.80 C 973.33 77.80, 981.67 77.80, 990.00 77.80" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-H-I-0">
-        <path d="M 1098.80 77.80 C 1107.13 77.80, 1115.47 77.80, 1123.80 77.80 C 1132.13 77.80, 1140.47 77.80, 1148.80 77.80" class="edge-path" stroke-width="1" marker-start="url(#arrow_circle_start)" fill="none" marker-end="url(#arrow_circle)"/>
+        <path d="M 1098.80 77.80 C 1107.13 77.80, 1115.47 77.80, 1123.80 77.80 C 1132.13 77.80, 1140.47 77.80, 1148.80 77.80" class="edge-path" marker-end="url(#arrow_circle)" fill="none" marker-start="url(#arrow_circle_start)" stroke-width="1"/>
       </g>
     </g>
     <g class="edgeLabels">
@@ -145,7 +145,7 @@ marker path {
     <g class="nodes">
       <g class="node" id="node-A">
         <rect x="0" y="51.40000000000001" width="80" height="52.8"/>
-        <text x="40" y="77.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">Start</text>
+        <text x="40" y="77.80000000000001" class="label" dominant-baseline="central" text-anchor="middle">Start</text>
       </g>
       <g class="node" id="node-B">
         <polygon points="194.8,13.000000000000014 259.6,77.80000000000001 194.8,142.60000000000002 130,77.80000000000001"/>
@@ -153,23 +153,23 @@ marker path {
       </g>
       <g class="node" id="node-C">
         <rect x="339.6" y="0.000000000000007105427357601002" width="108.8" height="52.8"/>
-        <text x="394" y="26.400000000000006" class="label" dominant-baseline="central" text-anchor="middle">Action 1</text>
+        <text x="394" y="26.400000000000006" class="label" text-anchor="middle" dominant-baseline="central">Action 1</text>
       </g>
       <g class="node" id="node-D">
         <rect x="339.6" y="102.80000000000001" width="108.8" height="52.8"/>
-        <text x="394" y="129.20000000000002" class="label" text-anchor="middle" dominant-baseline="central">Action 2</text>
+        <text x="394" y="129.20000000000002" class="label" dominant-baseline="central" text-anchor="middle">Action 2</text>
       </g>
       <g class="node" id="node-E">
         <rect x="498.4000000000001" y="51.40000000000001" width="60.8" height="52.8"/>
-        <text x="528.8000000000001" y="77.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">End</text>
+        <text x="528.8000000000001" y="77.80000000000001" class="label" dominant-baseline="central" text-anchor="middle">End</text>
       </g>
       <g class="node" id="node-F">
         <path d="M 635.6 51.40000000000001 H 715.6 A 26.4 26.4 0 0 1 715.6 104.20000000000002 H 635.6 A 26.4 26.4 0 0 1 635.6 51.40000000000001 Z"/>
-        <text x="675.6" y="77.80000000000001" class="label" dominant-baseline="central" text-anchor="middle">Round</text>
+        <text x="675.6" y="77.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">Round</text>
       </g>
       <g class="node" id="node-G">
         <polygon points="802,51.40000000000001 930,51.40000000000001 930,104.20000000000002 802,104.20000000000002 802,51.40000000000001 792,51.40000000000001 940,51.40000000000001 940,104.20000000000002 792,104.20000000000002 792,51.40000000000001"/>
-        <text x="866" y="77.80000000000001" class="label" dominant-baseline="central" text-anchor="middle">Subroutine</text>
+        <text x="866" y="77.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">Subroutine</text>
       </g>
       <g class="node" id="node-H">
         <path d="M 990.0000000000001 53.77600000000001 a 54.4 10.296 0 0 0 108.8 0 a 54.4 10.296 0 0 0 -108.8 0 l 0 48.048 a 54.4 10.296 0 0 0 108.8 0 l 0 -48.048"/>
@@ -177,7 +177,7 @@ marker path {
       </g>
       <g class="node" id="node-I">
         <circle cx="1181.6" cy="77.80000000000001" r="32.8"/>
-        <text x="1181.6" y="77.80000000000001" class="label" dominant-baseline="central" text-anchor="middle">Circle</text>
+        <text x="1181.6" y="77.80000000000001" class="label" text-anchor="middle" dominant-baseline="central">Circle</text>
       </g>
     </g>
   </g>

--- a/docs/images/flowchart_complex.svg
+++ b/docs/images/flowchart_complex.svg
@@ -87,7 +87,7 @@ marker path {
       <path d="M 0 5 L 10 10 L 10 0 z"/>
     </marker>
     <marker id="arrow_cross" viewBox="0 0 11 11" refX="12" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
-      <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
+      <path d="M 1 1 L 10 10 M 10 1 L 1 10" fill="none" stroke-width="2"/>
     </marker>
     <marker id="arrow_cross_start" viewBox="0 0 11 11" refX="-1" refY="5.2" markerWidth="11" markerHeight="11" orient="auto" markerUnits="userSpaceOnUse">
       <path d="M 1 1 L 10 10 M 10 1 L 1 10" stroke-width="2" fill="none"/>
@@ -120,61 +120,61 @@ marker path {
     </g>
     <g class="edgePaths">
       <g class="edge" id="edge-L-UI-Auth-0">
-        <path d="M 601.90 77.80 C 601.90 102.80, 601.90 127.80, 572.48 154.89 C 543.06 181.99, 484.21 211.18, 425.37 240.37" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 601.90 77.80 C 601.90 102.80, 601.90 127.80, 572.48 154.89 C 543.06 181.99, 484.21 211.18, 425.37 240.37" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Mobile-Auth-0">
-        <path d="M 409.50 77.80 L 389.24 204.24" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 409.50 77.80 L 389.24 204.24" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-CLI-Auth-0">
-        <path d="M 241.10 77.80 L 315.40 225.20" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 241.10 77.80 L 315.40 225.20" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Auth-Rate-0">
-        <path d="M 401.51 326.29 L 453.50 435.00" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 401.51 326.29 L 453.50 435.00" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Auth-Reject-0">
-        <path d="M 334.19 336.39 C 324.86 357.60, 315.53 378.80, 287.57 395.81 C 259.60 412.83, 213.00 425.66, 166.40 438.49" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 334.19 336.39 C 324.86 357.60, 315.53 378.80, 287.57 395.81 C 259.60 412.83, 213.00 425.66, 166.40 438.49" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-Rate-Cache-0">
-        <path d="M 453.50 487.80 C 453.50 496.13, 453.50 504.47, 453.50 512.80 C 453.50 521.13, 453.50 529.47, 453.50 537.80 C 453.50 554.47, 453.50 562.80, 453.50 562.80" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 453.50 487.80 C 453.50 496.13, 453.50 504.47, 453.50 512.80 C 453.50 521.13, 453.50 529.47, 453.50 537.80 C 453.50 554.47, 453.50 562.80, 453.50 562.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-Cache-Response-0">
-        <path d="M 400.85 631.44 L 362.50 726.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 400.85 631.44 L 362.50 726.44" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Cache-UserSvc-0">
         <path d="M 516.39 631.44 C 566.33 651.44, 616.26 671.44, 641.23 687.27 C 666.20 703.11, 666.20 714.77, 666.20 726.44" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-UserSvc-DB-0">
-        <path d="M 715.61 779.24 L 798.73 879.24" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 715.61 779.24 L 798.73 879.24" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-UserSvc-Search-0">
-        <path d="M 661.06 779.24 C 659.44 787.57, 657.82 795.91, 657.01 804.24 C 656.20 812.57, 656.20 820.91, 656.20 829.24 C 656.20 837.57, 656.20 845.91, 656.20 854.24 C 656.20 870.91, 656.20 879.24, 656.20 879.24" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 661.06 779.24 C 659.44 787.57, 657.82 795.91, 657.01 804.24 C 656.20 812.57, 656.20 820.91, 656.20 829.24 C 656.20 837.57, 656.20 845.91, 656.20 854.24 C 656.20 870.91, 656.20 879.24, 656.20 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-OrderSvc-DB-0">
-        <path d="M 1148.40 766.64 C 1077.20 779.17, 1006.00 791.71, 964.35 810.47 C 922.69 829.24, 910.58 854.24, 898.47 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 1148.40 766.64 C 1077.20 779.17, 1006.00 791.71, 964.35 810.47 C 922.69 829.24, 910.58 854.24, 898.47 879.24" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-OrderSvc-Queue-0">
-        <path d="M 1226.80 779.24 L 1195.61 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 1226.80 779.24 L 1195.61 879.24" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-PaymentSvc-DB-0">
-        <path d="M 880.19 623.52 L 843.28 879.24" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 880.19 623.52 L 843.28 879.24" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-PaymentSvc-NotifySvc-0">
-        <path d="M 945.61 623.52 L 986.40 726.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 945.61 623.52 L 986.40 726.44" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-NotifySvc-Queue-0">
-        <path d="M 986.40 779.24 C 986.40 804.24, 986.40 829.24, 1001.07 846.97 C 1015.73 864.70, 1045.07 875.15, 1074.40 885.61" class="edge-path" stroke-width="1" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 986.40 779.24 C 986.40 804.24, 986.40 829.24, 1001.07 846.97 C 1015.73 864.70, 1045.07 875.15, 1074.40 885.61" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-Queue-EmailWorker-0">
-        <path d="M 1074.40 926.81 C 983.57 942.17, 892.73 957.52, 847.32 973.54 C 801.90 989.55, 801.90 1006.21, 801.90 1022.88" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 1074.40 926.81 C 983.57 942.17, 892.73 957.52, 847.32 973.54 C 801.90 989.55, 801.90 1006.21, 801.90 1022.88" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-Queue-SMSWorker-0">
-        <path d="M 1195.61 947.88 L 1226.80 1022.88" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 1195.61 947.88 L 1226.80 1022.88" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
     </g>
     <g class="edgeLabels">
       <g class="edgeLabel" id="edge-label-L-Auth-Rate-0">
         <rect x="415.5922301020454" y="366.4449921843775" width="44" height="22" class="edge-label-bg"/>
-        <text x="437.5922301020454" y="377.4449921843775" class="edge-label" text-anchor="middle" dominant-baseline="central">Valid</text>
+        <text x="437.5922301020454" y="377.4449921843775" class="edge-label" dominant-baseline="central" text-anchor="middle">Valid</text>
       </g>
       <g class="edgeLabel" id="edge-label-L-Auth-Reject-0">
         <rect x="240.60016784660485" y="399.0221959381994" width="58.4" height="22" class="edge-label-bg"/>
@@ -186,7 +186,7 @@ marker path {
       </g>
       <g class="edgeLabel" id="edge-label-L-Cache-UserSvc-0">
         <rect x="566.0546670620357" y="660.1987821843388" width="80" height="22" class="edge-label-bg"/>
-        <text x="606.0546670620357" y="671.1987821843388" class="edge-label" text-anchor="middle" dominant-baseline="central">Cache Miss</text>
+        <text x="606.0546670620357" y="671.1987821843388" class="edge-label" dominant-baseline="central" text-anchor="middle">Cache Miss</text>
       </g>
     </g>
     <g class="nodes">
@@ -200,7 +200,7 @@ marker path {
       </g>
       <g class="node" id="node-Cache">
         <path d="M 384.7 573.096 a 68.8 10.296 0 0 0 137.6 0 a 68.8 10.296 0 0 0 -137.6 0 l 0 48.048 a 68.8 10.296 0 0 0 137.6 0 l 0 -48.048"/>
-        <text x="453.5" y="597.12" class="label" text-anchor="middle" dominant-baseline="central">Redis Cache</text>
+        <text x="453.5" y="597.12" class="label" dominant-baseline="central" text-anchor="middle">Redis Cache</text>
       </g>
       <g class="node" id="node-DB">
         <path d="M 784.6 889.536 a 64 10.296 0 0 0 128 0 a 64 10.296 0 0 0 -128 0 l 0 48.048 a 64 10.296 0 0 0 128 0 l 0 -48.048"/>
@@ -208,15 +208,15 @@ marker path {
       </g>
       <g class="node" id="node-EmailWorker">
         <rect x="728.3000000000001" y="1022.88" width="147.2" height="52.8"/>
-        <text x="801.9000000000001" y="1049.28" class="label" text-anchor="middle" dominant-baseline="central">Email Worker</text>
+        <text x="801.9000000000001" y="1049.28" class="label" dominant-baseline="central" text-anchor="middle">Email Worker</text>
       </g>
       <g class="node" id="node-Mobile">
         <rect x="345.5" y="25" width="128" height="52.8"/>
-        <text x="409.5" y="51.4" class="label" dominant-baseline="central" text-anchor="middle">Mobile App</text>
+        <text x="409.5" y="51.4" class="label" text-anchor="middle" dominant-baseline="central">Mobile App</text>
       </g>
       <g class="node" id="node-NotifySvc">
         <rect x="874.4" y="726.4399999999999" width="224" height="52.8"/>
-        <text x="986.4" y="752.8399999999999" class="label" dominant-baseline="central" text-anchor="middle">Notification Service</text>
+        <text x="986.4" y="752.8399999999999" class="label" text-anchor="middle" dominant-baseline="central">Notification Service</text>
       </g>
       <g class="node" id="node-OrderSvc">
         <rect x="1148.3999999999999" y="726.4399999999999" width="156.8" height="52.8"/>
@@ -224,11 +224,11 @@ marker path {
       </g>
       <g class="node" id="node-PaymentSvc">
         <rect x="824.9" y="570.72" width="176" height="52.8"/>
-        <text x="912.9" y="597.12" class="label" dominant-baseline="central" text-anchor="middle">Payment Service</text>
+        <text x="912.9" y="597.12" class="label" text-anchor="middle" dominant-baseline="central">Payment Service</text>
       </g>
       <g class="node" id="node-Queue">
         <path d="M 1074.3999999999999 889.536 a 78.4 10.296 0 0 0 156.8 0 a 78.4 10.296 0 0 0 -156.8 0 l 0 48.048 a 78.4 10.296 0 0 0 156.8 0 l 0 -48.048"/>
-        <text x="1152.8" y="913.56" class="label" dominant-baseline="central" text-anchor="middle">Message Queue</text>
+        <text x="1152.8" y="913.56" class="label" text-anchor="middle" dominant-baseline="central">Message Queue</text>
       </g>
       <g class="node" id="node-Rate">
         <rect x="379.9" y="435" width="147.2" height="52.8"/>
@@ -236,27 +236,27 @@ marker path {
       </g>
       <g class="node" id="node-Reject">
         <rect x="0.00000000000004263256414560601" y="435" width="166.4" height="52.8"/>
-        <text x="83.20000000000005" y="461.4" class="label" text-anchor="middle" dominant-baseline="central">Reject Request</text>
+        <text x="83.20000000000005" y="461.4" class="label" dominant-baseline="central" text-anchor="middle">Reject Request</text>
       </g>
       <g class="node" id="node-Response">
         <rect x="274.5" y="726.4399999999999" width="176" height="52.8"/>
-        <text x="362.5" y="752.8399999999999" class="label" dominant-baseline="central" text-anchor="middle">Return Response</text>
+        <text x="362.5" y="752.8399999999999" class="label" text-anchor="middle" dominant-baseline="central">Return Response</text>
       </g>
       <g class="node" id="node-SMSWorker">
         <rect x="1162.8" y="1022.88" width="128" height="52.8"/>
-        <text x="1226.8" y="1049.28" class="label" dominant-baseline="central" text-anchor="middle">SMS Worker</text>
+        <text x="1226.8" y="1049.28" class="label" text-anchor="middle" dominant-baseline="central">SMS Worker</text>
       </g>
       <g class="node" id="node-Search">
         <path d="M 577.8000000000001 889.536 a 78.4 10.296 0 0 0 156.8 0 a 78.4 10.296 0 0 0 -156.8 0 l 0 48.048 a 78.4 10.296 0 0 0 156.8 0 l 0 -48.048"/>
-        <text x="656.2" y="913.56" class="label" dominant-baseline="central" text-anchor="middle">Elasticsearch</text>
+        <text x="656.2" y="913.56" class="label" text-anchor="middle" dominant-baseline="central">Elasticsearch</text>
       </g>
       <g class="node" id="node-UI">
         <rect x="523.5000000000001" y="25" width="156.8" height="52.8"/>
-        <text x="601.9000000000001" y="51.4" class="label" dominant-baseline="central" text-anchor="middle">Web Interface</text>
+        <text x="601.9000000000001" y="51.4" class="label" text-anchor="middle" dominant-baseline="central">Web Interface</text>
       </g>
       <g class="node" id="node-UserSvc">
         <rect x="592.6" y="726.4399999999999" width="147.2" height="52.8"/>
-        <text x="666.2" y="752.8399999999999" class="label" dominant-baseline="central" text-anchor="middle">User Service</text>
+        <text x="666.2" y="752.8399999999999" class="label" text-anchor="middle" dominant-baseline="central">User Service</text>
       </g>
     </g>
   </g>

--- a/docs/images/flowchart_full.svg
+++ b/docs/images/flowchart_full.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="846" height="1956.2399999999996" viewBox="-8 -23.999999999999993 846 1956.2399999999996" class="mermaid">
+<svg xmlns="http://www.w3.org/2000/svg" width="846" height="1960.2399999999996" viewBox="-8 -27.999999999999993 846 1960.2399999999996" class="mermaid">
   <style>
 
 .mermaid {
@@ -102,103 +102,103 @@ marker path {
   <g class="root">
     <g class="clusters">
       <g class="subgraph" id="subgraph-main">
-        <rect x="223" y="-15.999999999999993" width="382" height="710.4399999999999" class="cluster"/>
-        <text x="414" y="0.000000000000007105427357601002" class="cluster-label" text-anchor="middle">Main Flow</text>
+        <rect x="219" y="-19.999999999999993" width="390" height="718.4399999999999" class="cluster"/>
+        <text x="414" y="-3.999999999999993" class="cluster-label" text-anchor="middle">Main Flow</text>
       </g>
       <g class="subgraph" id="subgraph-shapes">
-        <rect x="304.92" y="737.4399999999999" width="220.16000000000003" height="922.1999999999997" class="cluster"/>
-        <text x="415" y="753.4399999999999" class="cluster-label" text-anchor="middle">All Shapes</text>
+        <rect x="300.92" y="733.4399999999999" width="228.16000000000003" height="930.1999999999997" class="cluster"/>
+        <text x="415" y="749.4399999999999" class="cluster-label" text-anchor="middle">All Shapes</text>
       </g>
       <g class="subgraph" id="subgraph-edges">
-        <rect x="24" y="1702.6399999999996" width="782" height="212.5999999999999" class="cluster"/>
-        <text x="415" y="1718.6399999999996" class="cluster-label" text-anchor="middle">Edge Types</text>
+        <rect x="20" y="1698.6399999999996" width="790" height="220.5999999999999" class="cluster"/>
+        <text x="415" y="1714.6399999999996" class="cluster-label" text-anchor="middle">Edge Types</text>
       </g>
     </g>
     <g class="edgePaths">
       <g class="edge" id="edge-L-A-B-0">
-        <path d="M 415.00 77.80 C 415.00 86.13, 415.00 94.47, 415.00 102.80 C 415.00 111.13, 415.00 119.47, 415.00 127.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 415.00 77.80 C 415.00 86.13, 415.00 94.47, 415.00 102.80 C 415.00 111.13, 415.00 119.47, 415.00 127.80" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-B-C-0">
         <path d="M 415.00 180.60 C 415.00 188.93, 415.00 197.27, 415.00 205.60 C 415.00 213.93, 415.00 222.27, 415.00 230.60" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-C-D-0">
-        <path d="M 371.68 393.68 L 315.00 507.00" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
+        <path d="M 371.68 393.68 L 315.00 507.00" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-C-E-0">
-        <path d="M 458.32 393.68 L 515.00 507.00" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 458.32 393.68 L 515.00 507.00" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-D-F-0">
-        <path d="M 315.00 559.80 L 357.14 609.80" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
+        <path d="M 315.00 559.80 L 357.14 609.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-E-F-0">
-        <path d="M 515.00 559.80 L 472.86 609.80" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 515.00 559.80 L 472.86 609.80" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-G-H-0">
         <path d="M 415.00 844.04 C 415.00 852.37, 415.00 860.71, 415.00 869.04 C 415.00 877.37, 415.00 885.71, 415.00 894.04" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-H-I-0">
-        <path d="M 415.00 946.84 C 415.00 955.17, 415.00 963.51, 415.00 971.84 C 415.00 980.17, 415.00 988.51, 415.00 996.84" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 415.00 946.84 C 415.00 955.17, 415.00 963.51, 415.00 971.84 C 415.00 980.17, 415.00 988.51, 415.00 996.84" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-I-J-0">
-        <path d="M 415.00 1049.64 C 415.00 1057.97, 415.00 1066.31, 415.00 1074.64 C 415.00 1082.97, 415.00 1091.31, 415.00 1099.64" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 415.00 1049.64 C 415.00 1057.97, 415.00 1066.31, 415.00 1074.64 C 415.00 1082.97, 415.00 1091.31, 415.00 1099.64" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-J-K-0">
         <path d="M 415.00 1152.44 C 415.00 1160.77, 415.00 1169.11, 415.00 1177.44 C 415.00 1185.77, 415.00 1194.11, 415.00 1202.44" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-K-L-0">
-        <path d="M 415.00 1255.24 C 415.00 1263.57, 415.00 1271.91, 415.00 1280.24 C 415.00 1288.57, 415.00 1296.91, 415.00 1305.24" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 415.00 1255.24 C 415.00 1263.57, 415.00 1271.91, 415.00 1280.24 C 415.00 1288.57, 415.00 1296.91, 415.00 1305.24" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-L-M-0">
-        <path d="M 415.00 1358.04 C 415.00 1366.37, 415.00 1374.71, 415.00 1383.04 C 415.00 1391.37, 415.00 1399.71, 415.00 1408.04" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 415.00 1358.04 C 415.00 1366.37, 415.00 1374.71, 415.00 1383.04 C 415.00 1391.37, 415.00 1399.71, 415.00 1408.04" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-M-N-0">
-        <path d="M 415.00 1460.84 C 415.00 1469.17, 415.00 1477.51, 415.00 1485.84 C 415.00 1494.17, 415.00 1502.51, 415.00 1510.84" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
+        <path d="M 415.00 1460.84 C 415.00 1469.17, 415.00 1477.51, 415.00 1485.84 C 415.00 1494.17, 415.00 1502.51, 415.00 1510.84" class="edge-path" fill="none" marker-end="url(#arrow_point)" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-O-P-0">
         <path d="M 390.00 1773.71 C 281.67 1789.62, 173.33 1805.53, 119.17 1817.65 C 65.00 1829.77, 65.00 1838.11, 65.00 1846.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-width="1"/>
       </g>
       <g class="edge" id="edge-L-O-Q-0">
-        <path d="M 390.00 1775.18 C 315.00 1790.60, 240.00 1806.02, 202.50 1817.90 C 165.00 1829.77, 165.00 1838.11, 165.00 1846.44" class="edge-path" fill="none" stroke-width="1"/>
+        <path d="M 390.00 1775.18 C 315.00 1790.60, 240.00 1806.02, 202.50 1817.90 C 165.00 1829.77, 165.00 1838.11, 165.00 1846.44" class="edge-path" stroke-width="1" fill="none"/>
       </g>
       <g class="edge" id="edge-L-O-R-0">
-        <path d="M 390.00 1778.61 C 348.33 1792.88, 306.67 1807.16, 285.83 1818.47 C 265.00 1829.77, 265.00 1838.11, 265.00 1846.44" class="edge-path" fill="none" stroke-dasharray="3,3" stroke-width="2"/>
+        <path d="M 390.00 1778.61 C 348.33 1792.88, 306.67 1807.16, 285.83 1818.47 C 265.00 1829.77, 265.00 1838.11, 265.00 1846.44" class="edge-path" stroke-width="2" stroke-dasharray="3,3" fill="none"/>
       </g>
       <g class="edge" id="edge-L-O-S-0">
-        <path d="M 390.00 1795.74 L 365.00 1846.44" class="edge-path" marker-end="url(#arrow_point)" fill="none" stroke-dasharray="3,3" stroke-width="2"/>
+        <path d="M 390.00 1795.74 L 365.00 1846.44" class="edge-path" stroke-width="2" fill="none" marker-end="url(#arrow_point)" stroke-dasharray="3,3"/>
       </g>
       <g class="edge" id="edge-L-O-T-0">
-        <path d="M 440.00 1795.74 L 465.00 1846.44" class="edge-path" stroke-width="3.5" fill="none" marker-end="url(#arrow_point)"/>
+        <path d="M 440.00 1795.74 L 465.00 1846.44" class="edge-path" fill="none" stroke-width="3.5" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-O-U-0">
-        <path d="M 440.00 1778.61 C 481.67 1792.88, 523.33 1807.16, 544.17 1818.47 C 565.00 1829.77, 565.00 1838.11, 565.00 1846.44" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none" marker-start="url(#arrow_point_start)"/>
+        <path d="M 440.00 1778.61 C 481.67 1792.88, 523.33 1807.16, 544.17 1818.47 C 565.00 1829.77, 565.00 1838.11, 565.00 1846.44" class="edge-path" stroke-width="1" marker-start="url(#arrow_point_start)" fill="none" marker-end="url(#arrow_point)"/>
       </g>
       <g class="edge" id="edge-L-O-V-0">
-        <path d="M 440.00 1775.18 C 515.00 1790.60, 590.00 1806.02, 627.50 1817.90 C 665.00 1829.77, 665.00 1838.11, 665.00 1846.44" class="edge-path" marker-end="url(#arrow_cross)" marker-start="url(#arrow_cross_start)" stroke-width="1" fill="none"/>
+        <path d="M 440.00 1775.18 C 515.00 1790.60, 590.00 1806.02, 627.50 1817.90 C 665.00 1829.77, 665.00 1838.11, 665.00 1846.44" class="edge-path" marker-start="url(#arrow_cross_start)" stroke-width="1" marker-end="url(#arrow_cross)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-O-W-0">
-        <path d="M 440.00 1773.71 C 548.33 1789.62, 656.67 1805.53, 710.83 1817.65 C 765.00 1829.77, 765.00 1838.11, 765.00 1846.44" class="edge-path" fill="none" stroke-width="1" marker-start="url(#arrow_circle_start)" marker-end="url(#arrow_circle)"/>
+        <path d="M 440.00 1773.71 C 548.33 1789.62, 656.67 1805.53, 710.83 1817.65 C 765.00 1829.77, 765.00 1838.11, 765.00 1846.44" class="edge-path" marker-start="url(#arrow_circle_start)" stroke-width="1" fill="none" marker-end="url(#arrow_circle)"/>
       </g>
       <g class="edge" id="edge-L-F-G-0">
-        <path d="M 415.00 678.44 C 415.00 686.77, 415.00 695.11, 415.00 703.44 C 415.00 711.77, 415.00 720.11, 415.00 728.44 C 415.00 736.77, 415.00 745.11, 415.00 753.44 C 415.00 770.11, 415.00 778.44, 415.00 778.44" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
+        <path d="M 415.00 678.44 C 415.00 686.77, 415.00 695.11, 415.00 703.44 C 415.00 711.77, 415.00 720.11, 415.00 728.44 C 415.00 736.77, 415.00 745.11, 415.00 753.44 C 415.00 770.11, 415.00 778.44, 415.00 778.44" class="edge-path" stroke-width="1" marker-end="url(#arrow_point)" fill="none"/>
       </g>
       <g class="edge" id="edge-L-N-O-0">
-        <path d="M 415.00 1643.64 C 415.00 1651.97, 415.00 1660.31, 415.00 1668.64 C 415.00 1676.97, 415.00 1685.31, 415.00 1693.64 C 415.00 1701.97, 415.00 1710.31, 415.00 1718.64 C 415.00 1735.31, 415.00 1743.64, 415.00 1743.64" class="edge-path" marker-end="url(#arrow_point)" stroke-width="1" fill="none"/>
+        <path d="M 415.00 1643.64 C 415.00 1651.97, 415.00 1660.31, 415.00 1668.64 C 415.00 1676.97, 415.00 1685.31, 415.00 1693.64 C 415.00 1701.97, 415.00 1710.31, 415.00 1718.64 C 415.00 1735.31, 415.00 1743.64, 415.00 1743.64" class="edge-path" fill="none" stroke-width="1" marker-end="url(#arrow_point)"/>
       </g>
     </g>
     <g class="edgeLabels">
       <g class="edgeLabel" id="edge-label-L-C-D-0">
         <rect x="318.2787158405461" y="436.01521470836525" width="29.599999999999998" height="22" class="edge-label-bg"/>
-        <text x="333.0787158405461" y="447.01521470836525" class="edge-label" text-anchor="middle" dominant-baseline="central">Yes</text>
+        <text x="333.0787158405461" y="447.01521470836525" class="edge-label" dominant-baseline="central" text-anchor="middle">Yes</text>
       </g>
       <g class="edgeLabel" id="edge-label-L-C-E-0">
         <rect x="485.7212841594539" y="436.01521470836525" width="22.4" height="22" class="edge-label-bg"/>
-        <text x="496.9212841594539" y="447.01521470836525" class="edge-label" text-anchor="middle" dominant-baseline="central">No</text>
+        <text x="496.9212841594539" y="447.01521470836525" class="edge-label" dominant-baseline="central" text-anchor="middle">No</text>
       </g>
     </g>
     <g class="nodes">
       <g class="node" id="node-A">
         <rect x="355.8" y="25.000000000000007" width="118.39999999999999" height="52.8"/>
-        <text x="415" y="51.400000000000006" class="label" text-anchor="middle" dominant-baseline="central">Rectangle</text>
+        <text x="415" y="51.400000000000006" class="label" dominant-baseline="central" text-anchor="middle">Rectangle</text>
       </g>
       <g class="node" id="node-B">
         <path d="M 370.4 127.80000000000001 H 459.59999999999997 A 5 5 0 0 1 464.59999999999997 132.8 V 175.60000000000002 A 5 5 0 0 1 459.59999999999997 180.60000000000002 H 370.4 A 5 5 0 0 1 365.4 175.60000000000002 V 132.8 A 5 5 0 0 1 370.4 127.80000000000001 Z"/>
@@ -210,7 +210,7 @@ marker path {
       </g>
       <g class="node" id="node-D">
         <path d="M 265.4 507 H 364.6 A 26.4 26.4 0 0 1 364.6 559.8 H 265.4 A 26.4 26.4 0 0 1 265.4 507 Z"/>
-        <text x="315" y="533.4" class="label" text-anchor="middle" dominant-baseline="central">Stadium</text>
+        <text x="315" y="533.4" class="label" dominant-baseline="central" text-anchor="middle">Stadium</text>
       </g>
       <g class="node" id="node-E">
         <polygon points="451,507 579,507 579,559.8 451,559.8 451,507 441,507 589,507 589,559.8 441,559.8 441,507"/>
@@ -218,7 +218,7 @@ marker path {
       </g>
       <g class="node" id="node-F">
         <path d="M 346.2 620.096 a 68.8 10.296 0 0 0 137.6 0 a 68.8 10.296 0 0 0 -137.6 0 l 0 48.048 a 68.8 10.296 0 0 0 137.6 0 l 0 -48.048"/>
-        <text x="415" y="644.12" class="label" text-anchor="middle" dominant-baseline="central">Cylinder DB</text>
+        <text x="415" y="644.12" class="label" dominant-baseline="central" text-anchor="middle">Cylinder DB</text>
       </g>
       <g class="node" id="node-G">
         <circle cx="415" cy="811.2399999999999" r="32.8"/>
@@ -230,15 +230,15 @@ marker path {
       </g>
       <g class="node" id="node-I">
         <polygon points="349.144,996.84 509.08000000000004,996.84 480.85600000000005,1049.64 320.92,1049.64"/>
-        <text x="415" y="1023.24" class="label" dominant-baseline="central" text-anchor="middle">Parallelogram</text>
+        <text x="415" y="1023.24" class="label" text-anchor="middle" dominant-baseline="central">Parallelogram</text>
       </g>
       <g class="node" id="node-J">
         <polygon points="326.68,1099.6399999999999 476.824,1099.6399999999999 503.32,1152.4399999999998 353.176,1152.4399999999998"/>
-        <text x="415" y="1126.04" class="label" text-anchor="middle" dominant-baseline="central">Reverse Para</text>
+        <text x="415" y="1126.04" class="label" dominant-baseline="central" text-anchor="middle">Reverse Para</text>
       </g>
       <g class="node" id="node-K">
         <polygon points="365.27200000000005,1202.4399999999998 464.728,1202.4399999999998 486.04,1255.2399999999998 343.96000000000004,1255.2399999999998"/>
-        <text x="415" y="1228.84" class="label" dominant-baseline="central" text-anchor="middle">Trapezoid</text>
+        <text x="415" y="1228.84" class="label" text-anchor="middle" dominant-baseline="central">Trapezoid</text>
       </g>
       <g class="node" id="node-L">
         <polygon points="320.92,1305.2399999999998 509.08000000000004,1305.2399999999998 480.85600000000005,1358.0399999999997 349.144,1358.0399999999997"/>
@@ -246,14 +246,14 @@ marker path {
       </g>
       <g class="node" id="node-M">
         <path d="M 373.336 1408.0399999999997 L 456.664 1408.0399999999997 L 474.52 1434.4399999999998 L 456.664 1460.8399999999997 L 373.336 1460.8399999999997 L 355.48 1434.4399999999998 Z"/>
-        <text x="415" y="1434.4399999999998" class="label" text-anchor="middle" dominant-baseline="central">Hexagon</text>
+        <text x="415" y="1434.4399999999998" class="label" dominant-baseline="central" text-anchor="middle">Hexagon</text>
       </g>
       <g class="node" id="node-N">
         <g>
           <circle cx="415" cy="1577.2399999999998" r="66.4"/>
           <circle cx="415" cy="1577.2399999999998" r="62.400000000000006"/>
         </g>
-        <text x="415" y="1577.2399999999998" class="label" text-anchor="middle" dominant-baseline="central">Double Circle</text>
+        <text x="415" y="1577.2399999999998" class="label" dominant-baseline="central" text-anchor="middle">Double Circle</text>
       </g>
       <g class="node" id="node-O">
         <rect x="390" y="1743.6399999999996" width="50" height="52.8"/>
@@ -261,23 +261,23 @@ marker path {
       </g>
       <g class="node" id="node-P">
         <rect x="40" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="65" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">P</text>
+        <text x="65" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">P</text>
       </g>
       <g class="node" id="node-Q">
         <rect x="140" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="165" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">Q</text>
+        <text x="165" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">Q</text>
       </g>
       <g class="node" id="node-R">
         <rect x="240" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="265" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">R</text>
+        <text x="265" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">R</text>
       </g>
       <g class="node" id="node-S">
         <rect x="340" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="365" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">S</text>
+        <text x="365" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">S</text>
       </g>
       <g class="node" id="node-T">
         <rect x="440" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="465" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">T</text>
+        <text x="465" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">T</text>
       </g>
       <g class="node" id="node-U">
         <rect x="540" y="1846.4399999999996" width="50" height="52.8"/>
@@ -285,7 +285,7 @@ marker path {
       </g>
       <g class="node" id="node-V">
         <rect x="640" y="1846.4399999999996" width="50" height="52.8"/>
-        <text x="665" y="1872.8399999999997" class="label" text-anchor="middle" dominant-baseline="central">V</text>
+        <text x="665" y="1872.8399999999997" class="label" dominant-baseline="central" text-anchor="middle">V</text>
       </g>
       <g class="node" id="node-W">
         <rect x="740" y="1846.4399999999996" width="50" height="52.8"/>

--- a/src/render/ascii/mod.rs
+++ b/src/render/ascii/mod.rs
@@ -2174,12 +2174,15 @@ mod tests {
         let (db, graph) = parse_and_layout(&input);
         let output = render_flowchart_ascii(&db, &graph).unwrap();
 
-        // The "Invalid" label on the Auth -> Reject edge must render in full,
-        // not be truncated to "Inv" by the nearby Authentication diamond.
-        assert!(
-            output.contains("Invalid"),
-            "Flowchart edge label 'Invalid' should not be truncated near diamond shape\nOutput:\n{}",
-            output
-        );
+        // Edge labels near the Authentication diamond must render in full,
+        // not be truncated by the diamond's occupied cells.
+        for label in &["Invalid", "Valid", "Cache Hit", "Cache Miss"] {
+            assert!(
+                output.contains(label),
+                "Flowchart edge label '{}' should not be truncated\nOutput:\n{}",
+                label,
+                output
+            );
+        }
     }
 }

--- a/tests/flowchart_edge_label_truncation.rs
+++ b/tests/flowchart_edge_label_truncation.rs
@@ -45,38 +45,3 @@ fn flowchart_edge_label_not_truncated_near_diamond() {
         output
     );
 }
-
-/// Regression test: edge labels on the full flowchart_complex.mmd diagram.
-/// Ensures "Invalid", "Valid", "Cache Hit", and "Cache Miss" labels are intact.
-#[test]
-fn flowchart_complex_edge_labels_not_truncated() {
-    use selkie::layout::{CharacterSizeEstimator, ToLayoutGraph};
-    use selkie::render::ascii::render_flowchart_ascii;
-
-    let input = std::fs::read_to_string("docs/sources/flowchart_complex.mmd").unwrap();
-
-    let diagram = selkie::parse(&input).unwrap();
-    let db = match diagram {
-        selkie::diagrams::Diagram::Flowchart(db) => db,
-        _ => panic!("Expected flowchart"),
-    };
-    let estimator = CharacterSizeEstimator::default();
-    let graph = db.to_layout_graph(&estimator).unwrap();
-    let graph = selkie::layout::layout(graph).unwrap();
-
-    let output = render_flowchart_ascii(&db, &graph).unwrap();
-    println!(
-        "\n=== FLOWCHART COMPLEX OUTPUT ===\n{}\n=== END ===",
-        output
-    );
-
-    let labels = ["Invalid", "Valid", "Cache Hit", "Cache Miss"];
-    for label in &labels {
-        assert!(
-            output.contains(label),
-            "Edge label '{}' should not be truncated.\nOutput:\n{}",
-            label,
-            output
-        );
-    }
-}

--- a/tests/test_flowchart_edge_label_truncation.rs
+++ b/tests/test_flowchart_edge_label_truncation.rs
@@ -1,0 +1,82 @@
+/// Regression test: flowchart edge labels near diamond shapes must not be truncated.
+///
+/// Bug: the edge label "Invalid" on `Auth -->|Invalid| Reject` was rendered as
+/// "Inv" because the diamond's bounding box (marked as occupied) overlapped the
+/// label's ideal placement. The `find_clear_label_position` search in edges.rs
+/// should relocate the label to an unoccupied row/column so it appears in full.
+#[test]
+fn flowchart_edge_label_not_truncated_near_diamond() {
+    use selkie::layout::{CharacterSizeEstimator, ToLayoutGraph};
+    use selkie::render::ascii::render_flowchart_ascii;
+
+    // Minimal reproduction: a diamond with two labeled outgoing edges.
+    // The "Invalid" label is the one that was previously truncated to "Inv".
+    let input = r#"flowchart TB
+    Auth{Authentication}
+    Auth -->|Valid| Next[Next Step]
+    Auth -->|Invalid| Reject[Reject Request]"#;
+
+    let diagram = selkie::parse(input).unwrap();
+    let db = match diagram {
+        selkie::diagrams::Diagram::Flowchart(db) => db,
+        _ => panic!("Expected flowchart"),
+    };
+    let estimator = CharacterSizeEstimator::default();
+    let graph = db.to_layout_graph(&estimator).unwrap();
+    let graph = selkie::layout::layout(graph).unwrap();
+
+    let output = render_flowchart_ascii(&db, &graph).unwrap();
+    println!(
+        "\n=== FLOWCHART EDGE LABEL OUTPUT ===\n{}\n=== END ===",
+        output
+    );
+
+    // The full word "Invalid" (7 chars) must appear in the output.
+    // Previously it was truncated to "Inv" (3 chars).
+    assert!(
+        output.contains("Invalid"),
+        "Edge label 'Invalid' should not be truncated.\nOutput:\n{}",
+        output
+    );
+    // Also verify "Valid" appears
+    assert!(
+        output.contains("Valid"),
+        "Edge label 'Valid' should appear.\nOutput:\n{}",
+        output
+    );
+}
+
+/// Regression test: edge labels on the full flowchart_complex.mmd diagram.
+/// Ensures "Invalid", "Valid", "Cache Hit", and "Cache Miss" labels are intact.
+#[test]
+fn flowchart_complex_edge_labels_not_truncated() {
+    use selkie::layout::{CharacterSizeEstimator, ToLayoutGraph};
+    use selkie::render::ascii::render_flowchart_ascii;
+
+    let input = std::fs::read_to_string("docs/sources/flowchart_complex.mmd").unwrap();
+
+    let diagram = selkie::parse(&input).unwrap();
+    let db = match diagram {
+        selkie::diagrams::Diagram::Flowchart(db) => db,
+        _ => panic!("Expected flowchart"),
+    };
+    let estimator = CharacterSizeEstimator::default();
+    let graph = db.to_layout_graph(&estimator).unwrap();
+    let graph = selkie::layout::layout(graph).unwrap();
+
+    let output = render_flowchart_ascii(&db, &graph).unwrap();
+    println!(
+        "\n=== FLOWCHART COMPLEX OUTPUT ===\n{}\n=== END ===",
+        output
+    );
+
+    let labels = ["Invalid", "Valid", "Cache Hit", "Cache Miss"];
+    for label in &labels {
+        assert!(
+            output.contains(label),
+            "Edge label '{}' should not be truncated.\nOutput:\n{}",
+            label,
+            output
+        );
+    }
+}


### PR DESCRIPTION
<!-- midtown: broadway -->

## Summary
- Adds regression tests verifying flowchart edge labels near diamond shapes are not truncated
- The underlying bug (e.g., "Invalid" truncated to "Inv" near the Authentication diamond) was already fixed in PR #190 via the shared `find_clear_label_position` search in `edges.rs`
- Tests cover both a minimal reproduction case and the full `flowchart_complex.mmd` diagram
- Updates flowchart SVG documentation images reflecting the corrected rendering

## Context
Task #188 was created during the ER diagram work session (PR #190) when the flowchart truncation bug was discovered. Since the fix was in shared code (`render_edge_label` → `find_clear_label_position`), it resolved both ER and flowchart label truncation simultaneously. This PR adds the missing regression tests and updates doc images.

## Test plan
- [x] `cargo test --test flowchart_edge_label_truncation` passes
- [x] `flowchart_edge_label_invalid_not_truncated` unit test checks all 4 labels (Invalid, Valid, Cache Hit, Cache Miss)
- [x] Full test suite passes (1807+ tests, 0 failures)
- [x] `cargo fmt` clean
- [x] `cargo clippy --features all-formats -- -D warnings` clean
- [x] SVG documentation images updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)