### PR TITLE
feat: Auto-select legible text color over custom node backgrounds [Midtown #1]

### DIFF
--- a/src/render/svg/color.rs
+++ b/src/render/svg/color.rs
@@ -364,6 +364,53 @@ pub fn contrasting_text(background: &Color) -> Color {
     }
 }
 
+/// Extract a CSS property value from an inline style string.
+///
+/// Handles `!important` suffixes and whitespace. For example:
+/// `extract_style_property("fill:#ff5733 !important;stroke:#333", "fill")`
+/// returns `Some("#ff5733")`.
+pub fn extract_style_property<'a>(style: &'a str, property: &str) -> Option<&'a str> {
+    for part in style.split(';') {
+        let part = part.trim();
+        if let Some(rest) = part.strip_prefix(property) {
+            let rest = rest.trim_start();
+            if let Some(value) = rest.strip_prefix(':') {
+                let value = value.trim();
+                // Remove !important suffix if present
+                let value = value.strip_suffix("!important").unwrap_or(value).trim_end();
+                if !value.is_empty() {
+                    return Some(value);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Compute the appropriate text color for a node with custom styles.
+///
+/// If the style string contains an explicit `color` property, use that.
+/// Otherwise, if `fill` is set, compute a WCAG-contrasting text color.
+/// Returns `None` if no custom text color is needed (i.e., the theme default
+/// should be used).
+pub fn text_color_for_styles(style: &str) -> Option<String> {
+    // Check for explicit color property first
+    if let Some(color_val) = extract_style_property(style, "color") {
+        // User explicitly set text color — return it as a fill value for SVG text
+        return Some(color_val.to_string());
+    }
+
+    // No explicit color — derive from fill if present
+    if let Some(fill_val) = extract_style_property(style, "fill") {
+        if let Some(bg_color) = Color::parse(fill_val) {
+            let text_color = contrasting_text(&bg_color);
+            return Some(text_color.to_hex());
+        }
+    }
+
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -497,6 +544,93 @@ mod tests {
         let light_bg = Color::rgb(200, 200, 200);
         let text = contrasting_text(&light_bg);
         assert_eq!(text, Color::rgb(0, 0, 0));
+    }
+
+    #[test]
+    fn test_extract_style_property() {
+        // Basic extraction
+        assert_eq!(
+            extract_style_property("fill:#ff5733", "fill"),
+            Some("#ff5733")
+        );
+
+        // With !important
+        assert_eq!(
+            extract_style_property("fill:#ff5733 !important", "fill"),
+            Some("#ff5733")
+        );
+
+        // Multiple properties
+        assert_eq!(
+            extract_style_property("fill:#ff5733 !important;stroke:#333 !important", "fill"),
+            Some("#ff5733")
+        );
+        assert_eq!(
+            extract_style_property("fill:#ff5733 !important;stroke:#333 !important", "stroke"),
+            Some("#333")
+        );
+
+        // Color property
+        assert_eq!(
+            extract_style_property("fill:#333;color:#fff !important", "color"),
+            Some("#fff")
+        );
+
+        // Missing property
+        assert_eq!(
+            extract_style_property("fill:#ff5733 !important", "color"),
+            None
+        );
+
+        // Don't confuse fill with background-fill or similar
+        assert_eq!(
+            extract_style_property("background-fill:#aaa;fill:#bbb", "fill"),
+            Some("#bbb")
+        );
+    }
+
+    #[test]
+    fn test_text_color_for_styles_dark_background() {
+        // Dark background should produce white text
+        let style = "fill:#333333 !important;stroke:#000 !important";
+        let text_color = text_color_for_styles(style).unwrap();
+        assert_eq!(text_color, "#ffffff");
+    }
+
+    #[test]
+    fn test_text_color_for_styles_light_background() {
+        // Light background should produce black text
+        let style = "fill:#eeeeee !important";
+        let text_color = text_color_for_styles(style).unwrap();
+        assert_eq!(text_color, "#000000");
+    }
+
+    #[test]
+    fn test_text_color_for_styles_explicit_color() {
+        // Explicit color should be used as-is, regardless of fill
+        let style = "fill:#333333 !important;color:red !important";
+        let text_color = text_color_for_styles(style).unwrap();
+        assert_eq!(text_color, "red");
+    }
+
+    #[test]
+    fn test_text_color_for_styles_no_fill() {
+        // No fill or color → None (use theme default)
+        let style = "stroke:#333 !important";
+        assert!(text_color_for_styles(style).is_none());
+    }
+
+    #[test]
+    fn test_text_color_for_styles_named_colors() {
+        // Named dark color
+        let style = "fill:navy !important";
+        let text_color = text_color_for_styles(style).unwrap();
+        assert_eq!(text_color, "#ffffff");
+
+        // Named light color
+        let style = "fill:yellow !important";
+        let text_color = text_color_for_styles(style).unwrap();
+        assert_eq!(text_color, "#000000");
     }
 
     #[test]

--- a/src/render/svg/shapes.rs
+++ b/src/render/svg/shapes.rs
@@ -3,6 +3,7 @@
 use crate::diagrams::flowchart::{FlowVertex, FlowVertexType};
 use crate::layout::{LayoutNode, Point};
 
+use super::color::text_color_for_styles;
 use super::elements::{Attrs, SvgElement};
 use super::theme::Theme;
 
@@ -261,14 +262,20 @@ pub fn render_shape(
         shape
     };
 
-    // Create label
+    // Create label with contrasting text color when custom styles are present
     let label_text = vertex.text.as_deref().unwrap_or(&node.id);
-    let label = SvgElement::text(cx, cy, label_text).with_attrs(
-        Attrs::new()
-            .with_class("label")
-            .with_attr("text-anchor", "middle")
-            .with_attr("dominant-baseline", "central"),
-    );
+    let mut label_attrs = Attrs::new()
+        .with_class("label")
+        .with_attr("text-anchor", "middle")
+        .with_attr("dominant-baseline", "central");
+
+    if let Some(s) = style {
+        if let Some(text_fill) = text_color_for_styles(s) {
+            label_attrs = label_attrs.with_fill(&text_fill);
+        }
+    }
+
+    let label = SvgElement::text(cx, cy, label_text).with_attrs(label_attrs);
 
     // Wrap shape and label in a group with class="node"
     // This allows CSS selectors like ".node rect" to work correctly
@@ -282,6 +289,109 @@ pub fn render_shape(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_dark_fill_gets_white_text() {
+        // When a node has a dark custom fill, the text label should
+        // get a contrasting white fill to remain legible.
+        let mut node = LayoutNode::new("test", 100.0, 60.0);
+        node.x = Some(0.0);
+        node.y = Some(0.0);
+
+        let mut vertex = FlowVertex::new("test", "test");
+        vertex.text = Some("Dark Node".to_string());
+        vertex.vertex_type = Some(FlowVertexType::Square);
+
+        let theme = Theme::default();
+        let style = "fill:#333333 !important;stroke:#000 !important";
+        let shape_element = render_shape(&node, &vertex, &theme, Some(style));
+        let svg = shape_element.to_svg(0);
+
+        // The text element should have fill="#ffffff" for legibility
+        assert!(
+            svg.contains("fill=\"#ffffff\""),
+            "Dark background node text should have white fill for legibility, got: {}",
+            svg
+        );
+    }
+
+    #[test]
+    fn test_light_fill_gets_dark_text() {
+        // When a node has a light custom fill, the text label should
+        // get black fill to remain legible.
+        let mut node = LayoutNode::new("test", 100.0, 60.0);
+        node.x = Some(0.0);
+        node.y = Some(0.0);
+
+        let mut vertex = FlowVertex::new("test", "test");
+        vertex.text = Some("Light Node".to_string());
+        vertex.vertex_type = Some(FlowVertexType::Square);
+
+        let theme = Theme::default();
+        let style = "fill:#eeeeee !important";
+        let shape_element = render_shape(&node, &vertex, &theme, Some(style));
+        let svg = shape_element.to_svg(0);
+
+        // The text element should have fill="#000000" for legibility
+        assert!(
+            svg.contains("fill=\"#000000\""),
+            "Light background node text should have black fill for legibility, got: {}",
+            svg
+        );
+    }
+
+    #[test]
+    fn test_explicit_color_respected() {
+        // When a node's style explicitly sets color, that should be
+        // used for text fill regardless of background luminance.
+        let mut node = LayoutNode::new("test", 100.0, 60.0);
+        node.x = Some(0.0);
+        node.y = Some(0.0);
+
+        let mut vertex = FlowVertex::new("test", "test");
+        vertex.text = Some("Custom Color".to_string());
+        vertex.vertex_type = Some(FlowVertexType::Square);
+
+        let theme = Theme::default();
+        let style = "fill:#333333 !important;color:#ff0000 !important";
+        let shape_element = render_shape(&node, &vertex, &theme, Some(style));
+        let svg = shape_element.to_svg(0);
+
+        // The text element should use the explicit color value
+        assert!(
+            svg.contains("fill=\"#ff0000\""),
+            "Explicit color should be used for text fill, got: {}",
+            svg
+        );
+    }
+
+    #[test]
+    fn test_no_style_no_text_fill_override() {
+        // When no custom style is provided, the text label should not
+        // have an inline fill (it should use theme CSS).
+        let mut node = LayoutNode::new("test", 100.0, 60.0);
+        node.x = Some(0.0);
+        node.y = Some(0.0);
+
+        let mut vertex = FlowVertex::new("test", "test");
+        vertex.text = Some("Default".to_string());
+        vertex.vertex_type = Some(FlowVertexType::Square);
+
+        let theme = Theme::default();
+        let shape_element = render_shape(&node, &vertex, &theme, None);
+        let svg = shape_element.to_svg(0);
+
+        // The text element should NOT have an inline fill attribute
+        // (it should rely on the theme CSS for text color)
+        let text_start = svg.find("<text").expect("should have text element");
+        let text_end = svg[text_start..].find('>').unwrap() + text_start;
+        let text_tag = &svg[text_start..=text_end];
+        assert!(
+            !text_tag.contains("fill="),
+            "Text without custom style should not have inline fill, got: {}",
+            text_tag
+        );
+    }
 
     #[test]
     fn test_subroutine_uses_css_class_not_hardcoded_stroke() {

--- a/src/render/svg/shapes.rs
+++ b/src/render/svg/shapes.rs
@@ -271,7 +271,9 @@ pub fn render_shape(
 
     if let Some(s) = style {
         if let Some(text_fill) = text_color_for_styles(s) {
-            label_attrs = label_attrs.with_fill(&text_fill);
+            // Use inline style (not presentation attribute) so it takes
+            // precedence over theme CSS rules like `.node text { fill: ... }`.
+            label_attrs = label_attrs.with_style(&format!("fill: {}", text_fill));
         }
     }
 
@@ -307,10 +309,10 @@ mod tests {
         let shape_element = render_shape(&node, &vertex, &theme, Some(style));
         let svg = shape_element.to_svg(0);
 
-        // The text element should have fill="#ffffff" for legibility
+        // The text element should have inline style fill for legibility
         assert!(
-            svg.contains("fill=\"#ffffff\""),
-            "Dark background node text should have white fill for legibility, got: {}",
+            svg.contains("style=\"fill: #ffffff\""),
+            "Dark background node text should have white fill via inline style, got: {}",
             svg
         );
     }
@@ -332,10 +334,10 @@ mod tests {
         let shape_element = render_shape(&node, &vertex, &theme, Some(style));
         let svg = shape_element.to_svg(0);
 
-        // The text element should have fill="#000000" for legibility
+        // The text element should have inline style fill for legibility
         assert!(
-            svg.contains("fill=\"#000000\""),
-            "Light background node text should have black fill for legibility, got: {}",
+            svg.contains("style=\"fill: #000000\""),
+            "Light background node text should have black fill via inline style, got: {}",
             svg
         );
     }
@@ -357,11 +359,41 @@ mod tests {
         let shape_element = render_shape(&node, &vertex, &theme, Some(style));
         let svg = shape_element.to_svg(0);
 
-        // The text element should use the explicit color value
+        // The text element should use the explicit color value via inline style
         assert!(
-            svg.contains("fill=\"#ff0000\""),
-            "Explicit color should be used for text fill, got: {}",
+            svg.contains("style=\"fill: #ff0000\""),
+            "Explicit color should be used for text fill via inline style, got: {}",
             svg
+        );
+    }
+
+    #[test]
+    fn test_text_color_uses_inline_style_over_presentation_attr() {
+        // Text color must use inline style (style="fill:...") rather than
+        // a presentation attribute (fill="..."), because theme CSS rules
+        // like `.node text { fill: ... }` override presentation attributes.
+        // Inline styles have highest CSS specificity.
+        let mut node = LayoutNode::new("test", 100.0, 60.0);
+        node.x = Some(0.0);
+        node.y = Some(0.0);
+
+        let mut vertex = FlowVertex::new("test", "test");
+        vertex.text = Some("Styled Node".to_string());
+        vertex.vertex_type = Some(FlowVertexType::Square);
+
+        let theme = Theme::default();
+        let style = "fill:#333333 !important;stroke:#000 !important";
+        let shape_element = render_shape(&node, &vertex, &theme, Some(style));
+        let svg = shape_element.to_svg(0);
+
+        // The text element should use inline style, NOT a presentation attribute
+        let text_start = svg.find("<text").expect("should have text element");
+        let text_end = svg[text_start..].find('>').unwrap() + text_start;
+        let text_tag = &svg[text_start..=text_end];
+        assert!(
+            text_tag.contains("style=\"fill:"),
+            "Text color should use inline style for CSS specificity, got: {}",
+            text_tag
         );
     }
 

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -3781,17 +3781,18 @@ fn test_flowchart_classdef_dark_fill_gets_legible_text() {
     let diagram = parse(input).expect("Failed to parse flowchart");
     let svg = render(&diagram).expect("Failed to render flowchart");
 
-    // Node A has a very dark fill (#1a1a2e) — its text should have white fill for legibility
+    // Node A has a very dark fill (#1a1a2e) — its text should have white fill via inline style
+    // (inline style beats theme CSS rules like `.node text { fill: ... }`)
     assert!(
-        svg.contains("fill=\"#ffffff\""),
-        "Dark background node should have white text fill for legibility.\nSVG:\n{}",
+        svg.contains("style=\"fill: #ffffff\""),
+        "Dark background node should have white text fill via inline style.\nSVG:\n{}",
         svg
     );
 
-    // Node B has a light fill (#f0f0f0) — its text should have black fill for legibility
+    // Node B has a light fill (#f0f0f0) — its text should have black fill via inline style
     assert!(
-        svg.contains("fill=\"#000000\""),
-        "Light background node should have black text fill for legibility.\nSVG:\n{}",
+        svg.contains("style=\"fill: #000000\""),
+        "Light background node should have black text fill via inline style.\nSVG:\n{}",
         svg
     );
 }
@@ -3805,10 +3806,10 @@ fn test_flowchart_classdef_explicit_color_used() {
     let diagram = parse(input).expect("Failed to parse flowchart");
     let svg = render(&diagram).expect("Failed to render flowchart");
 
-    // The explicit color:#ff6600 should be used as the text fill
+    // The explicit color:#ff6600 should be used as the text fill via inline style
     assert!(
-        svg.contains("fill=\"#ff6600\""),
-        "Explicit color in classDef should be used for text fill.\nSVG:\n{}",
+        svg.contains("style=\"fill: #ff6600\""),
+        "Explicit color in classDef should be used for text fill via inline style.\nSVG:\n{}",
         svg
     );
 }

--- a/tests/render_integration.rs
+++ b/tests/render_integration.rs
@@ -3770,3 +3770,45 @@ fn test_state_nested_composite_centered_in_parent_with_siblings() {
         );
     }
 }
+
+#[test]
+fn test_flowchart_classdef_dark_fill_gets_legible_text() {
+    let input = r#"flowchart TD
+    A[Dark Node]:::dark --> B[Light Node]:::light
+    classDef dark fill:#1a1a2e,stroke:#16213e
+    classDef light fill:#f0f0f0,stroke:#ccc"#;
+
+    let diagram = parse(input).expect("Failed to parse flowchart");
+    let svg = render(&diagram).expect("Failed to render flowchart");
+
+    // Node A has a very dark fill (#1a1a2e) — its text should have white fill for legibility
+    assert!(
+        svg.contains("fill=\"#ffffff\""),
+        "Dark background node should have white text fill for legibility.\nSVG:\n{}",
+        svg
+    );
+
+    // Node B has a light fill (#f0f0f0) — its text should have black fill for legibility
+    assert!(
+        svg.contains("fill=\"#000000\""),
+        "Light background node should have black text fill for legibility.\nSVG:\n{}",
+        svg
+    );
+}
+
+#[test]
+fn test_flowchart_classdef_explicit_color_used() {
+    let input = r#"flowchart TD
+    A[Custom Color]:::custom
+    classDef custom fill:#333,color:#ff6600"#;
+
+    let diagram = parse(input).expect("Failed to parse flowchart");
+    let svg = render(&diagram).expect("Failed to render flowchart");
+
+    // The explicit color:#ff6600 should be used as the text fill
+    assert!(
+        svg.contains("fill=\"#ff6600\""),
+        "Explicit color in classDef should be used for text fill.\nSVG:\n{}",
+        svg
+    );
+}


### PR DESCRIPTION
<!-- midtown: amsterdam -->

## Summary
- When custom fill colors are set via `classDef` or `style` directives, text labels now automatically get a contrasting fill color (white or black) based on WCAG 2.0 luminance of the background
- If the user explicitly sets a `color` property in their classDef/style, that value is respected instead of auto-computing
- Added `extract_style_property()` and `text_color_for_styles()` utility functions in `color.rs`
- Applied contrast logic in `render_shape()` for flowchart nodes

## Test plan
- [x] Unit tests for `extract_style_property()` — various style formats, !important, missing properties
- [x] Unit tests for `text_color_for_styles()` — dark bg, light bg, explicit color, no fill, named colors
- [x] Unit tests in shapes.rs — dark fill gets white text, light fill gets black text, explicit color respected, no-style nodes unaffected
- [x] Integration tests — full pipeline from mermaid source with classDef to SVG output
- [x] All 1854 existing tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy --features all-formats -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)