### PR TITLE
Remove microbeads workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,5 @@
 # Agent Instructions
 
-This project uses **mb** (microbeads) for issue tracking. Run `mb onboard` to get started.
-
-## Quick Reference
-
-```bash
-mb ready              # Find available work
-mb show <id>          # View issue details
-mb update <id> --status in_progress  # Claim work
-mb close <id>         # Complete work
-mb sync               # Sync with git
-```
-
 ## Landing the Plane (Session Completion)
 
 **When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
@@ -32,7 +20,6 @@ mb sync               # Sync with git
 
    ```bash
    git pull --rebase
-   mb sync
    git push
    git status  # MUST show "up to date with origin"
    ```
@@ -66,7 +53,7 @@ Rule 5: Always prefer the implementation approach of the reference-implementatio
 
 1. Use `cargo run --features eval --bin selkie -- eval --type <diagram_type>` evaluate where our implementation is relative to the reference.
 2. Follow all instructions from its output & confirm our changes are increasing scores
-3. Log new issues in mb & resolve completed ones
+3. Record remaining follow-up work and resolve completed items in the current project tracker or handoff notes
 4. When you resolve a rendering issue, update the svg in docs/images
 5. Follow TDD, run `cargo fmt && cargo clippy --features all-formats -- -D warnings` before committing, commit when tests pass
 6. Explore Reference implementations available as git submodules in reference-implementations:

--- a/README.md
+++ b/README.md
@@ -292,25 +292,6 @@ Convenience feature that enables `png`, `pdf`, and `kitty` together. Best for de
 cargo install selkie-rs --features all-formats
 ```
 
-## Issue Tracking
-
-This project uses [Microbeads](https://github.com/btucker/microbeads) for issue tracking - an AI-native issue tracker that lives directly in the repository. Issues are stored in `.beads/` and sync with git, making them accessible to both humans and AI coding agents.
-
-```bash
-# View available work
-mb ready
-
-# View issue details
-mb show <issue-id>
-
-# Update issue status
-mb update <issue-id> --status in_progress
-mb close <issue-id>
-
-# Sync with remote
-mb sync
-```
-
 ## Development
 
 This project follows test-driven development. Run the test suite:

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -15,9 +15,9 @@ echo "Installing git hooks..."
 cat > "$HOOKS_DIR/pre-commit" << 'EOF'
 #!/usr/bin/env sh
 #
-# Combined pre-commit hook: cargo checks + mb (microbeads) sync
+# Pre-commit hook: cargo checks
 #
-# Runs cargo fmt and clippy to match CI, then syncs mb issues.
+# Runs cargo fmt and clippy to match CI.
 
 set -e
 
@@ -39,14 +39,6 @@ if ! cargo clippy --features all-formats -- -D warnings; then
     exit 1
 fi
 
-# 3. Run mb hooks for issue tracking
-if command -v mb >/dev/null 2>&1; then
-    echo "  Syncing mb issues..."
-    mb hooks run pre-commit "$@"
-else
-    echo "  Warning: mb not found, skipping issue sync"
-fi
-
 echo "Pre-commit checks passed!"
 EOF
 
@@ -57,4 +49,3 @@ echo ""
 echo "The hook will run on each commit:"
 echo "  - cargo fmt --check"
 echo "  - cargo clippy --features all-formats -- -D warnings"
-echo "  - mb sync (if mb is installed)"

--- a/src/layout/dagre/compound.rs
+++ b/src/layout/dagre/compound.rs
@@ -134,15 +134,11 @@ fn add_border_node(g: &mut DagreGraph, prop: &str, prefix: &str, sg: &str, rank:
     // Store the current border node id
     if let Some(node) = g.node_mut(sg) {
         match prop {
-            "borderLeft" => {
-                if idx < node.border_left.len() {
-                    node.border_left[idx] = Some(id.clone());
-                }
+            "borderLeft" if idx < node.border_left.len() => {
+                node.border_left[idx] = Some(id.clone());
             }
-            "borderRight" => {
-                if idx < node.border_right.len() {
-                    node.border_right[idx] = Some(id.clone());
-                }
+            "borderRight" if idx < node.border_right.len() => {
+                node.border_right[idx] = Some(id.clone());
             }
             _ => {}
         }

--- a/src/layout/dagre/order/sort.rs
+++ b/src/layout/dagre/order/sort.rs
@@ -48,7 +48,7 @@ pub fn sort(entries: Vec<BarycenterEntry>, bias_right: bool) -> SortResult {
     });
 
     // Sort unsortable by original index (descending for consumption)
-    unsortable.sort_by(|a, b| b.i.cmp(&a.i));
+    unsortable.sort_by_key(|entry| std::cmp::Reverse(entry.i));
 
     // Merge the two lists
     let mut vs = Vec::new();

--- a/src/render/kanban.rs
+++ b/src/render/kanban.rs
@@ -106,7 +106,7 @@ fn calculate_layout(db: &KanbanDb) -> KanbanLayout {
 
     // Total dimensions
     let total_width =
-        (num_sections as f64) * SECTION_WIDTH + ((num_sections - 1).max(0) as f64) * PADDING / 2.0;
+        (num_sections as f64) * SECTION_WIDTH + ((num_sections - 1) as f64) * PADDING / 2.0;
     let total_height = section_heights
         .iter()
         .cloned()

--- a/src/render/state.rs
+++ b/src/render/state.rs
@@ -821,7 +821,7 @@ fn center_nested_composites(
     // This ensures that when inner composites are centered, they account for the
     // outer shifts that already happened. Deepest-first would break because outer
     // shifts would undo inner centering.
-    nested_composites.sort_by(|a, b| a.2.cmp(&b.2));
+    nested_composites.sort_by_key(|composite| composite.2);
 
     // Deduplicate by parent: process each parent composite only once.
     // Track which parents have been processed.


### PR DESCRIPTION
## Summary
- Remove Microbeads/mb onboarding and command references from AGENTS.md
- Remove the README issue-tracking section that pointed to Microbeads and .beads
- Stop generating pre-commit hooks that run mb issue sync

## Test Plan
- [x] sh -n scripts/install-hooks.sh
- [x] git diff --check
- [x] cargo fmt --check
- [x] cargo clippy --features all-formats -- -D warnings
- [x] cargo test --features all-formats

## Notes
The remaining `MB` search hits are size units, not Microbeads references.